### PR TITLE
Fix Knight's Sword not highlighting cupboard and step requirement

### DIFF
--- a/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
+++ b/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
@@ -166,9 +166,9 @@ public class TheKnightsSword extends BasicQuestHelper
 		((ObjectStep)searchCupboard).addAlternateObjects(ObjectID.CUPBOARD_2271); // 2271 is the closed cupboard
 		givePortraitToThurgo = new NpcStep(this, NpcID.THURGO, new WorldPoint(3000, 3145, 0), "Bring Thurgo the portrait.", bluriteOre, ironBars, portrait);
 		givePortraitToThurgo.addDialogStep("About that sword...");
-		enterDungeon = new ObjectStep(this, ObjectID.TRAPDOOR_1738, new WorldPoint(3008, 3150, 0), "Go down the ladder south of Port Sarim. Be prepared for ice giants and ice warriors to attack you.", pickaxe, ironBars, portrait);
+		enterDungeon = new ObjectStep(this, ObjectID.TRAPDOOR_1738, new WorldPoint(3008, 3150, 0), "Go down the ladder south of Port Sarim. Be prepared for ice giants and ice warriors to attack you.", pickaxe, ironBars);
 		mineBlurite = new ObjectStep(this, ObjectID.ROCKS_11378, new WorldPoint(3049, 9566, 0), "Mine a blurite ore in the eastern cavern.", pickaxe);
-		bringThurgoOre = new NpcStep(this, NpcID.THURGO, new WorldPoint(3000, 3145, 0), "Return to Thurgo with a blurite ore, two iron bars and the portrait.", bluriteOre, ironBars, portrait);
+		bringThurgoOre = new NpcStep(this, NpcID.THURGO, new WorldPoint(3000, 3145, 0), "Return to Thurgo with a blurite ore and two iron bars.", bluriteOre, ironBars);
 		bringThurgoOre.addDialogStep("Can you make that replacement sword now?");
 		finishQuest = new NpcStep(this, NpcID.SQUIRE_4737, new WorldPoint(2978, 3341, 0), "Return to the Squire with the sword to finish the quest.", bluriteSword);
 	}

--- a/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
+++ b/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
@@ -27,13 +27,18 @@ package com.questhelper.quests.theknightssword;
 import com.questhelper.ItemCollections;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.Zone;
+import com.questhelper.requirements.NpcRequirement;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.Requirements;
 import com.questhelper.requirements.SkillRequirement;
+import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.conditional.ConditionForStep;
 import com.questhelper.steps.conditional.ItemRequirementCondition;
+import com.questhelper.steps.conditional.LogicType;
+import com.questhelper.steps.conditional.NpcCondition;
 import com.questhelper.steps.conditional.ZoneCondition;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,14 +66,15 @@ public class TheKnightsSword extends BasicQuestHelper
 
 	//Items Recommended
 	ItemRequirement varrockTeleport, faladorTeleports, homeTele;
+	Requirements searchCupboardReq;
 
-	ConditionForStep hasPortrait, hasBluriteOre, hasBluriteSword, inDungeon, inFaladorCastle1, inFaladorCastle2;
+	ConditionForStep hasPortrait, hasBluriteOre, hasBluriteSword, inDungeon, inFaladorCastle1, inFaladorCastle2, inFaladorCastle2Bedroom, sirVyinNotInRoom;
 
 	QuestStep talkToSquire, talkToReldo, talkToThurgo, talkToThurgoAgain, talkToSquire2, goUpCastle1, goUpCastle2, searchCupboard, enterDungeon,
 		mineBlurite, givePortraitToThurgo, bringThurgoOre, finishQuest;
 
 	//Zones
-	Zone dungeon, faladorCastle1, faladorCastle2;
+	Zone dungeon, faladorCastle1, faladorCastle2, faladorCastle2Bedroom;
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
@@ -124,6 +130,12 @@ public class TheKnightsSword extends BasicQuestHelper
 		inDungeon = new ZoneCondition(dungeon);
 		inFaladorCastle1 = new ZoneCondition(faladorCastle1);
 		inFaladorCastle2 = new ZoneCondition(faladorCastle2);
