### PR TITLE
Small fix in A Tail of Two Cats

### DIFF
--- a/src/main/java/com/questhelper/quests/atailoftwocats/ATailOfTwoCats.java
+++ b/src/main/java/com/questhelper/quests/atailoftwocats/ATailOfTwoCats.java
@@ -127,7 +127,7 @@ public class ATailOfTwoCats extends BasicQuestHelper
 
 	public void setupItemRequirements()
 	{
-		catspeak = new ItemRequirement("Catspeak amulet", ItemID.CATSPEAK_AMULET);
+		catspeak = new ItemRequirement("Catspeak amulet", ItemID.CATSPEAK_AMULET,1,true);
 		catspeakE = new ItemRequirement("Catspeak amulet (e)", ItemID.CATSPEAK_AMULETE);
 		catspeakEWorn = new ItemRequirement("Catspeak amulet (e)", ItemID.CATSPEAK_AMULETE, 1, true);
 		catspeakE.setHighlightInInventory(true);


### PR DESCRIPTION
The Catspeak amulet needs to be equipped as both steps that use this required it equipped as you talk to your cat and the NPC at the same time.