### PR TITLE
making-history: Fix missing requirement for relleka teleport.

### DIFF
--- a/src/main/java/com/questhelper/ItemCollections.java
+++ b/src/main/java/com/questhelper/ItemCollections.java
@@ -945,4 +945,14 @@ public class ItemCollections
 		ItemID.WATERING_CAN2,
 		ItemID.WATERING_CAN1
 	);
+
+	@Getter
+	private static final List<Integer> enchantedLyre = QuestUtil.toLinkedList(
+		ItemID.ENCHANTED_LYREI,
+		ItemID.ENCHANTED_LYRE5,
+		ItemID.ENCHANTED_LYRE4,
+		ItemID.ENCHANTED_LYRE3,
+		ItemID.ENCHANTED_LYRE2,
+		ItemID.ENCHANTED_LYRE1
+	);
 }

--- a/src/main/java/com/questhelper/quests/makinghistory/MakingHistory.java
+++ b/src/main/java/com/questhelper/quests/makinghistory/MakingHistory.java
@@ -26,8 +26,10 @@ package com.questhelper.quests.makinghistory;
 
 import com.questhelper.ItemCollections;
 import com.questhelper.QuestHelperQuest;
+import com.questhelper.requirements.ComplexRequirement;
 import com.questhelper.requirements.QuestRequirement;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.util.ComplexRequirementBuilder;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
 import com.questhelper.requirements.conditional.Conditions;
@@ -64,10 +66,11 @@ import com.questhelper.requirements.conditional.ConditionForStep;
 public class MakingHistory extends BasicQuestHelper
 {
 	//Items Required
-	ItemRequirement spade, saphAmulet, ghostSpeakAmulet, enchantedKey, chest, journal, scroll, letter, enchantedKeyHighlighted;
+	ItemRequirement spade, saphAmulet, ghostSpeakAmulet, enchantedKey, chest, journal, scroll, letter, enchantedKeyHighlighted, ectoTokens;
+	ComplexRequirement portPhasmatysEntry;
 
 	//Items Recommended
-	ItemRequirement ardougneTeleport, ectophial, ringOfDueling, passage;
+	ItemRequirement ardougneTeleport, ectophial, ringOfDueling, passage, rellekaTeleport, runRestoreItems;
 
 	ConditionForStep hasEnchantedKey, hasChest, hasJournal, hasScroll, talkedtoBlanin, talkedToDron, talkedToMelina, talkedToDroalak,
 		inCastle, gotKey, gotChest, gotScroll, handedInJournal, handedInScroll, finishedFrem, finishedKey, finishedGhost, handedInEverything;
@@ -127,10 +130,32 @@ public class MakingHistory extends BasicQuestHelper
 	{
 		spade = new ItemRequirement("Spade", ItemID.SPADE);
 		saphAmulet = new ItemRequirement("Sapphire amulet", ItemID.SAPPHIRE_AMULET);
-		ghostSpeakAmulet = new ItemRequirement("Ghostspeak amulet", ItemID.GHOSTSPEAK_AMULET, 1, true);
+		ghostSpeakAmulet = new ItemRequirement("Ghostspeak amulet", ItemCollections.getGhostspeak(), 1, true);
+		ghostSpeakAmulet.setTooltip("You can also wear the Morytania Legs 2 or higher.");
 		ardougneTeleport = new ItemRequirement("Teleports to Ardougne", ItemID.ARDOUGNE_TELEPORT, 3);
+
 		ectophial = new ItemRequirement("Ectophial, or method of getting to Port Phasmatys", ItemID.ECTOPHIAL);
-		ringOfDueling = new ItemRequirement("Ring of Dueling", ItemID.RING_OF_DUELING8);
+		ectophial.addAlternates(ItemID.FENKENSTRAINS_CASTLE_TELEPORT, ItemID.KHARYRLL_TELEPORT);
+		ectophial.addAlternates(ItemCollections.getSlayerRings()); // Slayer Tower
+		ectophial.addAlternates(ItemID.MORYTANIA_LEGS_2, ItemID.MORYTANIA_LEGS_3, ItemID.MORYTANIA_LEGS_4);
+		ectophial.setTooltip("You will need 2 ecto-tokens if you have not completed Ghosts Ahoy.");
+		ectophial.appendToTooltip("If you do not have 2 ecto-tokens bring 1 bone, 1 pot and 1 bucket to earn 5 ecto-tokens at the Ectofunctus.\n");
+		ectophial.appendToTooltip("You can use the Fairy Ring 'ALQ' or the Morytania Legs 2 or higher to get to Port Phasmatys.");
+		ectophial.appendToTooltip("Slayer rings and the Kharyrll teleport can also be used.");
+
+		ectoTokens = new ItemRequirement("Ecto-tokens", ItemID.ECTOTOKEN, 2);
+		ectoTokens.setTooltip("You do not need two ecto-tokens if you have completed Ghosts Ahoy.");
+		ectoTokens.appendToTooltip("If you do not have 2 ecto-tokens bring 1 bone, 1 pot and 1 bucket to earn 5 ecto-tokens at the Ectofunctus.");
+		ectoTokens.appendToTooltip("Additionally, you can also enter Port Phasmatys via Charter ship, but that costs up to 4,100 coins.");
+
+		portPhasmatysEntry = ComplexRequirementBuilder.or("2 x Ecto-tokens")
+			.with(ectoTokens)
+			.with(new QuestRequirement(QuestHelperQuest.GHOSTS_AHOY, QuestState.FINISHED))
+			.with(new ItemRequirement("Coins", ItemID.COINS_995, 4100))
+			.build();
+		portPhasmatysEntry.setTooltip(ectoTokens.getTooltip());
+
+		ringOfDueling = new ItemRequirement("Ring of Dueling", ItemCollections.getRingOfDuelings());
 		enchantedKey = new ItemRequirement("Enchanted key", ItemID.ENCHANTED_KEY);
 		enchantedKey.setTooltip("You can get another from the silver merchant in East Ardougne's market");
 
@@ -147,6 +172,13 @@ public class MakingHistory extends BasicQuestHelper
 		letter = new ItemRequirement("Letter", ItemID.LETTER_6757);
 		letter.setTooltip("You can get another from King Lathas in East Ardougne castle");
 		passage = new ItemRequirement("Necklace of passage", ItemCollections.getNecklaceOfPassages());
+		rellekaTeleport = new ItemRequirement("Relleka Teleport", ItemID.RELLEKKA_TELEPORT);
+		rellekaTeleport.addAlternates(ItemCollections.getEnchantedLyre());
+		rellekaTeleport.addAlternates(ItemID.FREMENNIK_SEA_BOOTS_2, ItemID.FREMENNIK_SEA_BOOTS_3, ItemID.FREMENNIK_SEA_BOOTS_4);
+		rellekaTeleport.setTooltip("You can also use Fairy Rings if you have those unlocked.");
+		rellekaTeleport.appendToTooltip("You can also teleport to Camelot and run North.");
+		runRestoreItems = new ItemRequirement("Potions/Items to restore run energy", ItemCollections.getRunRestoreItems());
+
 	}
 
 	public void loadZones()
@@ -205,7 +237,7 @@ public class MakingHistory extends BasicQuestHelper
 		talkToDron.addDialogStep("12, but what does that have to do with anything?");
 
 
-		talkToDroalak = new NpcStep(this, NpcID.DROALAK_3494, new WorldPoint(3659, 3468, 0), "Enter Port Phasmatys and talk to Droalak outside the general store.", ghostSpeakAmulet);
+		talkToDroalak = new NpcStep(this, NpcID.DROALAK_3494, new WorldPoint(3659, 3468, 0), "Enter Port Phasmatys and talk to Droalak outside the general store.", ghostSpeakAmulet, portPhasmatysEntry);
 		talkToMelina = new NpcStep(this, NpcID.MELINA_3492, new WorldPoint(3674, 3479, 0), "Give Melina a sapphire amulet in the house north east of the general store.", saphAmulet, ghostSpeakAmulet);
 		returnToDroalak = new NpcStep(this, NpcID.DROALAK_3494, new WorldPoint(3659, 3468, 0), "Return to Droalak outside the general store.");
 		returnToJorral = new NpcStep(this, NpcID.JORRAL, new WorldPoint(2436, 3346, 0), "Return to Jorral north of West Ardougne with the scroll and journal.", scroll, journal);
@@ -236,6 +268,8 @@ public class MakingHistory extends BasicQuestHelper
 		reqs.add(ectophial);
 		reqs.add(ringOfDueling);
 		reqs.add(passage);
+		reqs.add(rellekaTeleport);
+		reqs.add(runRestoreItems);
 		return reqs;
 	}
 
