### PR TITLE
Add the ability for NpcStep to show safespots for fights.

### DIFF
--- a/src/main/java/com/questhelper/steps/NpcStep.java
+++ b/src/main/java/com/questhelper/steps/NpcStep.java
@@ -25,24 +25,27 @@
  */
 package com.questhelper.steps;
 
-import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.steps.overlay.DirectionArrow;
 import com.questhelper.steps.tools.QuestPerspective;
 import java.awt.Graphics2D;
+import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Line2D;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.NPC;
+import net.runelite.api.Perspective;
+import net.runelite.api.SpriteID;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.NpcChanged;
@@ -61,6 +64,7 @@ public class NpcStep extends DetailedQuestStep
 
 	private final int npcID;
 	private final ArrayList<Integer> alternateNpcIDs = new ArrayList<>();
+	private final List<WorldPoint> safespots = new ArrayList<>();
 
 	private boolean allowMultipleHighlights;
 
@@ -117,6 +121,11 @@ public class NpcStep extends DetailedQuestStep
 	public void addAlternateNpcs(Integer... alternateNpcIDs)
 	{
 		this.alternateNpcIDs.addAll(Arrays.asList(alternateNpcIDs));
+	}
+
+	public void addSafeSpots(WorldPoint... points)
+	{
+		this.safespots.addAll(Arrays.asList(points));
 	}
 
 	public List<Integer> allIds()
@@ -215,6 +224,19 @@ public class NpcStep extends DetailedQuestStep
 		if (!questHelper.getConfig().showSymbolOverlay())
 		{
 			return;
+		}
+
+		if (!safespots.isEmpty())
+		{
+			BufferedImage combatIcon = spriteManager.getSprite(SpriteID.TAB_COMBAT, 0);
+			for (WorldPoint location : safespots)
+			{
+				LocalPoint localPoint = LocalPoint.fromWorld(client, location);
+				if (localPoint != null)
+				{
+					OverlayUtil.renderTileOverlay(client, graphics, localPoint, combatIcon, questHelper.getConfig().targetOverlayColor());
+				}
+			}
 		}
 
 		for (NPC otherNpc : npcs)


### PR DESCRIPTION
https://i.imgur.com/9OFfAe5.png

This adds the ability for `NpcStep` to add and show safespots during fights.
Multiple safespots can be rendered with each one getting a non-quest image related icon so it's clear what the box is for.