### PR TITLE
Add enum for QuestHelper icons.

### DIFF
--- a/src/main/java/com/questhelper/IconUtil.java
+++ b/src/main/java/com/questhelper/IconUtil.java
@@ -1,0 +1,93 @@
+/*
+ *
+ *  * Copyright (c) 2021, Senmori
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  *
+ *  * 1. Redistributions of source code must retain the above copyright notice, this
+ *  *    list of conditions and the following disclaimer.
+ *  * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *  *    this list of conditions and the following disclaimer in the documentation
+ *  *    and/or other materials provided with the distribution.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package com.questhelper;
+
+import java.awt.image.BufferedImage;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nonnull;
+import javax.swing.ImageIcon;
+import net.runelite.client.util.ImageUtil;
+
+public enum IconUtil
+{
+	CLOSE("/close.png"),
+	COLLAPSED("/collapsed.png"),
+	DISCORD("/discord.png"),
+	EXPANDED("/expanded.png"),
+	ICON_BACKGROUND("/icon_background.png"),
+	INFO_ICON("/info_icon.png"),
+	QUEST_ICON("/quest_icon.png"),
+	QUEST_STEP_ARROW("/quest_step_arrow.png"),
+	QUEST_STEP_ARROW_45("/quest_step_arrow_45.png"),
+	QUEST_STEP_ARROW_90("/quest_step_arrow_90.png"),
+	QUEST_STEP_ARROW_135("/quest_step_arrow_135.png"),
+	QUEST_STEP_ARROW_180("/quest_step_arrow_180.png"),
+	QUEST_STEP_ARROW_225("/quest_step_arrow_225.png"),
+	QUEST_STEP_ARROW_270("/quest_step_arrow_270.png"),
+	QUEST_STEP_ARROW_315("/quest_step_arrow_315.png"),
+	START("/start.png"),
+	;
+
+	private final String file;
+	IconUtil(String file)
+	{
+		this.file = file;
+	}
+
+	/**
+	 * Get the raw {@link BufferedImage} of this icon.
+	 * @return {@link BufferedImage} of the icon
+	 */
+	public BufferedImage getImage()
+	{
+		return ImageUtil.loadImageResource(QuestHelperPlugin.class, file);
+	}
+
+	/**
+	 * @return the {@link ImageIcon} with no modifications. Equivalent to {@code getIcon(UnaryOperator.identity())}
+	 */
+	public ImageIcon getIcon()
+	{
+		return getIcon(UnaryOperator.identity());
+	}
+
+	/**
+	 * Return this icon.
+	 * <br>
+	 * The {@link UnaryOperator} is applied to the {@link BufferedImage}. The {@link ImageIcon}
+	 * is then created using that modified image.
+	 *
+	 * @param func the {@link UnaryOperator} to apply to the image
+	 * @return the modified {@link ImageIcon}
+	 */
+	public ImageIcon getIcon(@Nonnull UnaryOperator<BufferedImage> func)
+	{
+		BufferedImage img = func.apply(getImage());
+		return new ImageIcon(img);
+	}
+}

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -87,7 +87,6 @@ import net.runelite.client.plugins.bank.BankSearch;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
@@ -241,7 +240,7 @@ public class QuestHelperPlugin extends Plugin
 			overlayManager.add(questHelperDebugOverlay);
 		}
 
-		final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "/quest_icon.png");
+		final BufferedImage icon = IconUtil.QUEST_ICON.getImage();
 
 		panel = new QuestHelperPanel(this);
 		navButton = NavigationButton.builder()

--- a/src/main/java/com/questhelper/QuestHelperWorldMapPoint.java
+++ b/src/main/java/com/questhelper/QuestHelperWorldMapPoint.java
@@ -26,10 +26,6 @@
 package com.questhelper;
 
 import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.GraphicsConfiguration;
