### PR TITLE
Fixed 2 steps in Curse of the Empty Lord miniquest

### DIFF
--- a/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
+++ b/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
@@ -180,6 +180,10 @@ public class CurseOfTheEmptyLord extends BasicQuestHelper
 
 		goUpstairsMonastery = new ObjectStep(this, ObjectID.LADDER_2641, new WorldPoint(3057, 3483, 0), "Talk to the Mysterious Ghost upstairs in the Edgeville Monastery.");
 
+		if(pathID==2){
+			talkToDhalak.addSubSteps(goUpstairsMonastery);
+		}
+
 		goDownIntoEdgevilleDungeon = new ObjectStep(this, ObjectID.TRAPDOOR_1579, new WorldPoint(3097, 3468, 0), "Talk to the Mysterious Ghost in the Edgeville Wilderness Dungeon, near the Earth Warriors.");
 		goDownIntoEdgevilleDungeon.addAlternateObjects(ObjectID.TRAPDOOR_1581);
 

--- a/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
+++ b/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
@@ -180,10 +180,6 @@ public class CurseOfTheEmptyLord extends BasicQuestHelper
 
 		goUpstairsMonastery = new ObjectStep(this, ObjectID.LADDER_2641, new WorldPoint(3057, 3483, 0), "Talk to the Mysterious Ghost upstairs in the Edgeville Monastery.");
 
-		if(pathID==2){
-			talkToDhalak.addSubSteps(goUpstairsMonastery);
-		}
-
 		goDownIntoEdgevilleDungeon = new ObjectStep(this, ObjectID.TRAPDOOR_1579, new WorldPoint(3097, 3468, 0), "Talk to the Mysterious Ghost in the Edgeville Wilderness Dungeon, near the Earth Warriors.");
 		goDownIntoEdgevilleDungeon.addAlternateObjects(ObjectID.TRAPDOOR_1581);
 
@@ -192,6 +188,11 @@ public class CurseOfTheEmptyLord extends BasicQuestHelper
 		goUpstairsRoguesCastle = new ObjectStep(this, ObjectID.STAIRCASE_14735, new WorldPoint(3281, 3937, 0), "Talk to the Mysterious Ghost Viggora upstairs in the Rogues' Castle in 54 Wilderness.");
 
 		goUpstairsPartyRoom = new ObjectStep(this, ObjectID.STAIRCASE_24249, new WorldPoint(3054, 3384, 0), "Talk to the Mysterious Ghost upstairs in the Falador Party Room.");
+
+		if(pathID==2){
+			talkToDhalak.addSubSteps(goUpstairsMonastery);
+			talkToViggora.addSubSteps(goUpstairsSlayerTower);
+		}
 	}
 
 	public void updateSteps(int pathID)


### PR DESCRIPTION
2 steps on the Curse of the Empty Lord miniquest were not updating on the panel for path 2.

Before
![before](https://user-images.githubusercontent.com/50681646/102844954-1f2a6f80-43d2-11eb-9416-e6ed6dedfd5d.PNG)

After
![After](https://user-images.githubusercontent.com/50681646/102844956-205b9c80-43d2-11eb-8bbd-eed03df777d4.PNG)
