### PR TITLE
Add the option to not show the overlay panel on screen.

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -137,6 +137,16 @@ public interface QuestHelperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showOverlayPanel",
+		name = "Display overlay on screen",
+		description = "Chose whether the overlay should be displayed on screen"
+	)
+	default boolean showOverlay()
+	{
+		return true;
+	}
 	
 	@ConfigSection(
 		position = 1,

--- a/src/main/java/com/questhelper/QuestHelperOverlay.java
+++ b/src/main/java/com/questhelper/QuestHelperOverlay.java
@@ -53,6 +53,10 @@ public class QuestHelperOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!plugin.getConfig().showOverlay())
+		{
+			return super.render(graphics);
+		}
 		QuestHelper questHelper = plugin.getSelectedQuest();
 
 		if (questHelper == null || questHelper.getCurrentStep() == null)


### PR DESCRIPTION
As per a request on Discord, this allows people to not show the overlay on screen. This does not include arrows/tile highlights/etc. This only prevents the actual overlay panel from being displayed.