### PR TITLE
plugin: inject members immediately after decleration

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -556,15 +556,6 @@ public class QuestHelperPlugin extends Plugin
 		try
 		{
 			questHelper = clazz.newInstance();
-			questHelper.setQuest(quest);
-		}
-		catch (InstantiationException | IllegalAccessException ex)
-		{
-			throw new QuestInstantiationException(ex);
-		}
-
-		try
-		{
 			Module questModule = (Binder binder) ->
 			{
 				binder.bind(clazz).toInstance(questHelper);
@@ -573,8 +564,9 @@ public class QuestHelperPlugin extends Plugin
 			Injector questInjector = RuneLite.getInjector().createChildInjector(questModule);
 			questInjector.injectMembers(questHelper);
 			questHelper.setInjector(questInjector);
+			questHelper.setQuest(quest);
 		}
-		catch (CreationException ex)
+		catch (InstantiationException | IllegalAccessException | CreationException ex)
 		{
 			throw new QuestInstantiationException(ex);
 		}


### PR DESCRIPTION
This resolves issues with an EventBus that subscribes automatically rather than using a register() function.
(it was possible to receive events before the plugin was ready for them, causing havoc.)