### PR TITLE
Add basic Quest Bank Tab solution

### DIFF
--- a/src/main/java/com/questhelper/BankItems.java
+++ b/src/main/java/com/questhelper/BankItems.java
@@ -1,5 +1,5 @@
 /*
-	* Copyright (c) 2020, Zoinkwiz <https://github.com/Zoinkwiz>
+	* Copyright (c) 2021, Zoinkwiz <https://github.com/Zoinkwiz>
 
 	* All rights reserved.
 	*

--- a/src/main/java/com/questhelper/banktab/BankTabItem.java
+++ b/src/main/java/com/questhelper/banktab/BankTabItem.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.banktab;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import lombok.Getter;
+import lombok.Setter;
+
+public class BankTabItem
+{
+	@Getter
+	private final int quantity;
+
+	@Getter
+	@Setter
+	private String text;
+
+	@Getter
+	private final ArrayList<Integer> itemIDs;
+
+	@Getter
+	private final String details;
+
+	public BankTabItem(int quantity, String text, int itemID, String details)
+	{
+		this.quantity = quantity;
+		this.text = text;
+		this.itemIDs = new ArrayList<>(Collections.singleton(itemID));
+		this.details = details;
+	}
+}

--- a/src/main/java/com/questhelper/banktab/BankTabItems.java
+++ b/src/main/java/com/questhelper/banktab/BankTabItems.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.banktab;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.Setter;
+
+public class BankTabItems
+{
+	@Getter
+	@Setter
+
+	private String name;
+
+	@Getter
+	private final ArrayList<BankTabItem> items;
+
+	public BankTabItems(String name, BankTabItem... items)
+	{
+		this.name = name;
+		this.items = new ArrayList<>(Arrays.asList(items));
+	}
+
+	public void addItems(BankTabItem... items)
+	{
+		this.items.addAll(Arrays.asList(items));
+	}
+
+	public void addItems(ArrayList<BankTabItem> items)
+	{
+		this.items.addAll(items);
+	}
+}

--- a/src/main/java/com/questhelper/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTab.java
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Ron Young <https://github.com/raiyni>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.banktab;
+
+import com.google.common.primitives.Shorts;
+import com.questhelper.QuestHelperPlugin;
+import java.awt.Color;
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.FontID;
+import net.runelite.api.ItemID;
+import net.runelite.api.ScriptEvent;
+import net.runelite.api.ScriptID;
+import net.runelite.api.SpriteID;
+import net.runelite.api.VarClientStr;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.GrandExchangeSearched;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.api.events.ScriptPostFired;
+import net.runelite.api.events.ScriptPreFired;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetType;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemVariationMapping;
+import net.runelite.client.util.QuantityFormatter;
+import net.runelite.client.util.Text;
+
+public class QuestBankTab
+{
+	private static final int ITEMS_PER_ROW = 8;
+	private static final int ITEM_VERTICAL_SPACING = 36;
+	private static final int ITEM_HORIZONTAL_SPACING = 48;
+	private static final int ITEM_ROW_START = 51;
+	private static final int LINE_VERTICAL_SPACING = 5;
+	private static final int LINE_HEIGHT = 2;
+	private static final int TEXT_HEIGHT = 15;
+	private static final int ITEM_HEIGHT = 32;
+	private static final int ITEM_WIDTH = 36;
+
+	private static final int MAX_RESULT_COUNT = 250;
+
+	private final ArrayList<Widget> addedWidgets = new ArrayList<>();
+
+	@Inject
+	private ItemManager itemManager;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	@Inject
+	private QuestBankTabInterface questBankTabInterface;
+
+	private final QuestHelperPlugin questHelper;
+
+	private final HashMap<Widget, BankTabItem> widgetItems = new HashMap<>();
+
+	public QuestBankTab(QuestHelperPlugin questHelperPlugin)
+	{
+		questHelper = questHelperPlugin;
+	}
+
+	public void startUp()
+	{
+		if (questHelper.getSelectedQuest() != null)
+		{
+			clientThread.invokeLater(questBankTabInterface::init);
+		}
+	}
+
+	public void shutDown()
+	{
+		clientThread.invokeLater(questBankTabInterface::destroy);
+		if (!addedWidgets.isEmpty())
+		{
+			for (Widget addedWidget : addedWidgets)
+			{
+				addedWidget.setHidden(true);
+			}
+			addedWidgets.clear();
+		}
+	}
+
+	@Subscribe
+	public void onGrandExchangeSearched(GrandExchangeSearched event)
+	{
+		final String input = client.getVar(VarClientStr.INPUT_TEXT);
+		String QUEST_BANK_TAG = "quest-helper";
+		if (!input.equals(QUEST_BANK_TAG))
+		{
+			return;
+		}
+
+		event.consume();
+
+		final List<Integer> idsList = questHelper.getBankTagService().itemsToTag();
+
+		final Set<Integer> ids = idsList
+			.stream()
+			.mapToInt(Math::abs)
+			.mapToObj(ItemVariationMapping::getVariations)
+			.flatMap(Collection::stream)
+			.distinct()
+			.filter(i -> itemManager.getItemComposition(i).isTradeable())
+			.limit(MAX_RESULT_COUNT)
+			.collect(Collectors.toCollection(TreeSet::new));
+
+		client.setGeSearchResultIndex(0);
+		client.setGeSearchResultCount(ids.size());
+		client.setGeSearchResultIds(Shorts.toArray(ids));
+	}
+
+	@Subscribe
+	public void onScriptPreFired(ScriptPreFired event)
+	{
+		int scriptId = event.getScriptId();
+		if (scriptId == ScriptID.BANKMAIN_FINISHBUILDING)
+		{
+			// Since we apply tag tab search filters even when the bank is not in search mode,
+			// bankkmain_build will reset the bank title to "The Bank of Gielinor". So apply our
+			// own title.
+			if (questBankTabInterface.isQuestTabActive())
+			{
+				Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
+				if (bankTitle != null)
+				{
+					bankTitle.setText("Tab <col=ff0000>Quest Helper</col>");
+				}
+			}
+		}
+	    else if (scriptId == ScriptID.BANKMAIN_SEARCH_TOGGLE)
+		{
+			questBankTabInterface.handleSearch();
+		}
+	}
+
+	@Subscribe
+	public void onScriptCallbackEvent(ScriptCallbackEvent event)
+	{
+		String eventName = event.getEventName();
+
+		int[] intStack = client.getIntStack();
+		int intStackSize = client.getIntStackSize();
+
+		switch (eventName)
+		{
+			case "bankSearchFilter":
+				final int itemId = intStack[intStackSize - 1];
+
+				if (!questBankTabInterface.isQuestTabActive())
+				{
+					return;
+				}
+				if (client.getVar(Varbits.CURRENT_BANK_TAB) != 0)
+				{
+					client.setVarbit(Varbits.CURRENT_BANK_TAB, 0);
+				}
+
+				if (questHelper.getBankTagService().shouldTag(itemId))
+				{
+					intStack[intStackSize - 2] = 1;
+				}
+				else
+				{
+					intStack[intStackSize - 2] = 0;
+				}
+				break;
+			case "getSearchingTagTab":
+				intStack[intStackSize - 1] = questBankTabInterface.isQuestTabActive() ? 1 : 0;
+				if (questBankTabInterface.isQuestTabActive())
+				{
+					// As we're on the quest helper tab, we don't need to check again for tab tags
+					// Change the name of the event so as to not proc another check
+					event.setEventName("getSearchingQuestHelperTab");
+				}
+				break;
+		}
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() == WidgetID.BANK_GROUP_ID && questHelper.getSelectedQuest() != null)
+		{
+			questBankTabInterface.init();
+		}
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		questBankTabInterface.handleClick(event);
+	}
+
+	@Subscribe
+	public void onScriptPostFired(ScriptPostFired event)
+	{
+		if (event.getScriptId() == ScriptID.BANKMAIN_SEARCHING)
+		{
+			// The return value of bankmain_searching is on the stack. If we have a tag tab active
+			// make it return true to put the bank in a searching state.
+			if (questBankTabInterface.isQuestTabActive())
+			{
+				client.getIntStack()[client.getIntStackSize() - 1] = 1; // true
+			}
+			if (!addedWidgets.isEmpty())
+			{
+				for (Widget addedWidget : addedWidgets)
+				{
+					addedWidget.setHidden(true);
+				}
+				addedWidgets.clear();
+			}
+			return;
+		}
+
+		if (event.getScriptId() != ScriptID.BANKMAIN_FINISHBUILDING)
+		{
+			return;
+		}
+
+		if (!questBankTabInterface.isQuestTabActive())
+		{
+			return;
+		}
+
+		Widget itemContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		if (itemContainer == null)
+		{
+			return;
+		}
+
+		if (!addedWidgets.isEmpty())
+		{
+
+			for (Widget addedWidget : addedWidgets)
+			{
+				addedWidget.setHidden(true);
+			}
+			addedWidgets.clear();
+		}
+
+		Widget[] containerChildren = itemContainer.getDynamicChildren();
+
+		ArrayList<BankTabItems> tabLayout = questHelper.getBankTagService().getPluginBankTagItemsForSections();
+
+		if (tabLayout != null)
+		{
+			sortBankTabItems(itemContainer, containerChildren, tabLayout);
+		}
+	}
+
+	private void sortBankTabItems(Widget itemContainer, Widget[] containerChildren,
+								  ArrayList<BankTabItems> newLayout)
+	{
+		int totalSectionsHeight = 0;
+
+		ArrayList<Integer> itemList = new ArrayList<>();
+		for (Widget itemWidget : containerChildren)
+		{
+			if (itemWidget.getSpriteId() == SpriteID.RESIZEABLE_MODE_SIDE_PANEL_BACKGROUND
+				|| itemWidget.getText().contains("Tab"))
+			{
+				itemWidget.setHidden(true);
+			}
+			else if (!itemWidget.isHidden() && itemWidget.getItemId() != -1 && !itemList.contains(itemWidget.getItemId()))
+			{
+				itemList.add(itemWidget.getItemId());
+			}
+		}
+
+		for (BankTabItems BankTabItems : newLayout)
+		{
+			totalSectionsHeight = addPluginTabSection(itemContainer, BankTabItems.getItems(), itemList,
+				BankTabItems.getName(), totalSectionsHeight);
+		}
+
+		totalSectionsHeight = addGeneralSection(itemContainer, itemList, totalSectionsHeight);
+
+		final Widget bankItemContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		int itemContainerHeight = bankItemContainer.getHeight();
+
+		bankItemContainer.setScrollHeight(Math.max(totalSectionsHeight, itemContainerHeight));
+
+		final int itemContainerScroll = bankItemContainer.getScrollY();
+		clientThread.invokeLater(() ->
+			client.runScript(ScriptID.UPDATE_SCROLLBAR,
+				WidgetInfo.BANK_SCROLLBAR.getId(),
+				WidgetInfo.BANK_ITEM_CONTAINER.getId(),
+				itemContainerScroll));
+	}
+
+	private int addPluginTabSection(Widget itemContainer, ArrayList<BankTabItem> items,
+									ArrayList<Integer> itemIds, String title,
+									int totalSectionsHeight)
+	{
+		int totalItemsAdded = 0;
+
+		if (items == null)
+		{
+			return 0;
+		}
+
+		for (BankTabItem bankTabItem : items)
+		{
+			boolean foundItem = false;
+			if (!Collections.disjoint(itemIds, bankTabItem.getItemIDs()))
+			{
+				for (Widget widget : itemContainer.getDynamicChildren())
+				{
+					if (!widget.isHidden() && (bankTabItem.getItemIDs().contains(widget.getItemId())))
+					{
+						foundItem = true;
+						if (totalItemsAdded == 0)
+						{
+							totalSectionsHeight = addSectionHeader(itemContainer, title, totalSectionsHeight);
+						}
+
+						Point point = placeItem(widget, totalItemsAdded, totalSectionsHeight);
+						widget.setItemQuantityMode(1);
+						widgetItems.put(widget, bankTabItem);
+
+						String quantityString = formatQuantity(bankTabItem.getQuantity());
+						int extraLength = formatQuantity(widget.getItemQuantity()).length() * 4;
+						int requirementLength = quantityString.length() * 4;
+
+						int xPos = point.x + 4 + extraLength;
+						int yPos = point.y - 1;
+						if (extraLength + requirementLength > 20)
+						{
+							xPos = point.x;
+							yPos = point.y + 9;
+						}
+
+						addedWidgets.add(createText(itemContainer,
+							"/ " + quantityString,
+							Color.WHITE.getRGB(),
+							ITEM_HORIZONTAL_SPACING,
+							TEXT_HEIGHT - 3,
+							xPos,
+							yPos));
+
+						totalItemsAdded++;
+						itemIds.removeAll(Collections.singletonList(widget.getItemId()));
+						break;
+					}
+				}
+			}
+			if (!foundItem)
+			{
+				if (totalItemsAdded == 0)
+				{
+					totalSectionsHeight = addSectionHeader(itemContainer, title, totalSectionsHeight);
+				}
+
+				// calculate correct item position as if this was a normal tab
+				int adjXOffset = (totalItemsAdded % ITEMS_PER_ROW) * ITEM_HORIZONTAL_SPACING + ITEM_ROW_START;
+				int adjYOffset = totalSectionsHeight + (totalItemsAdded / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING;
+
+				String quantityString = formatQuantity(bankTabItem.getQuantity());
+
+				Widget fakeItemWidget = createMissingItem(itemContainer, bankTabItem, adjXOffset, adjYOffset);
+				widgetItems.put(fakeItemWidget, bankTabItem);
+				addedWidgets.add(fakeItemWidget);
+
+
+				int requirementLength = quantityString.length() * 4;
+				int xPos = adjXOffset + 8;
+				int yPos = adjYOffset - 1;
+				if (requirementLength > 20)
+				{
+					xPos = adjXOffset;
+					yPos = adjYOffset + 9;
+				}
+
+				addedWidgets.add(createText(itemContainer,
+					"/ " + quantityString,
+					Color.WHITE.getRGB(),
+					ITEM_HORIZONTAL_SPACING,
+					TEXT_HEIGHT - 3,
+					xPos,
+					yPos));
+				itemIds.removeAll(bankTabItem.getItemIDs());
+				totalItemsAdded++;
+			}
+		}
+		int newHeight = totalSectionsHeight + (totalItemsAdded / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING;
+		newHeight = totalItemsAdded % ITEMS_PER_ROW != 0 ? newHeight + ITEM_VERTICAL_SPACING : newHeight;
+
+		return newHeight;
+	}
+
+	private int addGeneralSection(Widget itemContainer, ArrayList<Integer> items, int totalSectionsHeight)
+	{
+		int totalItemsAdded = 0;
+
+		if (items.isEmpty())
+		{
+			return totalSectionsHeight;
+		}
+
+		for (Integer itemID : items)
+		{
+			for (Widget widget : itemContainer.getDynamicChildren())
+			{
+				if (!widget.isHidden() && widget.getItemId() == itemID)
+				{
+					if (totalItemsAdded == 0)
+					{
+						totalSectionsHeight = addSectionHeader(itemContainer, "General", totalSectionsHeight);
+					}
+
+					placeItem(widget, totalItemsAdded, totalSectionsHeight);
+					totalItemsAdded++;
+				}
+			}
+		}
+		int newHeight = totalSectionsHeight + (totalItemsAdded / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING;
+		newHeight = totalItemsAdded % ITEMS_PER_ROW != 0 ? newHeight + ITEM_VERTICAL_SPACING : newHeight;
+
+		return newHeight;
+	}
+
+	private int addSectionHeader(Widget itemContainer, String title, int totalSectionsHeight)
+	{
+		addedWidgets.add(createGraphic(itemContainer, SpriteID.RESIZEABLE_MODE_SIDE_PANEL_BACKGROUND, ITEMS_PER_ROW * ITEM_HORIZONTAL_SPACING, LINE_HEIGHT, ITEM_ROW_START, totalSectionsHeight));
+		addedWidgets.add(createText(itemContainer, title, new Color(228, 216, 162).getRGB(), (ITEMS_PER_ROW * ITEM_HORIZONTAL_SPACING) + ITEM_ROW_START
+			, TEXT_HEIGHT, ITEM_ROW_START, totalSectionsHeight + LINE_VERTICAL_SPACING));
+
+		return totalSectionsHeight + LINE_VERTICAL_SPACING + TEXT_HEIGHT;
+	}
+
+	private Point placeItem(Widget widget, int totalItemsAdded, int totalSectionsHeight)
+	{
+		int adjYOffset = totalSectionsHeight + (totalItemsAdded / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING;
+		int adjXOffset = (totalItemsAdded % ITEMS_PER_ROW) * ITEM_HORIZONTAL_SPACING + ITEM_ROW_START;
+
+		if (widget.getOriginalY() != adjYOffset)
+		{
+			widget.setOriginalY(adjYOffset);
+			widget.revalidate();
+		}
+
+		if (widget.getOriginalX() != adjXOffset)
+		{
+			widget.setOriginalX(adjXOffset);
+			widget.revalidate();
+		}
+
+		return new Point(adjXOffset, adjYOffset);
+	}
+
+	private Widget createGraphic(Widget container, int spriteId, int width, int height, int x, int y)
+	{
+		Widget widget = container.createChild(-1, WidgetType.GRAPHIC);
+		widget.setOriginalWidth(width);
+		widget.setOriginalHeight(height);
+		widget.setOriginalX(x);
+		widget.setOriginalY(y);
+
+		widget.setSpriteId(spriteId);
+
+		widget.revalidate();
+
+		return widget;
+	}
+
+	private Widget createMissingItem(Widget container, BankTabItem bankTabItem, int x, int y)
+	{
+		Widget widget = container.createChild(-1, WidgetType.GRAPHIC);
+		widget.setItemQuantityMode(1); // quantity of 1 still shows number
+		widget.setOriginalWidth(ITEM_WIDTH);
+		widget.setOriginalHeight(ITEM_HEIGHT);
+		widget.setOriginalX(x);
+		widget.setOriginalY(y);
+
+		ArrayList<Integer> itemIDs = bankTabItem.getItemIDs();
+		if (itemIDs.size() == 0)
+		{
+			itemIDs.add(ItemID.CAKE_OF_GUIDANCE);
+		}
+
+		widget.setItemId(bankTabItem.getItemIDs().get(0));
+		widget.setName("<col=ff9040>" + bankTabItem.getText() + "</col>");
+		if (bankTabItem.getDetails() != null)
+		{
+			widget.setText(bankTabItem.getDetails());
+		}
+		widget.setItemQuantity(0);
+		widget.setOpacity(150);
+		widget.setOnOpListener(ScriptID.NULL);
+		widget.setHasListener(true);
+
+		addTabActions(widget);
+
+		widget.revalidate();
+
+		return widget;
+	}
+
+	private void addTabActions(Widget w)
+	{
+		w.setAction(1, "Details");
+
+		w.setOnOpListener((JavaScriptCallback) this::handleFakeItemClick);
+	}
+
+	private void handleFakeItemClick(ScriptEvent event)
+	{
+		Widget widget = event.getSource();
+		if (widget.getItemId() != -1)
+		{
+			String name = widget.getName();
+			BankTabItem item = widgetItems.get(widget);
+
+			final ChatMessageBuilder message = new ChatMessageBuilder()
+				.append("You need ")
+				.append(ChatColorType.HIGHLIGHT)
+				.append(QuantityFormatter.formatNumber(item.getQuantity()))
+				.append(" x ").append(Text.removeTags(name))
+				.append(".");
+
+			if (!widget.getText().isEmpty())
+			{
+				message.append(ChatColorType.NORMAL)
+				.append(" " + widget.getText() + ".");
+			}
+
+			chatMessageManager.queue(QueuedMessage.builder()
+				.type(ChatMessageType.ITEM_EXAMINE)
+				.runeLiteFormattedMessage(message.build())
+				.build());
+		}
+	}
+
+	private Widget createText(Widget container, String text, int color, int width, int height, int x, int y)
+	{
+		Widget widget = container.createChild(-1, WidgetType.TEXT);
+		widget.setOriginalWidth(width);
+		widget.setOriginalHeight(height);
+		widget.setOriginalX(x);
+		widget.setOriginalY(y);
+
+		widget.setText(text);
+		widget.setFontId(FontID.PLAIN_11);
+		widget.setTextColor(color);
+
+		widget.revalidate();
+
+		return widget;
+	}
+
+	private static String formatQuantity(int quantity)
+	{
+		if (quantity < 100000)
+		{
+			return String.valueOf(quantity);
+		}
+		if (quantity < 10000000)
+		{
+			return quantity / 1000 + "K";
+		}
+
+		return quantity / 1000000 + "M";
+	}
+}

--- a/src/main/java/com/questhelper/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTab.java
@@ -381,13 +381,14 @@ public class QuestBankTab
 
 						if (bankTabItem.getQuantity() > 0)
 						{
-							String quantityString = formatQuantity(bankTabItem.getQuantity());
-							int extraLength = formatQuantity(widget.getItemQuantity()).length() * 5;
-							int requirementLength = quantityString.length() * 5;
+							String quantityString = QuantityFormatter.quantityToStackSize(bankTabItem.getQuantity());
+							int extraLength =
+								QuantityFormatter.quantityToStackSize(widget.getItemQuantity()).length() * 6;
+							int requirementLength = quantityString.length() * 6;
 
-							int xPos = point.x + 3 + extraLength;
+							int xPos = point.x + 2 + extraLength;
 							int yPos = point.y - 1;
-							if (extraLength + requirementLength > 20)
+							if (extraLength + requirementLength > 24)
 							{
 								xPos = point.x;
 								yPos = point.y + 9;
@@ -418,8 +419,7 @@ public class QuestBankTab
 				int adjXOffset = (totalItemsAdded % ITEMS_PER_ROW) * ITEM_HORIZONTAL_SPACING + ITEM_ROW_START;
 				int adjYOffset = totalSectionsHeight + (totalItemsAdded / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING;
 
-				String quantityString = formatQuantity(bankTabItem.getQuantity());
-
+				String quantityString = QuantityFormatter.quantityToStackSize(bankTabItem.getQuantity());
 				Widget fakeItemWidget = createMissingItem(itemContainer, bankTabItem, adjXOffset, adjYOffset);
 				widgetItems.put(fakeItemWidget, bankTabItem);
 				addedWidgets.add(fakeItemWidget);
@@ -612,23 +612,10 @@ public class QuestBankTab
 		widget.setText(text);
 		widget.setFontId(FontID.PLAIN_11);
 		widget.setTextColor(color);
+		widget.setTextShadowed(true);
 
 		widget.revalidate();
 
 		return widget;
-	}
-
-	private static String formatQuantity(int quantity)
-	{
-		if (quantity < 100000)
-		{
-			return String.valueOf(quantity);
-		}
-		if (quantity < 10000000)
-		{
-			return quantity / 1000 + "K";
-		}
-
-		return quantity / 1000000 + "M";
 	}
 }

--- a/src/main/java/com/questhelper/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTab.java
@@ -372,10 +372,10 @@ public class QuestBankTab
 						widgetItems.put(widget, bankTabItem);
 
 						String quantityString = formatQuantity(bankTabItem.getQuantity());
-						int extraLength = formatQuantity(widget.getItemQuantity()).length() * 4;
-						int requirementLength = quantityString.length() * 4;
+						int extraLength = formatQuantity(widget.getItemQuantity()).length() * 5;
+						int requirementLength = quantityString.length() * 5;
 
-						int xPos = point.x + 4 + extraLength;
+						int xPos = point.x + 3 + extraLength;
 						int yPos = point.y - 1;
 						if (extraLength + requirementLength > 20)
 						{
@@ -415,7 +415,7 @@ public class QuestBankTab
 				addedWidgets.add(fakeItemWidget);
 
 
-				int requirementLength = quantityString.length() * 4;
+				int requirementLength = quantityString.length() * 5;
 				int xPos = adjXOffset + 8;
 				int yPos = adjYOffset - 1;
 				if (requirementLength > 20)

--- a/src/main/java/com/questhelper/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTab.java
@@ -378,26 +378,29 @@ public class QuestBankTab
 						widget.setItemQuantityMode(1);
 						widgetItems.put(widget, bankTabItem);
 
-						String quantityString = formatQuantity(bankTabItem.getQuantity());
-						int extraLength = formatQuantity(widget.getItemQuantity()).length() * 5;
-						int requirementLength = quantityString.length() * 5;
 
-						int xPos = point.x + 3 + extraLength;
-						int yPos = point.y - 1;
-						if (extraLength + requirementLength > 20)
+						if (bankTabItem.getQuantity() > 0)
 						{
-							xPos = point.x;
-							yPos = point.y + 9;
+							String quantityString = formatQuantity(bankTabItem.getQuantity());
+							int extraLength = formatQuantity(widget.getItemQuantity()).length() * 5;
+							int requirementLength = quantityString.length() * 5;
+
+							int xPos = point.x + 3 + extraLength;
+							int yPos = point.y - 1;
+							if (extraLength + requirementLength > 20)
+							{
+								xPos = point.x;
+								yPos = point.y + 9;
+							}
+
+							addedWidgets.add(createText(itemContainer,
+								"/ " + quantityString,
+								Color.WHITE.getRGB(),
+								ITEM_HORIZONTAL_SPACING,
+								TEXT_HEIGHT - 3,
+								xPos,
+								yPos));
 						}
-
-						addedWidgets.add(createText(itemContainer,
-							"/ " + quantityString,
-							Color.WHITE.getRGB(),
-							ITEM_HORIZONTAL_SPACING,
-							TEXT_HEIGHT - 3,
-							xPos,
-							yPos));
-
 						totalItemsAdded++;
 						itemIds.removeAll(Collections.singletonList(widget.getItemId()));
 						break;
@@ -421,23 +424,25 @@ public class QuestBankTab
 				widgetItems.put(fakeItemWidget, bankTabItem);
 				addedWidgets.add(fakeItemWidget);
 
-
-				int requirementLength = quantityString.length() * 5;
-				int xPos = adjXOffset + 8;
-				int yPos = adjYOffset - 1;
-				if (requirementLength > 20)
+				if (bankTabItem.getQuantity() > 0)
 				{
-					xPos = adjXOffset;
-					yPos = adjYOffset + 9;
-				}
+					int requirementLength = quantityString.length() * 5;
+					int xPos = adjXOffset + 8;
+					int yPos = adjYOffset - 1;
+					if (requirementLength > 20)
+					{
+						xPos = adjXOffset;
+						yPos = adjYOffset + 9;
+					}
 
-				addedWidgets.add(createText(itemContainer,
-					"/ " + quantityString,
-					Color.WHITE.getRGB(),
-					ITEM_HORIZONTAL_SPACING,
-					TEXT_HEIGHT - 3,
-					xPos,
-					yPos));
+					addedWidgets.add(createText(itemContainer,
+						"/ " + quantityString,
+						Color.WHITE.getRGB(),
+						ITEM_HORIZONTAL_SPACING,
+						TEXT_HEIGHT - 3,
+						xPos,
+						yPos));
+				}
 				itemIds.removeAll(bankTabItem.getItemIDs());
 				totalItemsAdded++;
 			}
@@ -571,11 +576,16 @@ public class QuestBankTab
 			String name = widget.getName();
 			BankTabItem item = widgetItems.get(widget);
 
+			String quantity = QuantityFormatter.formatNumber(item.getQuantity()) + " x ";
+			if (item.getQuantity() == -1)
+			{
+				quantity = "some ";
+			}
 			final ChatMessageBuilder message = new ChatMessageBuilder()
 				.append("You need ")
 				.append(ChatColorType.HIGHLIGHT)
-				.append(QuantityFormatter.formatNumber(item.getQuantity()))
-				.append(" x ").append(Text.removeTags(name))
+				.append(quantity)
+				.append(Text.removeTags(name))
 				.append(".");
 
 			if (!widget.getText().isEmpty())

--- a/src/main/java/com/questhelper/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTab.java
@@ -200,38 +200,15 @@ public class QuestBankTab
 		int[] intStack = client.getIntStack();
 		int intStackSize = client.getIntStackSize();
 
-		switch (eventName)
+		if ("getSearchingTagTab".equals(eventName))
 		{
-			case "bankSearchFilter":
-				final int itemId = intStack[intStackSize - 1];
-
-				if (!questBankTabInterface.isQuestTabActive())
-				{
-					return;
-				}
-				if (client.getVar(Varbits.CURRENT_BANK_TAB) != 0)
-				{
-					client.setVarbit(Varbits.CURRENT_BANK_TAB, 0);
-				}
-
-				if (questHelper.getBankTagService().shouldTag(itemId))
-				{
-					intStack[intStackSize - 2] = 1;
-				}
-				else
-				{
-					intStack[intStackSize - 2] = 0;
-				}
-				break;
-			case "getSearchingTagTab":
-				intStack[intStackSize - 1] = questBankTabInterface.isQuestTabActive() ? 1 : 0;
-				if (questBankTabInterface.isQuestTabActive())
-				{
-					// As we're on the quest helper tab, we don't need to check again for tab tags
-					// Change the name of the event so as to not proc another check
-					event.setEventName("getSearchingQuestHelperTab");
-				}
-				break;
+			intStack[intStackSize - 1] = questBankTabInterface.isQuestTabActive() ? 1 : 0;
+			if (questBankTabInterface.isQuestTabActive())
+			{
+				// As we're on the quest helper tab, we don't need to check again for tab tags
+				// Change the name of the event so as to not proc another check
+				event.setEventName("getSearchingQuestHelperTab");
+			}
 		}
 	}
 
@@ -272,7 +249,7 @@ public class QuestBankTab
 			return;
 		}
 
-		if (event.getScriptId() != ScriptID.BANKMAIN_FINISHBUILDING)
+		if (event.getScriptId() != ScriptID.BANKMAIN_BUILD)
 		{
 			return;
 		}

--- a/src/main/java/com/questhelper/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTab.java
@@ -175,7 +175,14 @@ public class QuestBankTab
 				Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
 				if (bankTitle != null)
 				{
-					bankTitle.setText("Tab <col=ff0000>Quest Helper</col>");
+					if (questHelper.getSelectedQuest() != null)
+					{
+						bankTitle.setText("Tab <col=ff0000>" + questHelper.getSelectedQuest().getQuest().getName() + "</col>");
+					}
+					else
+					{
+						bankTitle.setText("Tab <col=ff0000>Quest Helper</col>");
+					}
 				}
 			}
 		}

--- a/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
@@ -80,18 +80,18 @@ public class QuestBankTabInterface
 
 		parent = client.getWidget(WidgetInfo.BANK_CONTAINER);
 
-		int QUEST_BUTTON_SIZE = 22;
+		int QUEST_BUTTON_SIZE = 25;
 		int QUEST_BUTTON_X = 408;
-		int QUEST_BUTTON_Y = 6;
+		int QUEST_BUTTON_Y = 5;
 		questBackgroundWidget = createGraphic("quest-helper", SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL, QUEST_BUTTON_SIZE,
 			QUEST_BUTTON_SIZE,
 			QUEST_BUTTON_X, QUEST_BUTTON_Y);
 		questBackgroundWidget.setAction(1, VIEW_TAB);
 		questBackgroundWidget.setOnOpListener((JavaScriptCallback) this::handleTagTab);
 
-		questIconWidget = createGraphic("", SpriteID.QUESTS_PAGE_ICON_BLUE_QUESTS, QUEST_BUTTON_SIZE - 4,
-			QUEST_BUTTON_SIZE - 4,
-			QUEST_BUTTON_X + 2, QUEST_BUTTON_Y + 2);
+		questIconWidget = createGraphic("", SpriteID.QUESTS_PAGE_ICON_BLUE_QUESTS, QUEST_BUTTON_SIZE - 6,
+			QUEST_BUTTON_SIZE - 6,
+			QUEST_BUTTON_X + 3, QUEST_BUTTON_Y + 3);
 
 		questTabActive = false;
 	}

--- a/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
@@ -128,7 +128,7 @@ public class QuestBankTabInterface
 
 		// If click a base tab, close
 		boolean clickedTabTag = menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper");
-		boolean clickedOtherTab =  menuOption.equals("View all items") || menuOption.startsWith("View tag tab");
+		boolean clickedOtherTab = menuOption.equals("View all items") || menuOption.startsWith("View tag tab");
 		if (questTabActive && (clickedTabTag || clickedOtherTab))
 		{
 			closeTab();

--- a/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
@@ -61,7 +61,6 @@ public class QuestBankTabInterface
 	@Getter
 	private Widget questBackgroundWidget;
 
-
 	private final Client client;
 	private final BankSearch bankSearch;
 
@@ -128,10 +127,12 @@ public class QuestBankTabInterface
 		String menuOption = event.getMenuOption();
 
 		// If click a base tab, close
-		if (questTabActive
-			&& (menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper"))
-			|| menuOption.equals("View all items")
-			|| menuOption.startsWith("View tag tab"))
+		if (questTabActive &&
+			((menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper"))
+				|| menuOption.equals("View all items")
+				|| menuOption.startsWith("View tag tab")
+			)
+		)
 		{
 			closeTab();
 		}
@@ -179,8 +180,11 @@ public class QuestBankTabInterface
 	public void closeTab()
 	{
 		questTabActive = false;
-		questBackgroundWidget.setSpriteId(SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL);
-		questBackgroundWidget.revalidate();
+		if (questBackgroundWidget != null)
+		{
+			questBackgroundWidget.setSpriteId(SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL);
+			questBackgroundWidget.revalidate();
+		}
 	}
 
 	private void activateTab()

--- a/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
@@ -127,12 +127,9 @@ public class QuestBankTabInterface
 		String menuOption = event.getMenuOption();
 
 		// If click a base tab, close
-		if (questTabActive &&
-			((menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper"))
-				|| menuOption.equals("View all items")
-				|| menuOption.startsWith("View tag tab")
-			)
-		)
+		boolean clickedTabTag = menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper");
+		boolean clickedOtherTab =  menuOption.equals("View all items") || menuOption.startsWith("View tag tab");
+		if (questTabActive && (clickedTabTag || clickedOtherTab))
 		{
 			closeTab();
 		}

--- a/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
@@ -93,7 +93,11 @@ public class QuestBankTabInterface
 			QUEST_BUTTON_SIZE - 6,
 			QUEST_BUTTON_X + 3, QUEST_BUTTON_Y + 3);
 
-		questTabActive = false;
+		if (questTabActive)
+		{
+			questTabActive = false;
+			activateTab();
+		}
 	}
 
 	public void destroy()

--- a/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/banktab/QuestBankTabInterface.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018, Ron Young <https://github.com/raiyni>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.banktab;
+
+import javax.inject.Inject;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.Client;
+import net.runelite.api.ScriptEvent;
+import net.runelite.api.ScriptID;
+import net.runelite.api.SoundEffectID;
+import net.runelite.api.SpriteID;
+import net.runelite.api.VarClientInt;
+import net.runelite.api.VarClientStr;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetType;
+import net.runelite.client.plugins.bank.BankSearch;
+
+public class QuestBankTabInterface
+{
+	private static final String VIEW_TAB = "View tab ";
+
+	@Setter
+	@Getter
+	private boolean questTabActive = false;
+
+	@Getter
+	private Widget parent;
+
+	@Getter
+	private Widget questIconWidget;
+
+	@Getter
+	private Widget questBackgroundWidget;
+
+
+	private final Client client;
+	private final BankSearch bankSearch;
+
+	@Inject
+	public QuestBankTabInterface(Client client, BankSearch bankSearch)
+	{
+		this.client = client;
+		this.bankSearch = bankSearch;
+	}
+
+	public void init()
+	{
+		if (isHidden())
+		{
+			return;
+		}
+
+		parent = client.getWidget(WidgetInfo.BANK_CONTAINER);
+
+		int QUEST_BUTTON_SIZE = 22;
+		int QUEST_BUTTON_X = 408;
+		int QUEST_BUTTON_Y = 6;
+		questBackgroundWidget = createGraphic("quest-helper", SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL, QUEST_BUTTON_SIZE,
+			QUEST_BUTTON_SIZE,
+			QUEST_BUTTON_X, QUEST_BUTTON_Y);
+		questBackgroundWidget.setAction(1, VIEW_TAB);
+		questBackgroundWidget.setOnOpListener((JavaScriptCallback) this::handleTagTab);
+
+		questIconWidget = createGraphic("", SpriteID.QUESTS_PAGE_ICON_BLUE_QUESTS, QUEST_BUTTON_SIZE - 4,
+			QUEST_BUTTON_SIZE - 4,
+			QUEST_BUTTON_X + 2, QUEST_BUTTON_Y + 2);
+
+		questTabActive = false;
+	}
+
+	public void destroy()
+	{
+		if (questTabActive)
+		{
+			closeTab();
+			bankSearch.reset(true);
+		}
+
+		parent = null;
+
+		if (questIconWidget != null)
+		{
+			questIconWidget.setHidden(true);
+		}
+
+		if (questBackgroundWidget != null)
+		{
+			questBackgroundWidget.setHidden(true);
+		}
+		questTabActive = false;
+	}
+
+	public void handleClick(MenuOptionClicked event)
+	{
+		if (isHidden())
+		{
+			return;
+		}
+		String menuOption = event.getMenuOption();
+
+		// If click a base tab, close
+		if (questTabActive
+			&& (menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper"))
+			|| menuOption.equals("View all items")
+			|| menuOption.startsWith("View tag tab"))
+		{
+			closeTab();
+		}
+	}
+
+	public void handleSearch()
+	{
+		if (questTabActive)
+		{
+			closeTab();
+			// This ensures that when clicking Search when tab is selected, the search input is opened rather
+			// than client trying to close it first
+			client.setVar(VarClientStr.INPUT_TEXT, "");
+			client.setVar(VarClientInt.INPUT_TYPE, 0);
+		}
+	}
+
+	private boolean isHidden()
+	{
+		Widget widget = client.getWidget(WidgetInfo.BANK_CONTAINER);
+		return widget == null || widget.isHidden();
+	}
+
+	private void handleTagTab(ScriptEvent event)
+	{
+		if (event.getOp() == 2)
+		{
+			client.setVarbit(Varbits.CURRENT_BANK_TAB, 0);
+
+			if (questTabActive)
+			{
+				closeTab();
+				bankSearch.reset(true);
+			}
+			else
+			{
+				activateTab();
+				// openTag will reset and relayout
+			}
+
+			client.playSoundEffect(SoundEffectID.UI_BOOP);
+		}
+	}
+
+	public void closeTab()
+	{
+		questTabActive = false;
+		questBackgroundWidget.setSpriteId(SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL);
+		questBackgroundWidget.revalidate();
+	}
+
+	private void activateTab()
+	{
+		if (questTabActive)
+		{
+			return;
+		}
+
+		questBackgroundWidget.setSpriteId(SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL_SELECTED);
+		questBackgroundWidget.revalidate();
+		questTabActive = true;
+
+		bankSearch.reset(true); // clear search dialog & relayout bank for new tab.
+
+		// When searching the button has a script on timer to detect search end, that will set the background back
+		// and remove the timer. However since we are going from a bank search to our fake search this will not remove
+		// the timer but instead re-add it and reset the background. So remove the timer and the background. This is the
+		// same as bankmain_search_setbutton.
+		Widget searchButtonBackground = client.getWidget(WidgetInfo.BANK_SEARCH_BUTTON_BACKGROUND);
+		if (searchButtonBackground != null)
+		{
+			searchButtonBackground.setOnTimerListener((Object[]) null);
+			searchButtonBackground.setSpriteId(SpriteID.EQUIPMENT_SLOT_TILE);
+		}
+	}
+
+	private Widget createGraphic(Widget container, String name, int spriteId, int width, int height, int x, int y)
+	{
+		Widget widget = container.createChild(-1, WidgetType.GRAPHIC);
+		widget.setOriginalWidth(width);
+		widget.setOriginalHeight(height);
+		widget.setOriginalX(x);
+		widget.setOriginalY(y);
+
+		widget.setSpriteId(spriteId);
+		widget.setOnOpListener(ScriptID.NULL);
+		widget.setHasListener(true);
+		widget.setName(name);
+		widget.revalidate();
+
+		return widget;
+	}
+
+	private Widget createGraphic(String name, int spriteId, int width, int height, int x, int y)
+	{
+		return createGraphic(parent, name, spriteId, width, height, x, y);
+	}
+}

--- a/src/main/java/com/questhelper/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/banktab/QuestHelperBankTagService.java
@@ -42,9 +42,6 @@ public class QuestHelperBankTagService
 {
 	private final QuestHelperPlugin plugin;
 
-	private final HashMap<QuestHelper, ArrayList<Integer>> itemsForHelper = new HashMap<>();
-	private final HashMap<QuestHelper, ArrayList<BankTabItems>> bankItemsForHelper = new HashMap<>();
-
 	@Inject
 	public QuestHelperBankTagService(QuestHelperPlugin plugin)
 	{
@@ -53,13 +50,7 @@ public class QuestHelperBankTagService
 
 	public boolean shouldTag(int itemID)
 	{
-		QuestHelper currentQuest = plugin.getSelectedQuest();
-		if (!itemsForHelper.containsKey(currentQuest))
-		{
-			System.out.println("HMMMMM");
-			itemsForHelper.put(currentQuest, itemsToTag());
-		}
-		return itemsForHelper.get(currentQuest).contains(itemID);
+		return itemsToTag().contains(itemID);
 	}
 	
 	public ArrayList<Integer> itemsToTag()
@@ -95,23 +86,12 @@ public class QuestHelperBankTagService
 	
 	public ArrayList<BankTabItems> getPluginBankTagItemsForSections()
 	{
-		if (bankItemsForHelper.containsKey(plugin.getSelectedQuest()))
-		{
-			return bankItemsForHelper.get(plugin.getSelectedQuest());
-		}
-
 		ArrayList<BankTabItems> newList = new ArrayList<>();
-		if (plugin.getSelectedQuest() == null)
-		{
-			bankItemsForHelper.put(plugin.getSelectedQuest(), newList);
-			return newList;
-		}
 
 		ArrayList<PanelDetails> questSections = plugin.getSelectedQuest().getPanels();
 
 		if (questSections == null || questSections.isEmpty())
 		{
-			bankItemsForHelper.put(plugin.getSelectedQuest(), newList);
 			return newList;
 		}
 
@@ -138,8 +118,6 @@ public class QuestHelperBankTagService
 			}
 			newList.add(pluginItems);
 		}
-
-		bankItemsForHelper.put(plugin.getSelectedQuest(), newList);
 
 		return newList;
 	}

--- a/src/main/java/com/questhelper/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/banktab/QuestHelperBankTagService.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.banktab;
+
+import com.questhelper.QuestHelperPlugin;
+import com.questhelper.banktab.BankTabItem;
+import com.questhelper.banktab.BankTabItems;
+import com.questhelper.panel.PanelDetails;
+import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.requirements.ItemRequirement;
+import com.questhelper.requirements.ItemRequirements;
+import com.questhelper.steps.conditional.LogicType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import javax.inject.Inject;
+import net.runelite.api.InventoryID;
+import net.runelite.api.ItemContainer;
+
+public class QuestHelperBankTagService
+{
+	private final QuestHelperPlugin plugin;
+
+	private final HashMap<QuestHelper, ArrayList<Integer>> itemsForHelper = new HashMap<>();
+	private final HashMap<QuestHelper, ArrayList<BankTabItems>> bankItemsForHelper = new HashMap<>();
+
+	@Inject
+	public QuestHelperBankTagService(QuestHelperPlugin plugin)
+	{
+		this.plugin = plugin;
+	}
+
+	public boolean shouldTag(int itemID)
+	{
+		QuestHelper currentQuest = plugin.getSelectedQuest();
+		if (!itemsForHelper.containsKey(currentQuest))
+		{
+			System.out.println("HMMMMM");
+			itemsForHelper.put(currentQuest, itemsToTag());
+		}
+		return itemsForHelper.get(currentQuest).contains(itemID);
+	}
+	
+	public ArrayList<Integer> itemsToTag()
+	{
+		ArrayList<BankTabItems> sortedItems = getPluginBankTagItemsForSections();
+
+		if (sortedItems == null)
+		{
+			return null;
+		}
+
+		ArrayList<Integer> flattenedList = new ArrayList<>();
+
+		for (BankTabItems sortedItem : sortedItems)
+		{
+			for (BankTabItem pluginBankTabItem : sortedItem.getItems())
+			{
+				ArrayList<Integer> itemIds = pluginBankTabItem.getItemIDs();
+				if (itemIds != null)
+				{
+					for (Integer itemId : itemIds)
+					{
+						if (!flattenedList.contains(itemId))
+						{
+							flattenedList.add(itemId);
+						}
+					}
+				}
+			}
+		}
+		return flattenedList;
+	}
+	
+	public ArrayList<BankTabItems> getPluginBankTagItemsForSections()
+	{
+		if (bankItemsForHelper.containsKey(plugin.getSelectedQuest()))
+		{
+			return bankItemsForHelper.get(plugin.getSelectedQuest());
+		}
+
+		ArrayList<BankTabItems> newList = new ArrayList<>();
+		if (plugin.getSelectedQuest() == null)
+		{
+			bankItemsForHelper.put(plugin.getSelectedQuest(), newList);
+			return newList;
+		}
+
+		ArrayList<PanelDetails> questSections = plugin.getSelectedQuest().getPanels();
+
+		if (questSections == null || questSections.isEmpty())
+		{
+			bankItemsForHelper.put(plugin.getSelectedQuest(), newList);
+			return newList;
+		}
+
+		ArrayList<ItemRequirement> recommendedItems = plugin.getSelectedQuest().getItemRecommended();
+
+		if (recommendedItems != null && !recommendedItems.isEmpty())
+		{
+			BankTabItems pluginItems = new BankTabItems("Recommended items");
+			for (ItemRequirement item : recommendedItems)
+			{
+				getItemsFromRequirement(pluginItems, item);
+			}
+			newList.add(pluginItems);
+		}
+
+		for (PanelDetails questSection : questSections)
+		{
+			ArrayList<ItemRequirement> items = questSection.getItemRequirements();
+			BankTabItems pluginItems = new BankTabItems(questSection.getHeader());
+
+			for (ItemRequirement item : items)
+			{
+				getItemsFromRequirement(pluginItems, item);
+			}
+			newList.add(pluginItems);
+		}
+
+		bankItemsForHelper.put(plugin.getSelectedQuest(), newList);
+
+		return newList;
+	}
+
+	private void getItemsFromRequirement(BankTabItems pluginItems, ItemRequirement itemRequirement)
+	{
+		if (itemRequirement instanceof ItemRequirements)
+		{
+			ItemRequirements itemRequirements = (ItemRequirements) itemRequirement;
+			LogicType logicType = itemRequirements.getLogicType();
+			ArrayList<ItemRequirement> requirements = itemRequirements.getItemRequirements();
+			if (logicType == LogicType.AND)
+			{
+				for (ItemRequirement requirement : requirements)
+				{
+					getItemsFromRequirement(pluginItems, requirement);
+				}
+			}
+			if (logicType == LogicType.OR)
+			{
+				// If any of the requirements pass, use it
+				// Else, use first one?
+				boolean foundMatch = false;
+				for (ItemRequirement requirement : requirements)
+				{
+					if (requirement.checkBank(plugin.getClient()))
+					{
+						foundMatch = true;
+						getItemsFromRequirement(pluginItems, requirement);
+						break;
+					}
+				}
+				if (!foundMatch)
+				{
+					getItemsFromRequirement(pluginItems, requirements.get(0));
+				}
+			}
+		}
+		else
+		{
+			if (!itemRequirement.getDisplayItemIds().contains(-1))
+			{
+				pluginItems.addItems(makeBankTabItem(itemRequirement));
+			}
+		}
+	}
+
+	private BankTabItem makeBankTabItem(ItemRequirement item)
+	{
+		ArrayList<Integer> itemIds = item.getDisplayItemIds();
+
+		Integer displayId = itemIds.get(0);
+
+
+		for (Integer itemId : itemIds)
+		{
+			if (hasItemInBank(itemId))
+			{
+				displayId = itemId;
+				break;
+			}
+		}
+
+		return new BankTabItem(item.getQuantity(), item.getName(), displayId, item.getTip());
+	}
+
+	public boolean hasItemInBank(int itemID)
+	{
+		ItemContainer bankContainer = plugin.getClient().getItemContainer(InventoryID.BANK);
+		if (bankContainer == null)
+		{
+			return false;
+		}
+
+		return bankContainer.contains(itemID);
+	}
+
+	public boolean shouldSortTabIntoSections()
+	{
+		return true;
+	}
+
+	public boolean shouldShowMissingItems()
+	{
+		return true;
+	}
+}

--- a/src/main/java/com/questhelper/requirements/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/ItemRequirement.java
@@ -46,6 +46,9 @@ public class ItemRequirement extends Requirement
 	private final String name;
 
 	@Setter
+	private Integer displayItemId;
+
+	@Setter
 	@Getter
 	private int quantity;
 
@@ -318,5 +321,34 @@ public class ItemRequirement extends Requirement
 	public boolean check(Client client, boolean checkConsideringSlotRestrictions)
 	{
 		return check(client, checkConsideringSlotRestrictions, null);
+	}
+
+	public boolean checkBank(Client client)
+	{
+		ItemContainer bankContainer = client.getItemContainer(InventoryID.BANK);
+		if (bankContainer == null)
+		{
+			return false;
+		}
+
+		for (Integer itemId : getDisplayItemIds())
+		{
+			if (bankContainer.contains(itemId))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public ArrayList<Integer> getDisplayItemIds()
+	{
+		if (displayItemId == null)
+		{
+			return getAllIds();
+		}
+
+		return new ArrayList<>(Collections.singletonList(displayItemId));
 	}
 }

--- a/src/main/java/com/questhelper/requirements/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/ItemRequirements.java
@@ -38,6 +38,7 @@ public class ItemRequirements extends ItemRequirement
 	@Getter
 	ArrayList<ItemRequirement> itemRequirements = new ArrayList<>();
 
+	@Getter
 	LogicType logicType;
 
 	public ItemRequirements(String name, ItemRequirement... itemRequirements)


### PR DESCRIPTION
This adds a button to the bank which brings up an interface with the items you'll need for the currently active quest, with the items sorted into sections, and the number of items indicated.

Few things in terms of player-facing bits I'm unsure on:

1. The position of the button is far from ideal. I've put it at the top right to avoid it conflicting with any existing Runelite functionality, but it feels a bit rubbish. Any ideas on good placement + how it should interact are appreciated
2. Quantity overlay is okay, but can be bad for larger quantities, and over brighter items.
3. 