+		inFaladorCastle2Bedroom = new ZoneCondition(faladorCastle2Bedroom);
+		sirVyinNotInRoom = new NpcCondition(NpcID.SIR_VYVIN, faladorCastle2Bedroom);
+
+		NpcRequirement sirVyinNotInRoom = new NpcRequirement("Sir Vyin not in the bedroom.", NpcID.SIR_VYVIN, true, faladorCastle2Bedroom);
+		ZoneRequirement playerIsUpstairs = new ZoneRequirement("Upstairs", faladorCastle2);
+		searchCupboardReq = new Requirements(LogicType.AND, "Sir Vyin not in the bedroom.", playerIsUpstairs, sirVyinNotInRoom);
 	}
 
 	public void setupZones()
@@ -131,6 +143,7 @@ public class TheKnightsSword extends BasicQuestHelper
 		dungeon = new Zone(new WorldPoint(2979, 9538, 0), new WorldPoint(3069, 9602, 0));
 		faladorCastle1 = new Zone(new WorldPoint(2954, 3328, 1), new WorldPoint(2997, 3353, 1));
 		faladorCastle2 = new Zone(new WorldPoint(2980, 3331, 2), new WorldPoint(2986, 3346, 2));
+		faladorCastle2Bedroom = new Zone(new WorldPoint(2981, 3336, 2), new WorldPoint(2986, 3331, 2));
 	}
 
 	public void setupSteps()
@@ -149,7 +162,8 @@ public class TheKnightsSword extends BasicQuestHelper
 		talkToSquire2 = new NpcStep(this, NpcID.SQUIRE_4737, new WorldPoint(2978, 3341, 0), "Talk to the Squire in Falador Castle's courtyard.");
 		goUpCastle1 = new ObjectStep(this, ObjectID.LADDER_24070, new WorldPoint(2994, 3341, 0), "Climb up the east ladder in Falador Castle.");
 		goUpCastle2 = new ObjectStep(this, ObjectID.STAIRCASE_24077, new WorldPoint(2985, 3338, 1), "Go up the staircase west of the ladder on the 1st floor.");
-		searchCupboard = new ObjectStep(this, ObjectID.CUPBOARD_2272, new WorldPoint(2985, 3336, 2), "Search the cupboard in the room south of the staircase. You'll need Sir Vyvin to be in the other room.");
+		searchCupboard = new ObjectStep(this, ObjectID.CUPBOARD_2272, new WorldPoint(2985, 3336, 2), "Search the cupboard in the room south of the staircase. You'll need Sir Vyvin to be in the other room.", searchCupboardReq);
+		((ObjectStep)searchCupboard).addAlternateObjects(ObjectID.CUPBOARD_2271); // 2271 is the closed cupboard
 		givePortraitToThurgo = new NpcStep(this, NpcID.THURGO, new WorldPoint(3000, 3145, 0), "Bring Thurgo the portrait.", bluriteOre, ironBars, portrait);
 		givePortraitToThurgo.addDialogStep("About that sword...");
 		enterDungeon = new ObjectStep(this, ObjectID.TRAPDOOR_1738, new WorldPoint(3008, 3150, 0), "Go down the ladder south of Port Sarim. Be prepared for ice giants and ice warriors to attack you.", pickaxe, ironBars, portrait);

