### PR TITLE
Add the basic framework for adding debug information

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -204,4 +204,15 @@ public interface QuestHelperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "debugColor",
+		name = "Debug Color",
+		description = "debug",
+		hidden = true
+	)
+	default Color debugColor()
+	{
+		return Color.MAGENTA;
+	}
 }

--- a/src/main/java/com/questhelper/QuestHelperDebugOverlay.java
+++ b/src/main/java/com/questhelper/QuestHelperDebugOverlay.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  * Copyright (c) 2021, Senmori
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  *
+ *  * 1. Redistributions of source code must retain the above copyright notice, this
+ *  *    list of conditions and the following disclaimer.
+ *  * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *  *    this list of conditions and the following disclaimer in the documentation
+ *  *    and/or other materials provided with the distribution.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package com.questhelper;
+
+import com.questhelper.questhelpers.QuestDebugRenderer;
+import com.questhelper.questhelpers.QuestHelper;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+public class QuestHelperDebugOverlay extends OverlayPanel implements QuestDebugRenderer
+{
+	private final QuestHelperPlugin plugin;
+	@Inject
+	public QuestHelperDebugOverlay(QuestHelperPlugin plugin)
+	{
+		this.plugin = plugin;
+		setLayer(OverlayLayer.ALWAYS_ON_TOP);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		QuestHelper quest = plugin.getSelectedQuest();
+
+		if (plugin.isDeveloperMode() && quest != null)
+		{
+			renderDebugOverlay(graphics, plugin, quest, panelComponent);
+			renderDebugWorldOverlayHint(graphics, plugin, quest, panelComponent);
+			renderDebugWidgetOverlayHint(graphics, plugin, quest, panelComponent);
+		}
+
+		return super.render(graphics);
+	}
+
+	@Override
+	public void renderDebugOverlay(Graphics graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent)
+	{
+		if (plugin.isDeveloperMode())
+		{
+			quest.renderDebugOverlay(graphics, plugin, quest, panelComponent);
+		}
+	}
+}

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -156,6 +156,9 @@ public class QuestHelperPlugin extends Plugin
 	private QuestHelperWorldOverlay questHelperWorldOverlay;
 
 	@Inject
+	private QuestHelperDebugOverlay questHelperDebugOverlay;
+
+	@Inject
 	private QuestHelperConfig config;
 
 	@Getter
@@ -195,6 +198,10 @@ public class QuestHelperPlugin extends Plugin
 		overlayManager.add(questHelperOverlay);
 		overlayManager.add(questHelperWorldOverlay);
 		overlayManager.add(questHelperWidgetOverlay);
+		if (isDeveloperMode())
+		{
+			overlayManager.add(questHelperDebugOverlay);
+		}
 
 		final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "/quest_icon.png");
 
@@ -220,6 +227,10 @@ public class QuestHelperPlugin extends Plugin
 		overlayManager.remove(questHelperOverlay);
 		overlayManager.remove(questHelperWorldOverlay);
 		overlayManager.remove(questHelperWidgetOverlay);
+		if (isDeveloperMode())
+		{
+			overlayManager.remove(questHelperDebugOverlay);
+		}
 		clientToolbar.removeNavigation(navButton);
 		shutDownQuest();
 		quests = null;
@@ -565,6 +576,10 @@ public class QuestHelperPlugin extends Plugin
 		{
 			selectedQuest = questHelper;
 			eventBus.register(selectedQuest);
+			if (isDeveloperMode())
+			{
+				selectedQuest.debugStartup(config);
+			}
 			selectedQuest.startUp(config);
 			if (selectedQuest.getCurrentStep() == null)
 			{

--- a/src/main/java/com/questhelper/questhelpers/QuestDebugRenderer.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestDebugRenderer.java
@@ -33,9 +33,12 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public interface QuestDebugRenderer
 {
+	/** Used to render overlay's like quest steps. */
 	default void renderDebugOverlay(Graphics graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent) {}
 
+	/** Used to render an overlay similar to how fishing spot overlays work. */
 	default void renderDebugWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent) {}
 
+	/** Used to render overlays on widgets */
 	default void renderDebugWidgetOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent) {}
 }

--- a/src/main/java/com/questhelper/questhelpers/QuestDebugRenderer.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestDebugRenderer.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  * Copyright (c) 2021, Senmori
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  *
+ *  * 1. Redistributions of source code must retain the above copyright notice, this
+ *  *    list of conditions and the following disclaimer.
+ *  * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *  *    this list of conditions and the following disclaimer in the documentation
+ *  *    and/or other materials provided with the distribution.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package com.questhelper.questhelpers;
+
+import com.questhelper.QuestHelperPlugin;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+public interface QuestDebugRenderer
+{
+	default void renderDebugOverlay(Graphics graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent) {}
+
+	default void renderDebugWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent) {}
+
+	default void renderDebugWidgetOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent) {}
+}

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -29,10 +29,13 @@ import com.google.inject.CreationException;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.questhelper.QuestHelperConfig;
+import com.questhelper.QuestHelperPlugin;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.requirements.ItemRequirement;
 import com.questhelper.requirements.Requirement;
+import java.awt.Color;
+import java.awt.Graphics;
 import java.util.ArrayList;
 import java.util.Collection;
 import javax.inject.Inject;
@@ -43,8 +46,11 @@ import net.runelite.api.QuestState;
 import net.runelite.client.eventbus.EventBus;
 import com.questhelper.steps.OwnerStep;
 import com.questhelper.steps.QuestStep;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public abstract class QuestHelper implements Module
+public abstract class QuestHelper implements Module, QuestDebugRenderer
 {
 	@Inject
 	protected Client client;
@@ -76,6 +82,8 @@ public abstract class QuestHelper implements Module
 	public abstract void shutDown();
 
 	public abstract boolean updateQuest();
+
+	public void debugStartup(QuestHelperConfig config) {}
 
 	protected void startUpStep(QuestStep step)
 	{
@@ -153,6 +161,26 @@ public abstract class QuestHelper implements Module
 			}
 		}
 		return true;
+	}
+
+	@Override
+	public void renderDebugOverlay(Graphics graphics, QuestHelperPlugin plugin, QuestHelper quest, PanelComponent panelComponent)
+	{
+		if (!plugin.isDeveloperMode()) return;
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Quest")
+			.leftColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.right("Var")
+			.rightColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.build()
+		);
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left(quest.getQuest().getName())
+			.leftColor(quest.getConfig().debugColor())
+			.right(quest.getVar() + "")
+			.rightColor(quest.getConfig().debugColor())
+			.build()
+		);
 	}
 
 	public int getVar()


### PR DESCRIPTION
This will allow devs to have more information on screen while they are working on quests.

This PR implements the basic framework that will allow devs to add debug information on screen while working in dev-mode.
At the moment, all it does is display the current Var of the active quest, but devs can override that behavior in each quest using the correct methods.

See `QuestHelperRenderer` for which method to use.

`renderDebugOverlay` is for rendering overlay similar to how quest step overlays are rendered.
`renderDebugWorldOverlayHint` is for rendering overlays similar to how fishing spots/agility spots are rendered
`renderDebugWidgetOverlayHint` is for rendering overlay hints on widgets

