### PR TITLE
Add missing Requirements

### DIFF
--- a/src/main/java/com/questhelper/requirements/CombatLevelRequirement.java
+++ b/src/main/java/com/questhelper/requirements/CombatLevelRequirement.java
@@ -3,6 +3,7 @@ package com.questhelper.requirements;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
+import net.runelite.api.Player;
 import net.runelite.api.Skill;
 
 @RequiredArgsConstructor
@@ -13,15 +14,8 @@ public class CombatLevelRequirement extends Requirement
 	@Override
 	public boolean check(Client client)
 	{
-		int combatLevel = Experience.getCombatLevel(
-			client.getRealSkillLevel(Skill.ATTACK),
-			client.getRealSkillLevel(Skill.STRENGTH),
-			client.getRealSkillLevel(Skill.DEFENCE),
-			client.getRealSkillLevel(Skill.HITPOINTS),
-			client.getRealSkillLevel(Skill.MAGIC),
-			client.getRealSkillLevel(Skill.RANGED),
-			client.getRealSkillLevel(Skill.PRAYER));
-		return combatLevel >= level;
+		Player player = client.getLocalPlayer();
+		return player != null && player.getCombatLevel() >= level;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/CombatLevelRequirement.java
+++ b/src/main/java/com/questhelper/requirements/CombatLevelRequirement.java
@@ -1,0 +1,31 @@
+package com.questhelper.requirements;
+
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.Experience;
+import net.runelite.api.Skill;
+@RequiredArgsConstructor
+public class CombatLevelRequirement extends Requirement
+{
+	private final int level;
+
+	@Override
+	public boolean check(Client client)
+	{
+		int combatLevel = Experience.getCombatLevel(
+			client.getRealSkillLevel(Skill.ATTACK),
+			client.getRealSkillLevel(Skill.STRENGTH),
+			client.getRealSkillLevel(Skill.DEFENCE),
+			client.getRealSkillLevel(Skill.HITPOINTS),
+			client.getRealSkillLevel(Skill.MAGIC),
+			client.getRealSkillLevel(Skill.RANGED),
+			client.getRealSkillLevel(Skill.PRAYER));
+		return combatLevel >= level;
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		return "Combat Level " + level;
+	}
+}

--- a/src/main/java/com/questhelper/requirements/CombatLevelRequirement.java
+++ b/src/main/java/com/questhelper/requirements/CombatLevelRequirement.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Skill;
+
 @RequiredArgsConstructor
 public class CombatLevelRequirement extends Requirement
 {

--- a/src/main/java/com/questhelper/requirements/FavourRequirement.java
+++ b/src/main/java/com/questhelper/requirements/FavourRequirement.java
@@ -1,0 +1,27 @@
+package com.questhelper.requirements;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.Favour;
+
+@AllArgsConstructor
+@Getter
+public class FavourRequirement extends Requirement
+{
+	private Favour houseFavour;
+	private int percentage;
+
+	@Override
+	public boolean check(Client client)
+	{
+		int realFavour = client.getVar(houseFavour.getVarbit());
+		return (realFavour / 10) >= percentage;
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		return percentage + "% " + houseFavour.getName() + " favour";
+	}
+}

--- a/src/main/java/com/questhelper/requirements/FollowerRequirement.java
+++ b/src/main/java/com/questhelper/requirements/FollowerRequirement.java
@@ -24,13 +24,11 @@
  */
 package com.questhelper.requirements;
 
-import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
-import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class FollowerRequirement extends Requirement
 {
@@ -66,32 +64,6 @@ public class FollowerRequirement extends Requirement
 		}
 
 		return false;
-	}
-
-	@Override
-	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client)
-	{
-		ArrayList<LineComponent> lines = new ArrayList<>();
-
-		Color color = getColor(client);
-
-		lines.add(LineComponent.builder()
-			.left(getDisplayText())
-			.leftColor(color)
-			.build());
-
-		return lines;
-	}
-
-	@Override
-	public Color getColor(Client client)
-	{
-		Color color = Color.RED;
-		if (check(client))
-		{
-			color = Color.GREEN;
-		}
-		return color;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/FreeInventorySlotRequirement.java
+++ b/src/main/java/com/questhelper/requirements/FreeInventorySlotRequirement.java
@@ -1,0 +1,41 @@
+package com.questhelper.requirements;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+
+@Getter
+public class FreeInventorySlotRequirement extends Requirement
+{
+	private InventoryID inventoryID;
+	private int numSlotsFree;
+
+	public FreeInventorySlotRequirement(InventoryID inventoryID, int numSlotsFree) {
+		this.inventoryID = inventoryID;
+		this.numSlotsFree = numSlotsFree;
+	}
+
+	@Override
+	public boolean check(Client client)
+	{
+		ItemContainer container = client.getItemContainer(getInventoryID());
+		if (container != null) {
+			return Stream.of(container.getItems()).filter(this::isOpenSlot).count() >= getNumSlotsFree();
+		}
+		return false;
+	}
+
+	private boolean isOpenSlot(Item item) {
+		return item == null || item.getId() == -1;
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		return getNumSlotsFree() + " free " + getInventoryID().name().toLowerCase(Locale.ROOT).replaceAll("_", " ") + " slots";
+	}
+}

--- a/src/main/java/com/questhelper/requirements/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/ItemRequirements.java
@@ -96,22 +96,12 @@ public class ItemRequirements extends ItemRequirement
 	@Override
 	public Color getColor(Client client)
 	{
-		Color color;
-
-		if (this.check(client, true))
-		{
-			color = Color.GREEN;
-		}
-		else
-		{
-			color = Color.RED;
-		}
-		return color;
+		return this.check(client, true) ? Color.GREEN : Color.RED;
 	}
 
 	public Color getColorConsideringBank(Client client, boolean checkConsideringSlotRestrictions, Item[] bankItems)
 	{
-		Color color;
+		Color color = Color.RED;
 		if (!this.isActualItem())
 		{
 			color = Color.GRAY;
@@ -120,10 +110,7 @@ public class ItemRequirements extends ItemRequirement
 		{
 			color = Color.GREEN;
 		}
-		else
-		{
-			color = Color.RED;
-		}
+
 		if (color == Color.RED && bankItems != null)
 		{
 			if (check(client, false, bankItems))

--- a/src/main/java/com/questhelper/requirements/NoItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/NoItemRequirement.java
@@ -24,13 +24,10 @@
  */
 package com.questhelper.requirements;
 
-import java.awt.Color;
-import java.util.ArrayList;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
-import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class NoItemRequirement extends ItemRequirement
 {
@@ -122,25 +119,6 @@ public class NoItemRequirement extends ItemRequirement
 		}
 
 		return equipment[slot] <= 512;
-	}
-
-	@Override
-	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client)
-	{
-		ArrayList<LineComponent> lines = new ArrayList<>();
-
-		Color color = Color.RED;
-		if (check(client))
-		{
-			color = Color.GREEN;
-		}
-
-		lines.add(LineComponent.builder()
-			.left(getDisplayText())
-			.leftColor(color)
-			.build());
-
-		return lines;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/PrayerRequirement.java
+++ b/src/main/java/com/questhelper/requirements/PrayerRequirement.java
@@ -24,13 +24,8 @@
  */
 package com.questhelper.requirements;
 
-import com.google.common.base.CaseFormat;
-import java.awt.Color;
-import java.util.ArrayList;
-import java.util.HashMap;
 import net.runelite.api.Client;
 import net.runelite.api.Prayer;
-import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class PrayerRequirement extends Requirement
 {
@@ -48,31 +43,6 @@ public class PrayerRequirement extends Requirement
 	{
 		int currentPrayer = client.getVar(prayer.getVarbit());
 		return currentPrayer == 1;
-	}
-
-	@Override
-	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client)
-	{
-		ArrayList<LineComponent> lines = new ArrayList<>();
-
-		Color color = getColor(client);
-
-		lines.add(LineComponent.builder()
-			.left(getDisplayText())
-			.leftColor(color)
-			.build());
-
-		return lines;
-	}
-
-	public Color getColor(Client client)
-	{
-		Color color = Color.RED;
-		if (check(client))
-		{
-			color = Color.GREEN;
-		}
-		return color;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/QuestPointRequirement.java
+++ b/src/main/java/com/questhelper/requirements/QuestPointRequirement.java
@@ -1,0 +1,34 @@
+package com.questhelper.requirements;
+
+import com.questhelper.steps.conditional.Operation;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.VarPlayer;
+
+public class QuestPointRequirement extends Requirement
+{
+	@Getter
+	private int requiredQuestPoints;
+	private Operation operation;
+
+	public QuestPointRequirement(int requiredQuestPoints) {
+		this.requiredQuestPoints = requiredQuestPoints;
+		this.operation = Operation.GREATER_EQUAL;
+	}
+
+	public QuestPointRequirement(int requiredQuestPoints, Operation operation) {
+		this.requiredQuestPoints = requiredQuestPoints;
+		this.operation = operation;
+	}
+	@Override
+	public boolean check(Client client)
+	{
+		return operation.check(client.getVar(VarPlayer.QUEST_POINTS), requiredQuestPoints);
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		return getRequiredQuestPoints() + " Quest Points";
+	}
+}

--- a/src/main/java/com/questhelper/requirements/QuestRequirement.java
+++ b/src/main/java/com/questhelper/requirements/QuestRequirement.java
@@ -1,0 +1,41 @@
+package com.questhelper.requirements;
+
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+
+@Getter
+public class QuestRequirement extends Requirement
+{
+	private Quest quest;
+	private QuestState requiredState;
+	private String displayText = null;
+
+	public QuestRequirement(Quest quest, QuestState requiredState) {
+		this.quest = quest;
+		this.requiredState = requiredState;
+	}
+
+	public QuestRequirement(Quest quest, QuestState requiredState, String displayText) {
+		this(quest, requiredState);
+		this.displayText = displayText;
+	}
+
+	@Override
+	public boolean check(Client client)
+	{
+		QuestState state = quest.getState(client);
+		if (requiredState == QuestState.IN_PROGRESS && state == QuestState.FINISHED) {
+			return true;
+		}
+		return state == requiredState;
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		String text = Character.toUpperCase(requiredState.name().charAt(0)) + requiredState.name().substring(1);
+		return text.replaceAll("_", " ") + " " + quest.getName();
+	}
+}

--- a/src/main/java/com/questhelper/requirements/Requirement.java
+++ b/src/main/java/com/questhelper/requirements/Requirement.java
@@ -31,11 +31,25 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 
 abstract public class Requirement
 {
-	public abstract Color getColor(Client client);
+	public Color getColor(Client client) {
+		return check(client) ? Color.GREEN : Color.RED;
+	}
 
 	abstract public boolean check(Client client);
 
-	abstract public ArrayList<LineComponent> getDisplayTextWithChecks(Client client);
+	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client) {
+		ArrayList<LineComponent> lines = new ArrayList<>();
+
+		String text = getDisplayText();
+		Color color = getColor(client);
+
+		lines.add(LineComponent.builder()
+			.left(text)
+			.leftColor(color)
+			.build());
+
+		return lines;
+	}
 
 	abstract public String getDisplayText();
 }

--- a/src/main/java/com/questhelper/requirements/Requirements.java
+++ b/src/main/java/com/questhelper/requirements/Requirements.java
@@ -25,11 +25,9 @@
 package com.questhelper.requirements;
 
 import com.questhelper.steps.conditional.LogicType;
-import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import net.runelite.api.Client;
-import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class Requirements extends Requirement
 {
@@ -54,14 +52,8 @@ public class Requirements extends Requirement
 	@Override
 	public boolean check(Client client)
 	{
-		int successes = 0;
-		for (Requirement requirement : requirements)
-		{
-			if (requirement.check(client))
-			{
-				successes++;
-			}
-		}
+		int successes = (int) requirements.stream().filter(r -> r.check(client)).count();
+
 		return (successes == requirements.size() && logicType == LogicType.AND)
 			|| (successes > 0 && logicType == LogicType.OR)
 			|| (successes < requirements.size() && logicType == LogicType.NAND)
@@ -69,42 +61,8 @@ public class Requirements extends Requirement
 	}
 
 	@Override
-	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client)
-	{
-		ArrayList<LineComponent> lines = new ArrayList<>();
-
-		Color color = Color.RED;
-		if (check(client))
-		{
-			color = Color.GREEN;
-		}
-
-		lines.add(LineComponent.builder()
-			.left(getDisplayText())
-			.leftColor(color)
-			.build());
-
-		return lines;
-	}
-
-	@Override
 	public String getDisplayText()
 	{
 		return name;
-	}
-
-	public Color getColor(Client client)
-	{
-		Color color;
-
-		if (this.check(client))
-		{
-			color = Color.GREEN;
-		}
-		else
-		{
-			color = Color.RED;
-		}
-		return color;
 	}
 }

--- a/src/main/java/com/questhelper/requirements/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/SkillRequirement.java
@@ -1,0 +1,46 @@
+package com.questhelper.requirements;
+
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+
+@Getter
+public class SkillRequirement extends Requirement
+{
+	private Skill skill;
+	private int requiredLevel;
+	private boolean canBeBoosted;
+	private String displayText;
+
+	public SkillRequirement(Skill skill, int requiredLevel) {
+		this.skill = skill;
+		this.requiredLevel = requiredLevel;
+		this.displayText = getDisplayText();
+	}
+
+	public SkillRequirement(Skill skill, int requiredLevel, boolean canBeBoosted) {
+		this(skill, requiredLevel);
+		this.canBeBoosted = canBeBoosted;
+	}
+
+	public SkillRequirement(Skill skill, int requiredLevel, boolean canBeBoosted, String displayText) {
+		this(skill, requiredLevel, canBeBoosted);
+		this.displayText = displayText;
+	}
+
+	@Override
+	public boolean check(Client client)
+	{
+		int skillLevel = canBeBoosted ? client.getBoostedSkillLevel(skill) : client.getRealSkillLevel(skill);
+		return skillLevel >= requiredLevel;
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		if (displayText != null) {
+			return displayText;
+		}
+		return requiredLevel + " " + skill.getName();
+	}
+}

--- a/src/main/java/com/questhelper/requirements/SpellbookRequirement.java
+++ b/src/main/java/com/questhelper/requirements/SpellbookRequirement.java
@@ -24,10 +24,7 @@
  */
 package com.questhelper.requirements;
 
-import java.awt.Color;
-import java.util.ArrayList;
 import net.runelite.api.Client;
-import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class SpellbookRequirement extends Requirement
 {
@@ -43,33 +40,6 @@ public class SpellbookRequirement extends Requirement
 	{
 		int currentSpellbook = client.getVarbitValue(4070);
 		return currentSpellbook == spellBook.getId();
-	}
-
-	@Override
-	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client)
-	{
-		ArrayList<LineComponent> lines = new ArrayList<>();
-
-		String text = getDisplayText();
-		Color color = getColor(client);
-
-		lines.add(LineComponent.builder()
-			.left(text)
-			.leftColor(color)
-			.build());
-
-		return lines;
-	}
-
-	@Override
-	public Color getColor(Client client)
-	{
-		Color color = Color.RED;
-		if (check(client))
-		{
-			color = Color.GREEN;
-		}
-		return color;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/WeightRequirement.java
+++ b/src/main/java/com/questhelper/requirements/WeightRequirement.java
@@ -46,49 +46,7 @@ public class WeightRequirement extends Requirement
 	@Override
 	public boolean check(Client client)
 	{
-		if (operation == Operation.EQUAL)
-		{
-			return client.getWeight() == weight;
-		}
-		else if (operation == Operation.NOT_EQUAL)
-		{
-			return client.getWeight() != weight;
-		}
-		else if (operation == Operation.LESS_EQUAL)
-		{
-			return client.getWeight() <= weight;
-		}
-		else if (operation == Operation.GREATER_EQUAL)
-		{
-			return client.getWeight() >= weight;
-		}
-		return false;
-	}
-
-	@Override
-	public ArrayList<LineComponent> getDisplayTextWithChecks(Client client)
-	{
-		ArrayList<LineComponent> lines = new ArrayList<>();
-
-		Color color = getColor(client);
-
-		lines.add(LineComponent.builder()
-			.left(getDisplayText())
-			.leftColor(color)
-			.build());
-
-		return lines;
-	}
-
-	@Override
-	public Color getColor(Client client)
-	{
-		Color color = Color.RED;
-		if (check(client))
-		{
-			color = Color.GREEN;
-		}
-		return color;
+		return operation.check(client.getWeight(), weight);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/steps/conditional/Operation.java
+++ b/src/main/java/com/questhelper/steps/conditional/Operation.java
@@ -24,10 +24,21 @@
  */
 package com.questhelper.steps.conditional;
 
+import java.util.function.BiFunction;
+
 public enum Operation
 {
-	LESS_EQUAL,
-	EQUAL,
-	GREATER_EQUAL,
-	NOT_EQUAL
+	LESS_EQUAL((x,y) -> x <= y),
+	EQUAL(Integer::equals),
+	GREATER_EQUAL((x,y) -> x >= y),
+	NOT_EQUAL((x,y) -> !x.equals(y));
+
+	private final BiFunction<Integer, Integer, Boolean> operation;
+	Operation(BiFunction<Integer, Integer, Boolean> operation) {
+		this.operation = operation;
+	}
+
+	public boolean check(int numberToCheck, int numberToCheckAgainst) {
+		return operation.apply(numberToCheck, numberToCheckAgainst);
+	}
 }

--- a/src/main/java/com/questhelper/steps/conditional/SkillCondition.java
+++ b/src/main/java/com/questhelper/steps/conditional/SkillCondition.java
@@ -28,24 +28,6 @@ public class SkillCondition extends ConditionForStep
 	@Override
 	public boolean checkCondition(Client client)
 	{
-		if (operation == Operation.EQUAL)
-		{
-			return client.getRealSkillLevel(skill) == value;
-		}
-		else if (operation == Operation.NOT_EQUAL)
-		{
-			return client.getRealSkillLevel(skill) != value;
-		}
-		else if (operation == Operation.LESS_EQUAL)
-		{
-			return client.getRealSkillLevel(skill) <= value;
-		}
-
-		else if (operation == Operation.GREATER_EQUAL)
-		{
-			return client.getRealSkillLevel(skill) >= value;
-		}
-
-		return false;
+		return operation.check(client.getRealSkillLevel(skill), value);
 	}
 }

--- a/src/main/java/com/questhelper/steps/conditional/VarbitCondition.java
+++ b/src/main/java/com/questhelper/steps/conditional/VarbitCondition.java
@@ -75,24 +75,6 @@ public class VarbitCondition extends ConditionForStep
 			return bitIsSet == BigInteger.valueOf(client.getVarbitValue(varbitId)).testBit(bitPosition);
 		}
 
-		if (operation == Operation.EQUAL)
-		{
-			return client.getVarbitValue(varbitId) == value;
-		}
-		else if (operation == Operation.NOT_EQUAL)
-		{
-			return client.getVarbitValue(varbitId) != value;
-		}
-		else if (operation == Operation.LESS_EQUAL)
-		{
-			return client.getVarbitValue(varbitId) <= value;
-		}
-
-		else if (operation == Operation.GREATER_EQUAL)
-		{
-			return client.getVarbitValue(varbitId) >= value;
-		}
-
-		return false;
+		return operation.check(client.getVarbitValue(varbitId), value);
 	}
 }

