### PR TITLE
Add the ability to start creating developer tools

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
 import lombok.Setter;
@@ -159,6 +160,11 @@ public class QuestHelperPlugin extends Plugin
 
 	@Getter
 	private QuestHelper selectedQuest = null;
+
+	@Getter
+	@Inject
+	@Named("developerMode")
+	private boolean developerMode;
 
 	@Setter
 	private QuestHelper sidebarSelectedQuest = null;


### PR DESCRIPTION
This is a simple change but it allows us to start talking about what tools we want to add for when users are working on QuestHelper.
Either when they are making a quest or just doing dev work in general.

I did a short test and confirmed this worked by adding to the overlay in the `QuestHelperOverlay` class.

I believe with this we can now start working on some useful tools for when quests need to be added/edited.

You could also a way for devs to 'step' through their existing steps without having to progress through a quest so they can make sure their zones/objects/npcs work as intended. Obviously these won't work for instances or places that only appear during the quest, but for most things this should remove the doubt that a particular step works.