@@ -248,7 +282,7 @@ public class MakingHistory extends BasicQuestHelper
 		chestPanel.setLockingStep(keySteps);
 		PanelDetails fremPanel = new PanelDetails("Fremennik tale", Arrays.asList(talkToBlanin, talkToDron));
 		fremPanel.setLockingStep(dronSteps);
-		PanelDetails ghostPanel = new PanelDetails("Find the scroll", Arrays.asList(talkToDroalak, talkToMelina, returnToDroalak), saphAmulet, ghostSpeakAmulet);
+		PanelDetails ghostPanel = new PanelDetails("Find the scroll", Arrays.asList(talkToDroalak, talkToMelina, returnToDroalak), saphAmulet, ghostSpeakAmulet, portPhasmatysEntry);
 		ghostPanel.setLockingStep(ghostSteps);
 
 		PanelDetails finishingPanel = new PanelDetails("Finishing off", Arrays.asList(returnToJorral, talkToLathas, finishQuest));


### PR DESCRIPTION
Also adds a step requirement for when entering Port Phasmatys so players know to bring 2 ecto-tokens if they haven't completed Ghosts Ahoy.
Also adds tooltip to ghostspeak amulet requirement saying that they can also use Morytania Legs 2 or higher.
Add tooltips to clarify the other options for entering Port Phasmatys (charter ship, Ghosts Ahoy completed, or what to bring to earn some ecto-tokens at the Ectofunctus).