--- a/src/main/java/com/questhelper/steps/conditional/VarplayerCondition.java
+++ b/src/main/java/com/questhelper/steps/conditional/VarplayerCondition.java
@@ -74,23 +74,6 @@ public class VarplayerCondition extends ConditionForStep
 		{
 			return bitIsSet == BigInteger.valueOf(client.getVarpValue(varplayerId)).testBit(bitPosition);
 		}
-		if (operation == Operation.EQUAL)
-		{
-			return client.getVarpValue(varplayerId) == value;
-		}
-		else if (operation == Operation.NOT_EQUAL)
-		{
-			return client.getVarpValue(varplayerId) != value;
-		}
-		else if (operation == Operation.LESS_EQUAL)
-		{
-			return client.getVarpValue(varplayerId) <= value;
-		}
-
-		else if (operation == Operation.GREATER_EQUAL)
-		{
-			return client.getVarpValue(varplayerId) >= value;
-		}
-		return false;
+		return operation.check(client.getVarpValue(varplayerId), value);
 	}
 }

--- a/src/main/java/com/questhelper/steps/conditional/WeightCondition.java
+++ b/src/main/java/com/questhelper/steps/conditional/WeightCondition.java
@@ -48,24 +48,6 @@ public class WeightCondition extends ConditionForStep
 	@Override
 	public boolean checkCondition(Client client)
 	{
-		if (operation == Operation.EQUAL)
-		{
-			return client.getWeight() == weight;
-		}
-		else if (operation == Operation.NOT_EQUAL)
-		{
-			return client.getWeight() != weight;
-		}
-		else if (operation == Operation.LESS_EQUAL)
-		{
-			return client.getWeight() <= weight;
-		}
-
-		else if (operation == Operation.GREATER_EQUAL)
-		{
-			return client.getWeight() >= weight;
-		}
-
-		return false;
+		return operation.check(client.getWeight(), weight);
 	}
 }


