### PR TITLE
The Forsaken Tower: fix potion puzzle

### DIFF
--- a/src/main/java/com/questhelper/quests/theforsakentower/PotionPuzzle.java
+++ b/src/main/java/com/questhelper/quests/theforsakentower/PotionPuzzle.java
@@ -66,7 +66,7 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 	protected Client client;
 
 	// Potion 1
-	private static final Pattern LINE1 = Pattern.compile("^(.*) blend is directly");
+	private static final Pattern LINE1 = Pattern.compile("^(.*) is directly left of");
 	// Potion 2, potion 3
 	private static final Pattern LINE2 = Pattern.compile("^(.*) is next to (.*)[.]");
 	// Potion 5, potion 4


### PR DESCRIPTION
**Issue:** When "Cleansing fluid" appears in line 1 (aka yellow position on the wiki image below), the puzzle variation is not detected.

**Fix:** Update regex to reflect line text. 

I assume the original author had a puzzle that said "Toadflax blend is directly left of..." and accidentally included the word "blend" in the regex. I finished the rest of the quest after testing this change in game. Cheers for the awesome plugin!

Quick reference: https://oldschool.runescape.wiki/w/The_Forsaken_Tower/Quick_guide#/media/File:The_Forsaken_Tower_-_old_notes_explanation.png

More context: https://oldschool.runescape.wiki/w/The_Forsaken_Tower/Quick_guide#Potion