--- a/src/main/java/com/questhelper/requirements/NpcRequirement.java
+++ b/src/main/java/com/questhelper/requirements/NpcRequirement.java
@@ -1,0 +1,127 @@
+/*
+ *
+ *  * Copyright (c) 2021, Senmori
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  *
+ *  * 1. Redistributions of source code must retain the above copyright notice, this
+ *  *    list of conditions and the following disclaimer.
+ *  * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *  *    this list of conditions and the following disclaimer in the documentation
+ *  *    and/or other materials provided with the distribution.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package com.questhelper.requirements;
+
+import com.questhelper.Zone;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
+
+public class NpcRequirement extends Requirement
+{
+	private final int npcID;
+	private final Zone zone;
+	private final String displayText;
+	private boolean checkNotInZone = false;
+
+	/**
+	 * Check for the existence of an NPC within your canvas.
+	 *
+	 * @param displayText the display text
+	 * @param npcID the NPC to check for
+	 */
+	public NpcRequirement(String displayText, int npcID)
+	{
+		this(displayText, npcID, false, null);
+	}
+
+	/**
+	 * Check if a given NPC is in a specified {@link Zone}.
+	 *
+	 * @param displayText the display text
+	 * @param npcID the {@link NPC} to check for
+	 * @param worldPoint the location to check for the NPC
+	 */
+	public NpcRequirement(String displayText, int npcID, WorldPoint worldPoint)
+	{
+		this(displayText, npcID, false, new Zone(worldPoint));
+	}
+
+	/**
+	 * Check if a given NPC is in a specified {@link Zone}.
+	 *
+	 * @param displayText the display text
+	 * @param npcID the {@link NPC} to check for
+	 * @param zone the zone to check.
+	 */
+	public NpcRequirement(String displayText, int npcID, Zone zone)
+	{
+		this(displayText, npcID, false, zone);
+	}
+
+	/**
+	 * Check if a given NPC is in a specified {@link Zone}.
+	 * <br>
+	 * If {@param checkNotInZone} is true, this will check if the NPC is NOT in the zone.
+	 *
+	 * @param displayText the display text
+	 * @param npcID the {@link NPC} to check for
+	 * @param checkNotInZone determines whether to check if the NPC is in the zone or not
+	 * @param zone the zone to check.
+	 */
+	public NpcRequirement(String displayText, int npcID, boolean checkNotInZone, Zone zone)
+	{
+		this.displayText = displayText;
+		this.npcID = npcID;
+		this.zone = zone;
+		this.checkNotInZone = checkNotInZone;
+	}
+
+	@Override
+	public boolean check(Client client)
+	{
+		List<NPC> found = client.getNpcs().stream()
+			.filter(npc -> npc.getId() == npcID)
+			.collect(Collectors.toList());
+
+		if (!found.isEmpty())
+		{
+			if (zone != null)
+			{
+				for(NPC npc : found)
+				{
+					WorldPoint npcLocation = WorldPoint.fromLocalInstance(client,  npc.getLocalLocation(), 2);
+					if (npcLocation != null)
+					{
+						boolean inZone = zone.contains(npcLocation);
+						return inZone && !checkNotInZone || (!inZone && checkNotInZone);
+					}
+				}
+			}
+			return true; // the NPC exists, and we aren't checking for it's location
+		}
+		return false; // npc not in scene
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		return displayText;
+	}
+}

--- a/src/main/java/com/questhelper/requirements/ZoneRequirement.java
+++ b/src/main/java/com/questhelper/requirements/ZoneRequirement.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  * Copyright (c) 2021, Senmori
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  *
+ *  * 1. Redistributions of source code must retain the above copyright notice, this
+ *  *    list of conditions and the following disclaimer.
+ *  * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *  *    this list of conditions and the following disclaimer in the documentation
+ *  *    and/or other materials provided with the distribution.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package com.questhelper.requirements;
+
+import com.questhelper.Zone;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
+
+public class ZoneRequirement extends Requirement
+{
+	private final Zone zone;
+	private final boolean checkNotInZone;
+	private final String displayText;
+
+	/**
+	 * Check if the player is either in the specified zone.
+	 *
+	 * @param displayText display text
+	 * @param zone the zone to check
+	 */
+	public ZoneRequirement(String displayText, Zone zone)
+	{
+		this(displayText, false, zone);
+	}
+
+	/**
+	 * Check if the player is either in, or not in, the specified zone.
+	 *
+	 * @param displayText display text
+	 * @param checkNotInZone true to negate this requirement check (i.e. it will check if the player is NOT in the zone)
+	 * @param zone the zone to check
+	 */
+	public ZoneRequirement(String displayText, boolean checkNotInZone, Zone zone)
+	{
+		this.displayText = displayText;
+		this.checkNotInZone = checkNotInZone;
+		this.zone = zone;
+	}
+
+	@Override
+	public boolean check(Client client)
+	{
+		Player player = client.getLocalPlayer();
+		if (player != null && zone != null)
+		{
+			WorldPoint location = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
+			boolean isInZone = zone.contains(location);
+			return isInZone && !checkNotInZone || (!isInZone && checkNotInZone);
+		}
+		return false;
+	}
+
+	@Override
+	public String getDisplayText()
+	{
+		return displayText;
+	}
+}


### PR DESCRIPTION
1. When you search the cupboard for the portrait, the cupboard wasn't highlighting when it was closed (different object id).
    * Also added new requirements `ZoneRequirement` and `NpcRequirement` to see if Sir Vyin is not in the room when you search it.

2. Some step requirements were wrong with thurgo after you give him the portrait. Remove the unnecessary portrait requirement and adjusted the display text to match.