### PR TITLE
Add missing knife requirement

### DIFF
--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -547,7 +547,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 		{
 			prepareForCombatPanel = new PanelDetails("Preparing to fight", Arrays.asList(getYakArmour, makeShield), yakBottom, yakTop, roundShield);
 			prepareForRepairPanel = new PanelDetails("Helping Mawnis", Arrays.asList(talkToMawnis, talkToMawnisWithLogs, repairBridge1, talkToMawnisAfterRepair), rope8, splitLogs8);
-			items = Arrays.asList(tuna, ores, rope9, splitLogs8, roundShield, yakTop, yakBottom, meleeWeapon, food);
+			items = Arrays.asList(tuna, ores, rope9, knife, splitLogs8, roundShield, yakTop, yakBottom, meleeWeapon, food);
 		}
 	}
 


### PR DESCRIPTION
As per the wiki a knife is required: https://oldschool.runescape.wiki/w/The_Fremennik_Isles#Details:~:text=A%20knife,-8