### PR TITLE
Arrow Toggle

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -130,8 +130,8 @@ public interface QuestHelperConfig extends Config
 
 	@ConfigItem(
 			keyName = "showMiniMapArrow",
-			name = "Display arrows on the mini-map",
-			description = "Choose whether arrows point to the next objective"
+			name = "Display arrows on the mini-map and overworld",
+			description = "Choose whether flashing arrows point to the next objective"
 	)
 	default boolean showMiniMapArrow()
 	{

--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -128,6 +128,16 @@ public interface QuestHelperConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+			keyName = "showMiniMapArrow",
+			name = "Display arrows on the mini-map",
+			description = "Choose whether arrows point to the next objective"
+	)
+	default boolean showMiniMapArrow()
+	{
+		return true;
+	}
+	
 	@ConfigSection(
 		position = 1,
 		name = "Colors",

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -229,30 +229,28 @@ public class DetailedQuestStep extends QuestStep
 		tileHighlights.keySet().forEach(tile -> checkAllTilesForHighlighting(tile, tileHighlights.get(tile), graphics));
 	}
 
-	public void renderArrow(Graphics2D graphics)
-	{
-		if (worldPoint == null || hideWorldArrow)
-		{
-			return;
+	public void renderArrow(Graphics2D graphics) {
+		if (questHelper.getConfig().showMiniMapArrow()) {
+			if (worldPoint == null || hideWorldArrow) {
+				return;
+			}
+
+			LocalPoint lp = QuestPerspective.getInstanceLocalPoint(client, worldPoint);
+			if (lp == null) {
+				return;
+			}
+
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp, 30);
+			if (poly == null || poly.getBounds() == null) {
+				return;
+			}
+
+			int startX = poly.getBounds().x + (poly.getBounds().width / 2);
+			int startY = poly.getBounds().y + (poly.getBounds().height / 2);
+
+			DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(),
+					startX, startY);
 		}
-
-		LocalPoint lp = QuestPerspective.getInstanceLocalPoint(client, worldPoint);
-		if (lp == null)
-		{
-			return;
-		}
-
-		Polygon poly = Perspective.getCanvasTilePoly(client, lp, 30);
-		if (poly == null || poly.getBounds() == null)
-		{
-			return;
-		}
-
-		int startX = poly.getBounds().x + (poly.getBounds().width / 2);
-		int startY =  poly.getBounds().y + (poly.getBounds().height / 2);
-
-		DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(),
-			startX, startY);
 	}
 
 	@Override
@@ -268,24 +266,23 @@ public class DetailedQuestStep extends QuestStep
 		renderMapArrows(graphics);
 	}
 
