### PR TITLE
Fixed issue where widgets would fire 2 times in ConditionalStep

### DIFF
--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -252,7 +252,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 		}
 	}
 
-	@Subscribe
+	@Override
 	public void onWidgetLoaded(final WidgetLoaded event)
 	{
 		super.onWidgetLoaded(event);


### PR DESCRIPTION
Since QuestStep already subscribes to the "onWidgetLoaded" event we want to override and re-use that subscription instead of creating another one. Hence ConditionalStep should override not subscribe. 