-import java.awt.geom.AffineTransform;
-import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import net.runelite.api.Point;
@@ -47,7 +43,7 @@ public class QuestHelperWorldMapPoint extends WorldMapPoint
 	{
 		super(worldPoint, null);
 
-		BufferedImage iconBackground = ImageUtil.getResourceStreamFromClass(getClass(), "/util/clue_arrow.png");
+		BufferedImage iconBackground = ImageUtil.loadImageResource(getClass(), "/util/clue_arrow.png");
 		questWorldImage = new BufferedImage(iconBackground.getWidth(), iconBackground.getHeight(), BufferedImage.TYPE_INT_ARGB);
 
 		Graphics graphics = questWorldImage.getGraphics();
@@ -59,14 +55,14 @@ public class QuestHelperWorldMapPoint extends WorldMapPoint
 
 		questWorldImagePoint = new Point(questWorldImage.getWidth() / 2, questWorldImage.getHeight());
 
-		arrows.put(0, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow.png"));
-		arrows.put(45, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_45.png"));
-		arrows.put(90, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_90.png"));
-		arrows.put(135, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_135.png"));
-		arrows.put(180, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_180.png"));
-		arrows.put(225, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_225.png"));
-		arrows.put(270, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_270.png"));
-		arrows.put(315, ImageUtil.getResourceStreamFromClass(getClass(), "/quest_step_arrow_315.png"));
+		arrows.put(0, IconUtil.QUEST_STEP_ARROW.getImage());
+		arrows.put(45, IconUtil.QUEST_STEP_ARROW_45.getImage());
+		arrows.put(90, IconUtil.QUEST_STEP_ARROW_90.getImage());
+		arrows.put(135, IconUtil.QUEST_STEP_ARROW_135.getImage());
+		arrows.put(180, IconUtil.QUEST_STEP_ARROW_180.getImage());
+		arrows.put(225, IconUtil.QUEST_STEP_ARROW_225.getImage());
+		arrows.put(270, IconUtil.QUEST_STEP_ARROW_270.getImage());
+		arrows.put(315, IconUtil.QUEST_STEP_ARROW_315.getImage());
 
 		activeQuestArrow = arrows.get(0);
 

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -25,13 +25,13 @@
 package com.questhelper.panel;
 
 import com.questhelper.BankItems;
+import com.questhelper.IconUtil;
 import com.questhelper.QuestHelperConfig;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.questhelpers.Quest;
 import com.questhelper.questhelpers.QuestHelper;
 import java.awt.*;
 import java.awt.event.ItemEvent;
-import java.awt.image.BufferedImage;
 import java.util.*;
 import java.util.List;
 import javax.swing.*;
@@ -45,11 +45,9 @@ import com.questhelper.QuestHelperPlugin;
 import com.questhelper.steps.QuestStep;
 import net.runelite.api.Client;
 import net.runelite.api.QuestState;
-import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.IconTextField;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
@@ -82,9 +80,7 @@ public class QuestHelperPanel extends PluginPanel
 
 	static
 	{
-		final BufferedImage discordImage = ImageUtil.getResourceStreamFromClass(QuestHelperPlugin.class, "/discord.png");
-		final BufferedImage scaledImage = ImageUtil.resizeImage(discordImage, 16, 16);
-		DISCORD_ICON = new ImageIcon(scaledImage);
+		DISCORD_ICON = IconUtil.DISCORD.getIcon(img -> ImageUtil.resizeImage(img, 16, 16));
 	}
 
 	public QuestHelperPanel(QuestHelperPlugin questHelperPlugin)

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -25,6 +25,7 @@
 package com.questhelper.panel;
 
 import com.questhelper.BankItems;
+import com.questhelper.IconUtil;
 import com.questhelper.QuestHelperPlugin;
 
 import com.questhelper.questhelpers.QuestHelper;
@@ -39,7 +40,6 @@ import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.BorderFactory;
@@ -54,7 +54,6 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.SwingUtil;
 
 public class QuestOverviewPanel extends JPanel
@@ -85,22 +84,14 @@ public class QuestOverviewPanel extends JPanel
 
 	private final JLabel questNameLabel = new JLabel();
 
-	private static final ImageIcon CLOSE_ICON;
-	private static final ImageIcon INFO_ICON;
+	private static final ImageIcon CLOSE_ICON = IconUtil.CLOSE.getIcon();
+	private static final ImageIcon INFO_ICON = IconUtil.INFO_ICON.getIcon();
 
 	private final JButton collapseBtn = new JButton();
 
 	private final List<QuestStepPanel> questStepPanelList = new ArrayList<>();
 
 	private final List<QuestRequirementPanel> requirementPanels = new ArrayList<>();
-
-	static
-	{
-		final BufferedImage closeImg = ImageUtil.getResourceStreamFromClass(QuestHelperPlugin.class, "/close.png");
-		final BufferedImage infoImg = ImageUtil.getResourceStreamFromClass(QuestHelperPlugin.class, "/info_icon.png");
-		CLOSE_ICON = new ImageIcon(closeImg);
-		INFO_ICON = new ImageIcon(infoImg);
-	}
 
 	public QuestOverviewPanel(QuestHelperPlugin questHelperPlugin)
 	{

--- a/src/main/java/com/questhelper/panel/QuestRequirementPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRequirementPanel.java
@@ -24,14 +24,13 @@
  */
 package com.questhelper.panel;
 
-import com.questhelper.QuestHelperPlugin;
+import com.questhelper.IconUtil;
 import com.questhelper.requirements.ItemRequirement;
 import com.questhelper.requirements.Requirement;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
-import java.awt.image.BufferedImage;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -39,11 +38,10 @@ import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.client.util.ImageUtil;
 
 public class QuestRequirementPanel extends JPanel
 {
-	private static final ImageIcon INFO_ICON;
+	private static final ImageIcon INFO_ICON = IconUtil.INFO_ICON.getIcon();
 
 	@Getter
 	@Setter
@@ -52,12 +50,6 @@ public class QuestRequirementPanel extends JPanel
 
 	@Getter
 	private final Requirement itemRequirement;
-
-	static
-	{
-		final BufferedImage infoImg = ImageUtil.getResourceStreamFromClass(QuestHelperPlugin.class, "/info_icon.png");
-		INFO_ICON = new ImageIcon(infoImg);
-	}
 
 	public QuestRequirementPanel(Requirement requirement)
 	{

--- a/src/main/java/com/questhelper/panel/QuestSelectPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestSelectPanel.java
@@ -24,12 +24,12 @@
  */
 package com.questhelper.panel;
 
+import com.questhelper.IconUtil;
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +40,6 @@ import javax.swing.JPanel;
 import lombok.Getter;
 import net.runelite.api.QuestState;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.util.ImageUtil;
 
 public class QuestSelectPanel extends JPanel
 {
@@ -50,14 +49,8 @@ public class QuestSelectPanel extends JPanel
 	@Getter
 	private final QuestHelper questHelper;
 
-	private static final ImageIcon START_ICON;
+	private static final ImageIcon START_ICON = IconUtil.START.getIcon();
 
-	static
-	{
-		final BufferedImage startImg = ImageUtil.getResourceStreamFromClass(QuestHelperPlugin.class, "/start.png");
-
-		START_ICON = new ImageIcon(startImg);
-	}
 	public QuestSelectPanel(QuestHelperPlugin questHelperPlugin, QuestHelperPanel questHelperPanel, QuestHelper questHelper, QuestState questState)
 	{
 		this.questHelper = questHelper;

--- a/src/main/java/com/questhelper/steps/overlay/IconOverlay.java
+++ b/src/main/java/com/questhelper/steps/overlay/IconOverlay.java
@@ -24,17 +24,15 @@
  */
 package com.questhelper.steps.overlay;
 
-import com.questhelper.QuestHelperPlugin;
+import com.questhelper.IconUtil;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
-import net.runelite.client.util.ImageUtil;
 
 public class IconOverlay
 {
 	public static BufferedImage createIconImage(BufferedImage newImage)
 	{
-		BufferedImage iconBackground = ImageUtil.getResourceStreamFromClass(QuestHelperPlugin.class,
-			"/icon_background.png");
+		BufferedImage iconBackground = IconUtil.ICON_BACKGROUND.getImage();
 		BufferedImage icon = new BufferedImage(iconBackground.getWidth(), iconBackground.getHeight(),
 			BufferedImage.TYPE_INT_ARGB);
 		Graphics tmpGraphics = icon.getGraphics();


### PR DESCRIPTION
Removes the need for ImageUtil in the QuestHelper codebase and is much easier to maintain.

Replaced all unnecessary `ImageUtil.loadResourceFromStream` calls with our own.