-	public void renderMapArrows(Graphics2D graphics)
-	{
-		if (mapPoint == null)
-		{
-			return;
+	public void renderMapArrows(Graphics2D graphics) {
+		if (questHelper.getConfig().showMiniMapArrow()) {
+			if (mapPoint == null) {
+				return;
+			}
+
+			WorldPoint point = mapPoint.getWorldPoint();
+
+			if (currentRender < 24) {
+				renderMinimapArrow(graphics);
+			}
+
+			final Rectangle mapViewArea = QuestPerspective.getWorldMapClipArea(client);
+
+			Point drawPoint = QuestPerspective.mapWorldPointToGraphicsPoint(client, point);
+			DirectionArrow.renderWorldMapArrow(mapViewArea, drawPoint, mapPoint);
 		}
-
-		WorldPoint point = mapPoint.getWorldPoint();
-
-		if (currentRender < 24)
-		{
-			renderMinimapArrow(graphics);
-		}
-
-		final Rectangle mapViewArea = QuestPerspective.getWorldMapClipArea(client);
-
-		Point drawPoint = QuestPerspective.mapWorldPointToGraphicsPoint(client, point);
-		DirectionArrow.renderWorldMapArrow(mapViewArea, drawPoint, mapPoint);
 	}
 
 	public void renderMapLines(Graphics2D graphics)
@@ -305,7 +302,9 @@ public class DetailedQuestStep extends QuestStep
 
 	public void renderMinimapArrow(Graphics2D graphics)
 	{
-		DirectionArrow.renderMinimapArrow(graphics, client, worldPoint, getQuestHelper().getConfig().targetOverlayColor());
+		if (questHelper.getConfig().showMiniMapArrow()) {
+			DirectionArrow.renderMinimapArrow(graphics, client, worldPoint, getQuestHelper().getConfig().targetOverlayColor());
+		}
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/steps/NpcStep.java
+++ b/src/main/java/com/questhelper/steps/NpcStep.java
@@ -25,20 +25,11 @@
  */
 package com.questhelper.steps;
 
-import com.questhelper.requirements.AbstractRequirement;
+import com.questhelper.QuestHelperPlugin;
+import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.steps.overlay.DirectionArrow;
 import com.questhelper.steps.tools.QuestPerspective;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Shape;
-import java.awt.geom.Line2D;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import javax.inject.Inject;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -49,10 +40,17 @@ import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.eventbus.Subscribe;
-import com.questhelper.questhelpers.QuestHelper;
-import com.questhelper.QuestHelperPlugin;
-import static com.questhelper.QuestHelperWorldOverlay.IMAGE_Z_OFFSET;
 import net.runelite.client.ui.overlay.OverlayUtil;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.awt.geom.Line2D;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static com.questhelper.QuestHelperWorldOverlay.IMAGE_Z_OFFSET;
 
 public class NpcStep extends DetailedQuestStep
 {
@@ -235,6 +233,7 @@ public class NpcStep extends DetailedQuestStep
 	@Override
 	public void renderArrow(Graphics2D graphics)
 	{
+		if (questHelper.getConfig().showMiniMapArrow()) {
 		if (npcs.size() == 0)
 		{
 			super.renderArrow(graphics);
@@ -252,25 +251,25 @@ public class NpcStep extends DetailedQuestStep
 			}
 		}
 	}
+	}
 
 	@Override
-	public void renderMinimapArrow(Graphics2D graphics)
-	{
-		if (npcs.contains(client.getHintArrowNpc()))
-		{
-			return;
+	public void renderMinimapArrow(Graphics2D graphics) {
+		if (questHelper.getConfig().showMiniMapArrow()) {
+			if (npcs.contains(client.getHintArrowNpc())) {
+				return;
+			}
+
+			if (!npcs.isEmpty() && npcs.get(0).getMinimapLocation() != null) {
+				int x = npcs.get(0).getMinimapLocation().getX();
+				int y = npcs.get(0).getMinimapLocation().getY();
+				Line2D.Double line = new Line2D.Double(x, y - 18, x, y - 8);
+
+				DirectionArrow.drawMinimapArrow(graphics, line, getQuestHelper().getConfig().targetOverlayColor());
+				return;
+			}
+
+			super.renderMinimapArrow(graphics);
 		}
-
-		if (!npcs.isEmpty() && npcs.get(0).getMinimapLocation() != null)
-		{
-			int x = npcs.get(0).getMinimapLocation().getX();
-			int y = npcs.get(0).getMinimapLocation().getY();
-			Line2D.Double line = new Line2D.Double(x, y - 18, x, y - 8);
-
-			DirectionArrow.drawMinimapArrow(graphics, line, getQuestHelper().getConfig().targetOverlayColor());
-			return;
-		}
-
-		super.renderMinimapArrow(graphics);
 	}
 }

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -24,43 +24,25 @@
  */
 package com.questhelper.steps;
 
+import com.questhelper.QuestHelperPlugin;
+import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.steps.overlay.DirectionArrow;
 import com.questhelper.steps.tools.QuestPerspective;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.Shape;
+import net.runelite.api.Point;
+import net.runelite.api.*;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.*;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
-import net.runelite.api.ObjectComposition;
-import net.runelite.api.Point;
-import net.runelite.api.Tile;
-import net.runelite.api.TileObject;
-import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.DecorativeObjectChanged;
-import net.runelite.api.events.DecorativeObjectDespawned;
-import net.runelite.api.events.DecorativeObjectSpawned;
-import net.runelite.api.events.GameObjectChanged;
-import net.runelite.api.events.GameObjectDespawned;
-import net.runelite.api.events.GameObjectSpawned;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
-import net.runelite.api.events.GroundObjectChanged;
-import net.runelite.api.events.GroundObjectDespawned;
-import net.runelite.api.events.GroundObjectSpawned;
-import net.runelite.api.events.WallObjectChanged;
-import net.runelite.api.events.WallObjectDespawned;
-import net.runelite.api.events.WallObjectSpawned;
-import net.runelite.client.eventbus.Subscribe;
-import com.questhelper.QuestHelperPlugin;
-import com.questhelper.questhelpers.QuestHelper;
-import net.runelite.client.ui.overlay.OverlayUtil;
 
 public class ObjectStep extends DetailedQuestStep
 {
@@ -317,20 +299,19 @@ public class ObjectStep extends DetailedQuestStep
 
 
 	@Override
-	public void renderArrow(Graphics2D graphics)
-	{
-		if (object == null || hideWorldArrow)
-		{
-			return;
-		}
-		Shape clickbox = object.getClickbox();
-		if (clickbox != null)
-		{
-			Rectangle2D boundingBox = clickbox.getBounds2D();
-			int x = (int) boundingBox.getCenterX();
-			int y = (int) boundingBox.getMinY() - 20;
+	public void renderArrow(Graphics2D graphics) {
+		if (questHelper.getConfig().showMiniMapArrow()) {
+			if (object == null || hideWorldArrow) {
+				return;
+			}
+			Shape clickbox = object.getClickbox();
+			if (clickbox != null && questHelper.getConfig().showMiniMapArrow()) {
+				Rectangle2D boundingBox = clickbox.getBounds2D();
+				int x = (int) boundingBox.getCenterX();
+				int y = (int) boundingBox.getMinY() - 20;
 
-			DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(), x, y);
+				DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(), x, y);
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds toggle in the settings pane for the flashing arrow on the minimap and overworld (enabled by default). This change does not affect the boxes around objects, but that could be added if desired. 

This feature is one i personally wanted, as I like the quest plugin, but found the arrows made quests too easy (and thus of a feeling of accomplishment). 

Tested through Misthalin Mystery, Could enable/ disable arrows for NPCs, objects, and objectives, and arrows would automatically stop & resume being rendered.  