### PR DESCRIPTION
Lots of changes in this one. This PR adds missing `Requirement`s as well as removing some duplicate code.

I'm marking this as a draft because it's 3AM and I wanted

Quest Requirements are found at: https://oldschool.runescape.wiki/w/Quests/Requirements

I was able to run QuestHelper without any errors with these changes but I did not test quests that specifically used some of these requirements.

I would appreciate it if someone could review this and see if I missed anything or changed some logic somewhere.

****1. Duplicate code****
Duplicate code was found in several classes, mainly `getDisplayTextWithChecks` where all it did was use the same `LineComponent` builder to combine the display text and `getColor`. This bit of code was moved back into the abstract `Requirement`.
`getColor` was also moved back into `Requirement` for code that just called `check(Client)` to determine if the color should be RED or GREEN.
Everything more complicated than `getColor(client) ? Color.GREEN : Color.RED;` was left alone.
Same thing for `getDisplayTextWithChecks`. If it was doing anything other than combining the display text with the Color it was left alone.

****2. Operation****
`Operation` is a simple enum that is used to calculate if a number is greater than, less than, equal to, or not equal to another number.
`Operation` now has a `BiFunction` attached to it. This allows for de-duplication of code, as well as it is just easier to read and maintain.
See `WeightRequirement` or `SkillCondition` for an example of how this is easier.

*****3. Missing Requirements****
`CombatLevelRequirement` checks if the client has a required combat level. There could be additional functionality where we could check if the combat level is anything other than `Operation#GREATER_THAN`, however there is no quest requirement that uses it.

`FavourRequirement` checks if the client has at least a certain percentage of favour with a certain house (i.e. Shayzien, Arceuus, etc).

`FreeInventorySlotRequirement` checks if the client has a certain number of `InventoryID` slots not in use. While this is primarily going to be used for the inventory, I did not specify the inventory just in case future inventories are added that could be used (i.e. Looting Bag)

`QuestPointRequirement' checks if the client has a certain number of quest points. Several quests require a minimum number of quest points in order to start the quest so this seemed like an easy one.

`QuestRequirement` checks if the client has completed a certain quest. As well, if the quest only requires the player to start the required quest but the client has finished that quest, this will return true.

`SkillRequirement` checks if the client has at least a required skill level. Some quests allow boosting of skill levels in order to complete certain parts. This requirement allows for that as well.