### PR TITLE
Create a shareable run configuration for IntelliJ 2020.1+

### DIFF
--- a/.run/Run QuestHelper.run.xml
+++ b/.run/Run QuestHelper.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run QuestHelper" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="BUNDLED" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.questhelper.QuestHelperPluginTest" />
+    <module name="quest-helper.test" />
+    <option name="PROGRAM_PARAMETERS" value="--debug --developer-mode" />
+    <option name="VM_PARAMETERS" value="-ea" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This will work for IntelliJ versions 2020.1+.
Multiple run configurations can be added to the .run/ directory. (i.e. build configurations, etc.)

The configuration name can be changed of course. As for the JDK; I personally use OpenJDK 13 but used the Bundled option so it should work with any installation of IntelliJ.

This should make it extremely easy for people to start doing some dev work for this project. If they don't have much experience with Java or IntelliJ it can be a bit of a pain to figure out how to run Runelite via this project. This allows them to not have to worry about it and just start the actual coding.

Picture of Run Configuration: https://i.imgur.com/h59n63u.png