### PR TITLE
overlay: use OverlayPanel instead of Overlay

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperOverlay.java
+++ b/src/main/java/com/questhelper/QuestHelperOverlay.java
@@ -32,17 +32,15 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import com.questhelper.questhelpers.QuestHelper;
-import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.ComponentConstants;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public class QuestHelperOverlay extends Overlay
+public class QuestHelperOverlay extends OverlayPanel
 {
 	public static final Color TITLED_CONTENT_COLOR = new Color(190, 190, 190);
 
 	private final QuestHelperPlugin plugin;
-	private final PanelComponent panelComponent = new PanelComponent();
 
 	@Inject
 	public QuestHelperOverlay(QuestHelperPlugin plugin)
@@ -60,12 +58,8 @@ public class QuestHelperOverlay extends Overlay
 		{
 			return null;
 		}
-
-		panelComponent.getChildren().clear();
-		panelComponent.setPreferredSize(new Dimension(ComponentConstants.STANDARD_WIDTH, 0));
-
 		questHelper.getCurrentStep().makeOverlayHint(panelComponent, plugin);
 
-		return panelComponent.render(graphics);
+		return super.render(graphics);
 	}
 }


### PR DESCRIPTION
Allows resizing and using the Runelite's colorOverlayBackground config option to recolor the background of the quest helper overlay.