### PR TITLE
Add quest rewards to side-panel

### DIFF
--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -69,6 +69,7 @@ public class QuestOverviewPanel extends JPanel
 	private final JPanel questItemRecommendedListPanel = new JPanel();
 	private final JPanel questCombatRequirementsListPanel = new JPanel();
 	private final JPanel questOverviewNotesPanel = new JPanel();
+	private final JPanel questRewardPanel = new JPanel();
 	private final JPanel externalQuestResourcesPanel = new JPanel();
 
 	private final JPanel questGeneralRequirementsHeader = new JPanel();
@@ -76,6 +77,7 @@ public class QuestOverviewPanel extends JPanel
 	private final JPanel questItemRequirementsHeader = new JPanel();
 	private final JPanel questCombatRequirementHeader = new JPanel();
 	private final JPanel questItemRecommendedHeader = new JPanel();
+	private final JPanel questRewardHeader = new JPanel();
 	private final JPanel questNoteHeader = new JPanel();
 	private final JPanel externalQuestResourcesHeader = new JPanel();
 
@@ -152,6 +154,7 @@ public class QuestOverviewPanel extends JPanel
 			"Recommended items:"));
 		overviewPanel.add(generateRequirementPanel(questCombatRequirementsListPanel, questCombatRequirementHeader,
 			"Enemies to defeat:"));
+		overviewPanel.add(generateRequirementPanel(questRewardPanel, questRewardHeader, "Rewards:"));
 		overviewPanel.add(generateRequirementPanel(questOverviewNotesPanel, questNoteHeader, "Notes:"));
 		overviewPanel.add(generateRequirementPanel(externalQuestResourcesPanel, externalQuestResourcesHeader , "External Resources:"));
 
@@ -311,6 +314,7 @@ public class QuestOverviewPanel extends JPanel
 		questItemRequirementsListPanel.removeAll();
 		questItemRecommendedListPanel.removeAll();
 		questCombatRequirementsListPanel.removeAll();
+		questRewardPanel.removeAll();
 		currentQuest = null;
 		questOverviewNotesPanel.removeAll();
 		repaint();
@@ -350,6 +354,9 @@ public class QuestOverviewPanel extends JPanel
 
 		/* Combat requirements */
 		updateCombatRequirementsPanels(quest.getCombatRequirements());
+
+		/* Quest Rewards */
+		updateQuestRewardPanels(quest.getQuestRewards());
 
 		/* External Resources */
 		updateExternalResourcesPanel(quest);
@@ -491,6 +498,28 @@ public class QuestOverviewPanel extends JPanel
 			questNoteHeader.setVisible(false);
 			questOverviewNotesPanel.setVisible(false);
 		}
+	}
+
+	private void updateQuestRewardPanels(List<String> rewards)
+	{
+		JLabel rewardLabel = new JLabel();
+		rewardLabel.setForeground(Color.GRAY);
+		StringBuilder textReward = new StringBuilder();
+		if (rewards == null)
+		{
+			textReward.append("This should not be blank and should show quest rewards. If you are seeing this message, please report it on Discord! :)");
+		}
+		else
+		{
+			for (String reward : rewards)
+			{
+				textReward.append(reward);
+				textReward.append("<br>");
+			}
+		}
+		rewardLabel.setText("<html><body style = 'text-align:left'>" + textReward + "</body></html>");
+
+		questRewardPanel.add(rewardLabel);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -36,10 +36,15 @@ import com.questhelper.QuestHelperQuest;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import java.awt.Graphics;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
@@ -217,9 +222,47 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		return null;
 	}
 
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
 		return null;
+	}
+
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return null;
+	}
+
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return null;
+	}
+
+	public List<String> getQuestRewards()
+	{
+		List<String> rewards = new ArrayList<>();
+
+		QuestPointReward questPointReward = getQuestPointReward();
+		if (questPointReward != null)
+		{
+			rewards.add(questPointReward.getDisplayText());
+			rewards.add("</br>");
+		}
+
+		List<ExperienceReward> experienceReward = getExperienceRewards();
+		if (experienceReward != null)
+		{
+			experienceReward.forEach((expReward -> rewards.add(expReward.getDisplayText())));
+			rewards.add("</br>");
+		}
+
+		List<UnlockReward> unlockRewards = getUnlockRewards();
+		if (unlockRewards != null)
+		{
+			unlockRewards.forEach((unlockReward -> rewards.add(unlockReward.getDisplayText())));
+			rewards.add("</br>");
+		}
+
+		return rewards;
 	}
 
 	public List<ExternalQuestResources> getExternalResources(){ return null; }

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -217,6 +217,11 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		return null;
 	}
 
+	public List<String> getQuestRewards()
+	{
+		return null;
+	}
+
 	public List<ExternalQuestResources> getExternalResources(){ return null; }
 
 	public abstract List<PanelDetails> getPanels();

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -37,6 +37,7 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
 import java.awt.Graphics;
@@ -44,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
@@ -232,6 +232,11 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		return null;
 	}
 
+	public List<ItemReward> getItemRewards()
+	{
+		return null;
+	}
+
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return null;
@@ -252,6 +257,13 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		if (experienceReward != null)
 		{
 			experienceReward.forEach((expReward -> rewards.add(expReward.getDisplayText())));
+			rewards.add("</br>");
+		}
+
+		List<ItemReward> itemRewards = getItemRewards();
+		if (itemRewards != null)
+		{
+			itemRewards.forEach((itemReward -> rewards.add(itemReward.getDisplayText())));
 			rewards.add("</br>");
 		}
 

--- a/src/main/java/com/questhelper/quests/alfredgrimhandsbarcrawl/AlfredGrimhandsBarcrawl.java
+++ b/src/main/java/com/questhelper/quests/alfredgrimhandsbarcrawl/AlfredGrimhandsBarcrawl.java
@@ -208,6 +208,12 @@ public class AlfredGrimhandsBarcrawl extends ComplexStateQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("Access to Barbarian Outpost Agility Course", "</br>", "Speak to the Barbarian Guard to learn how to smash empty vials automatically.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/alfredgrimhandsbarcrawl/AlfredGrimhandsBarcrawl.java
+++ b/src/main/java/com/questhelper/quests/alfredgrimhandsbarcrawl/AlfredGrimhandsBarcrawl.java
@@ -36,6 +36,7 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -208,9 +209,11 @@ public class AlfredGrimhandsBarcrawl extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<UnlockReward> getUnlockRewards()
 	{
-		return Arrays.asList("Access to Barbarian Outpost Agility Course", "</br>", "Speak to the Barbarian Guard to learn how to smash empty vials automatically.");
+		return Arrays.asList(
+				new UnlockReward("Access to Barbarian Outpost Agility Course"),
+				new UnlockReward("Speak to the Barbarian Guard to learn how to smash empty vials automatically."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/animalmagnetism/AnimalMagnetism.java
+++ b/src/main/java/com/questhelper/quests/animalmagnetism/AnimalMagnetism.java
@@ -37,6 +37,10 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -293,9 +297,31 @@ public class AnimalMagnetism extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,000 Crafting Experience", "1,000 Fletching Experience", "1,000 Slayer Experience", "2,500 Woodcutting Experience", "</br>", "Ava's Device");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 1000),
+				new ExperienceReward(Skill.FLETCHING, 1000),
+				new ExperienceReward(Skill.SLAYER, 1000),
+				new ExperienceReward(Skill.WOODCUTTING, 2500));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Ava's Attractor", ItemID.AVAS_ATTRACTOR, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to purchase Ava's Devices"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/animalmagnetism/AnimalMagnetism.java
+++ b/src/main/java/com/questhelper/quests/animalmagnetism/AnimalMagnetism.java
@@ -293,6 +293,12 @@ public class AnimalMagnetism extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,000 Crafting Experience", "1,000 Fletching Experience", "1,000 Slayer Experience", "2,500 Woodcutting Experience", "</br>", "Ava's Device");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/anothersliceofham/AnotherSliceOfHam.java
+++ b/src/main/java/com/questhelper/quests/anothersliceofham/AnotherSliceOfHam.java
@@ -44,6 +44,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -436,9 +440,31 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward	getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "3,000 Mining Experience", "3,000 Prayer Experience", "</br>", "An Ancient Mace.", "Dorgeshuun Train Access.", "Ability to buy Goblin Village Teleport Spheres.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.MINING, 3000),
+				new ExperienceReward(Skill.PRAYER, 3000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("An Ancient Mace", ItemID.ANCIENT_MACE, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Dorgeshuun Train Access."),
+				new UnlockReward("Ability to buy Goblin Village Teleport Spheres"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/anothersliceofham/AnotherSliceOfHam.java
+++ b/src/main/java/com/questhelper/quests/anothersliceofham/AnotherSliceOfHam.java
@@ -436,6 +436,12 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "3,000 Mining Experience", "3,000 Prayer Experience", "</br>", "An Ancient Mace.", "Dorgeshuun Train Access.", "Ability to buy Goblin Village Teleport Spheres.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/quests/aporcineofinterest/APorcineOfInterest.java
@@ -34,6 +34,10 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -45,10 +49,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -180,9 +182,27 @@ public class APorcineOfInterest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "5,000 Coins", "1,000 Slayer Experience", "30 Slayer Points", "</br>", "Access to Sourhog Cave", "Sourhog can be assigned as a slayer task by Spria or Tureal");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.SLAYER, 1000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("5,000 Coins", ItemID.COINS_995, 5000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(new UnlockReward("30 Slayer Points"), new UnlockReward("Access to Sourhog Cave"), new UnlockReward("Sourhog can be assigned as a slayer task by Spria or Tureal"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/quests/aporcineofinterest/APorcineOfInterest.java
@@ -180,6 +180,12 @@ public class APorcineOfInterest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Coins", "1,000 Slayer Experience", "30 Slayer Points", "</br>", "Access to Sourhog Cave", "Sourhog can be assigned as a slayer task by Spria or Tureal");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/architecturalalliance/ArchitecturalAlliance.java
+++ b/src/main/java/com/questhelper/quests/architecturalalliance/ArchitecturalAlliance.java
@@ -134,4 +134,10 @@ public class ArchitecturalAlliance extends BasicQuestHelper
 			new QuestRequirement(QuestHelperQuest.PLAGUE_CITY, QuestState.IN_PROGRESS)));
 		return req;
 	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("10,000 Experience Lamp (Any skill over level 40).", "Xeric's Heart Teleport on Xeric's Talisman.");
+	}
 }

--- a/src/main/java/com/questhelper/quests/architecturalalliance/ArchitecturalAlliance.java
+++ b/src/main/java/com/questhelper/quests/architecturalalliance/ArchitecturalAlliance.java
@@ -35,15 +35,16 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
+import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
@@ -136,8 +137,15 @@ public class ArchitecturalAlliance extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ItemReward> getItemRewards()
 	{
-		return Arrays.asList("10,000 Experience Lamp (Any skill over level 40).", "Xeric's Heart Teleport on Xeric's Talisman.");
+		return Collections.singletonList(new ItemReward("10,000 Experience Lamp (Any skill over level 40).", ItemID.ANTIQUE_LAMP_21262, 1)); //21262 May not be the correct ID, I can't find a proper way to confirm until I can get it ingame again.
 	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Xeric's Heart Teleport on Xeric's Talisman."));
+	}
+
 }

--- a/src/main/java/com/questhelper/quests/asoulsbane/ASoulsBane.java
+++ b/src/main/java/com/questhelper/quests/asoulsbane/ASoulsBane.java
@@ -287,6 +287,12 @@ public class ASoulsBane extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "500 Defence Experience", "500 Hitpoints Experience", "500 Coins", "</br>", "Access to the Dungeon of Tolna");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/asoulsbane/ASoulsBane.java
+++ b/src/main/java/com/questhelper/quests/asoulsbane/ASoulsBane.java
@@ -38,20 +38,19 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import java.util.*;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -287,9 +286,29 @@ public class ASoulsBane extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "500 Defence Experience", "500 Hitpoints Experience", "500 Coins", "</br>", "Access to the Dungeon of Tolna");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.DEFENCE, 500),
+				new ExperienceReward(Skill.HITPOINTS, 500));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("500 Coins", ItemID.COINS_995, 500));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Dungeon of Tolna"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/atailoftwocats/ATailOfTwoCats.java
+++ b/src/main/java/com/questhelper/quests/atailoftwocats/ATailOfTwoCats.java
@@ -230,6 +230,12 @@ public class ATailOfTwoCats extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2x 2,500 Experience Lamps (Any skill over level 30)", "</br>", "A Doctors or Nurses Hat", "A Mouse toy");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/atailoftwocats/ATailOfTwoCats.java
+++ b/src/main/java/com/questhelper/quests/atailoftwocats/ATailOfTwoCats.java
@@ -38,6 +38,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -49,10 +51,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -230,9 +230,19 @@ public class ATailOfTwoCats extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "2x 2,500 Experience Lamps (Any skill over level 30)", "</br>", "A Doctors or Nurses Hat", "A Mouse toy");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("2 x 2,500 Experience Lamps (Any skill over level 30).", ItemID.ANTIQUE_LAMP, 2),
+				new ItemReward("A Doctors hat", ItemID.DOCTORS_HAT, 1),
+				new ItemReward("A Nurse hat", ItemID.NURSE_HAT, 1),
+				new ItemReward("A Mouse Toy", ItemID.MOUSE_TOY, 1)); //4447 Is Placeholder.
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/atasteofhope/ATasteOfHope.java
+++ b/src/main/java/com/questhelper/quests/atasteofhope/ATasteOfHope.java
@@ -600,4 +600,10 @@ public class ATasteOfHope extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.SLAYER, 38));
 		return req;
 	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "Ivandis Flail", "Drakan's Medallion", "</br>", "3x 2,500 Experience Tomes (Any skill over 35).");
+	}
 }

--- a/src/main/java/com/questhelper/quests/atasteofhope/ATasteOfHope.java
+++ b/src/main/java/com/questhelper/quests/atasteofhope/ATasteOfHope.java
@@ -33,6 +33,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ObjectStep;
@@ -599,6 +601,22 @@ public class ATasteOfHope extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.HERBLORE, 40));
 		req.add(new SkillRequirement(Skill.SLAYER, 38));
 		return req;
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("Ivandis Flail", ItemID.IVANDIS_FLAIL, 1),
+				new ItemReward("Drakan's Medallion", ItemID.DRAKANS_MEDALLION, 1),
+				new ItemReward("3 x 2,500 Experience Tomes (Any skill over level 35).", ItemID.TOME_OF_EXPERIENCE, 3) //22415 is placeholder
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/bearyoursoul/BearYourSoul.java
+++ b/src/main/java/com/questhelper/quests/bearyoursoul/BearYourSoul.java
@@ -136,6 +136,12 @@ public class BearYourSoul extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("A Soul Bearer");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/bearyoursoul/BearYourSoul.java
+++ b/src/main/java/com/questhelper/quests/bearyoursoul/BearYourSoul.java
@@ -33,6 +33,7 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ItemReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
@@ -136,9 +137,9 @@ public class BearYourSoul extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ItemReward> getItemRewards()
 	{
-		return Arrays.asList("A Soul Bearer");
+		return Collections.singletonList(new ItemReward("A Soul Bearer", ItemID.SOUL_BEARER, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/betweenarock/BetweenARock.java
+++ b/src/main/java/com/questhelper/quests/betweenarock/BetweenARock.java
@@ -41,6 +41,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -52,11 +56,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -427,9 +428,34 @@ public class BetweenARock extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "5,000 Defence Experience", "5,000 Mining Experience", "5,000 Smithing Experience", "</br>", "Rune Pickaxe", "Ability to teleport to Dondakan's rock using a ring of wealth.", "Access to the Arzinian Mine");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.DEFENCE, 5000),
+				new ExperienceReward(Skill.MINING, 5000),
+				new ExperienceReward(Skill.SMITHING, 5000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Rune Pickaxe.", ItemID.RUNE_PICKAXE, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to Teleport to Dondakan's Rock using a Ring of Wealth."),
+				new UnlockReward("Access to Arzinian Mine.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/betweenarock/BetweenARock.java
+++ b/src/main/java/com/questhelper/quests/betweenarock/BetweenARock.java
@@ -427,6 +427,12 @@ public class BetweenARock extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "5,000 Defence Experience", "5,000 Mining Experience", "5,000 Smithing Experience", "</br>", "Rune Pickaxe", "Ability to teleport to Dondakan's rock using a ring of wealth.", "Access to the Arzinian Mine");
+	}
+
+	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
+++ b/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
@@ -326,6 +326,12 @@ public class BigChompyBirdHunting extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "262 Fletching Experience", "1,470 Cooking Experience", "735 Ranged Experience", "</br>", "An Ogre Bow", "The ability to fletch ogre arrows.", "The ability cook Chompy Birds and earn a Bowman Hat.");
+	}
+
+	@Override
 	public List<String> getCombatRequirements()
 	{
 		return Collections.singletonList("Chompy");

--- a/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
+++ b/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
@@ -40,6 +40,10 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -326,9 +330,34 @@ public class BigChompyBirdHunting extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "262 Fletching Experience", "1,470 Cooking Experience", "735 Ranged Experience", "</br>", "An Ogre Bow", "The ability to fletch ogre arrows.", "The ability cook Chompy Birds and earn a Bowman Hat.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.FLETCHING, 262),
+				new ExperienceReward(Skill.COOKING, 1470),
+				new ExperienceReward(Skill.RANGED, 735)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("An Ogre Bow", ItemID.OGRE_BOW, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("The ability to fletch Ogre Arrows."),
+				new UnlockReward("The ability to hunt and cook Chompy Birds.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/biohazard/Biohazard.java
+++ b/src/main/java/com/questhelper/quests/biohazard/Biohazard.java
@@ -359,4 +359,10 @@ public class Biohazard extends BasicQuestHelper
 		requirements.add(new QuestRequirement(QuestHelperQuest.PLAGUE_CITY, QuestState.FINISHED));
 		return requirements;
 	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "1,250 Thieving XP");
+	}
 }

--- a/src/main/java/com/questhelper/quests/blackknightfortress/BlackKnightFortress.java
+++ b/src/main/java/com/questhelper/quests/blackknightfortress/BlackKnightFortress.java
@@ -294,6 +294,12 @@ public class BlackKnightFortress extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "2,500 Coins");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/blackknightfortress/BlackKnightFortress.java
+++ b/src/main/java/com/questhelper/quests/blackknightfortress/BlackKnightFortress.java
@@ -13,6 +13,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -294,9 +296,15 @@ public class BlackKnightFortress extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "2,500 Coins");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("2,500 Coins", ItemID.COINS_995, 2500));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/bonevoyage/BoneVoyage.java
+++ b/src/main/java/com/questhelper/quests/bonevoyage/BoneVoyage.java
@@ -34,6 +34,8 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.ObjectStep;
 import java.util.ArrayList;
@@ -274,9 +276,15 @@ public class BoneVoyage extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "Access to Fossil Island");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Fossil Island"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/bonevoyage/BoneVoyage.java
+++ b/src/main/java/com/questhelper/quests/bonevoyage/BoneVoyage.java
@@ -274,6 +274,12 @@ public class BoneVoyage extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "Access to Fossil Island");
+	}
+
+	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
 		final int KUDOS_VARBIT = 3637;

--- a/src/main/java/com/questhelper/quests/cabinfever/CabinFever.java
+++ b/src/main/java/com/questhelper/quests/cabinfever/CabinFever.java
@@ -40,6 +40,10 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -51,13 +55,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.InventoryID;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -657,9 +656,39 @@ public class CabinFever extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "7,000 Smithing Experience", "7,000 Crafting Experience", "7,000 Agility Experience", "</br>", "The Little Book o' Piracy");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.SMITHING, 7000),
+				new ExperienceReward(Skill.CRAFTING, 7000),
+				new ExperienceReward(Skill.AGILITY, 7000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("10,000 Coins", ItemID.COINS_995, 10000),
+				new ItemReward("The Book o' Piracy", ItemID.BOOK_O_PIRACY, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Mos Le'Harmless"),
+				new UnlockReward("Access to Cave Horrors and the ability to receive them as a Slayer Task."),
+				new UnlockReward("Charter Ship prices are now halved."),
+				new UnlockReward("Ability to play the Trouble Brewing minigame.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/cabinfever/CabinFever.java
+++ b/src/main/java/com/questhelper/quests/cabinfever/CabinFever.java
@@ -657,6 +657,12 @@ public class CabinFever extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "7,000 Smithing Experience", "7,000 Crafting Experience", "7,000 Agility Experience", "</br>", "The Little Book o' Piracy");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/clientofkourend/ClientOfKourend.java
+++ b/src/main/java/com/questhelper/quests/clientofkourend/ClientOfKourend.java
@@ -28,6 +28,8 @@ import com.questhelper.QuestHelperQuest;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -165,9 +167,19 @@ public class ClientOfKourend extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2x 500 Experience Lamps (Any Skill)", "</br>", "20% Kourend Favour Certificate", "Kharedst's Memoirs");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("2 x 500 Experience Lamps (Any Skill)", ItemID.ANTIQUE_LAMP, 2), //4447 Placeholder until confirmed.
+				new ItemReward("20% Kourend Favour Certificate", ItemID.KOUREND_FAVOUR_CERTIFICATE, 1),
+				new ItemReward("Kharedst's Memoirs", ItemID.KHAREDSTS_MEMOIRS, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/clientofkourend/ClientOfKourend.java
+++ b/src/main/java/com/questhelper/quests/clientofkourend/ClientOfKourend.java
@@ -165,6 +165,12 @@ public class ClientOfKourend extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2x 500 Experience Lamps (Any Skill)", "</br>", "20% Kourend Favour Certificate", "Kharedst's Memoirs");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
@@ -39,6 +39,8 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ObjectStep;
@@ -346,9 +348,15 @@ public class ClockTower extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "500 Coins");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("500 Coins", ItemID.COINS_995, 500));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
@@ -346,6 +346,12 @@ public class ClockTower extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "500 Coins");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
@@ -15,6 +15,9 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -450,9 +453,29 @@ public class ColdWar extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2,000 Crafting Experience", "5,000 Agility Experience", "1,500 Construction Experience", "</br>", "The ability to create Penguin Suits.", "The ability to use the Penguin Agility Course.", "Ability to make more Bongo Drums.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 2000),
+				new ExperienceReward(Skill.AGILITY, 5000),
+				new ExperienceReward(Skill.CONSTRUCTION, 1500)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to create Penguin Suits"),
+				new UnlockReward("Ability to use the Penguin Agility Course"),
+				new UnlockReward("Abillity to make Bongo Drums")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
@@ -450,6 +450,12 @@ public class ColdWar extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,000 Crafting Experience", "5,000 Agility Experience", "1,500 Construction Experience", "</br>", "The ability to create Penguin Suits.", "The ability to use the Penguin Agility Course.", "Ability to make more Bongo Drums.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/contact/Contact.java
+++ b/src/main/java/com/questhelper/quests/contact/Contact.java
@@ -32,6 +32,10 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -40,20 +44,15 @@ import com.questhelper.steps.ObjectStep;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -271,9 +270,30 @@ public class Contact extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "7,000 Thieving Experience", "2x 7,000 Experience Lamps (Combat Skills)", "</br>", "Keris", "Access to Sophanem's Bank.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.THIEVING, 7000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("2 x 7,000 Experience Lamps (Combat Skills)", ItemID.ANTIQUE_LAMP, 2),
+				new ItemReward("Keris", ItemID.KERIS, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Sophanem's Bank"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/contact/Contact.java
+++ b/src/main/java/com/questhelper/quests/contact/Contact.java
@@ -271,6 +271,12 @@ public class Contact extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "7,000 Thieving Experience", "2x 7,000 Experience Lamps (Combat Skills)", "</br>", "Keris", "Access to Sophanem's Bank.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/quests/cooksassistant/CooksAssistant.java
@@ -26,10 +26,14 @@ package com.questhelper.quests.cooksassistant;
 
 import com.questhelper.QuestHelperQuest;
 
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import java.util.*;
 
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
@@ -85,9 +89,21 @@ public class CooksAssistant extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "300 Cooking Experience", "</br>", "Permission to use The Cook's range.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.COOKING, 300));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Permission to use The Cook's range."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/quests/cooksassistant/CooksAssistant.java
@@ -25,11 +25,9 @@
 package com.questhelper.quests.cooksassistant;
 
 import com.questhelper.QuestHelperQuest;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
@@ -84,6 +82,12 @@ public class CooksAssistant extends BasicQuestHelper
 		reqs.add(flour);
 		reqs.add(milk);
 		return reqs;
+	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "300 Cooking Experience", "</br>", "Permission to use The Cook's range.");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -399,6 +399,12 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "1,000 Thieving Experience", "</br>", "Ring of Charos", "Access to Werewolf Agility Course.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -31,6 +31,7 @@ import com.questhelper.Zone;
 import com.questhelper.banktab.BankSlotIcons;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
+import com.questhelper.questhelpers.Quest;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
@@ -41,6 +42,10 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
@@ -399,9 +404,27 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "1,000 Thieving Experience", "</br>", "Ring of Charos", "Access to Werewolf Agility Course.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.THIEVING, 1000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Ring of Charos", ItemID.RING_OF_CHAROS, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Werewolf Agility Course"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
+++ b/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
@@ -35,16 +35,16 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -266,6 +266,19 @@ public class CurseOfTheEmptyLord extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("A Set of Ghostly Robes", "</br>", "10,000 Experience Lamp (Any skill over level 50).", "Experience Lamp can be claimed from Historian Minas in Varrock Museum.");
+	}
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("10,000 Experience Lamp (Any skill over level 50).", ItemID.ANTIQUE_LAMP, 1)); //4447 is used as placeholder
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("A Set of Ghostly Robes")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
+++ b/src/main/java/com/questhelper/quests/curseoftheemptylord/CurseOfTheEmptyLord.java
@@ -263,6 +263,12 @@ public class CurseOfTheEmptyLord extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("A Set of Ghostly Robes", "</br>", "10,000 Experience Lamp (Any skill over level 50).", "Experience Lamp can be claimed from Historian Minas in Varrock Museum.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/daddyshome/DaddysHome.java
+++ b/src/main/java/com/questhelper/quests/daddyshome/DaddysHome.java
@@ -218,6 +218,12 @@ public class DaddysHome extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("400 Construction Experience", "</br>", "POH in Rimmington <b>or</b> 1,000 coins if you already own one.", "</br>", "25 x Planks", "50 x Mithril Nails", "5 x Steel Bars", "10 x Oak Planks", "8 x Bolts of Cloth", "5 x House Teleports", "1 x Falador Teleport");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/daddyshome/DaddysHome.java
+++ b/src/main/java/com/questhelper/quests/daddyshome/DaddysHome.java
@@ -34,20 +34,17 @@ import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import java.util.*;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -218,9 +215,24 @@ public class DaddysHome extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ExperienceReward> getExperienceRewards()
 	{
-		return Arrays.asList("400 Construction Experience", "</br>", "POH in Rimmington <b>or</b> 1,000 coins if you already own one.", "</br>", "25 x Planks", "50 x Mithril Nails", "5 x Steel Bars", "10 x Oak Planks", "8 x Bolts of Cloth", "5 x House Teleports", "1 x Falador Teleport");
+		return Collections.singletonList(new ExperienceReward(Skill.CONSTRUCTION, 400));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("25 x Planks", ItemID.PLANK, 25),
+				new ItemReward("10 x Oak Planks", ItemID.OAK_PLANK, 10),
+				new ItemReward("50 x Mithril Nails", ItemID.MITHRIL_NAILS, 50),
+				new ItemReward("5 x Steel Bars", ItemID.STEEL_BAR, 5),
+				new ItemReward("8 x Bolt of Cloth", ItemID.BOLT_OF_CLOTH, 8),
+				new ItemReward("5 x House Teleport Tablets", ItemID.TELEPORT_TO_HOUSE, 5),
+				new ItemReward("1 x Falador Teleport Tablet", ItemID.FALADOR_TELEPORT, 1),
+				new ItemReward("POH in Rimmington or 1,000 Coins", ItemID.COINS_995, 1000)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/darknessofhallowvale/DarknessOfHallowvale.java
+++ b/src/main/java/com/questhelper/quests/darknessofhallowvale/DarknessOfHallowvale.java
@@ -778,6 +778,12 @@ public class DarknessOfHallowvale extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "7,000 Agility Experience", "6,000 Thieving Experience", "2,000 Construction Experience", "</br>", "3 x 2,000 Experience Tomes (Any Skill over level 30).");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/darknessofhallowvale/DarknessOfHallowvale.java
+++ b/src/main/java/com/questhelper/quests/darknessofhallowvale/DarknessOfHallowvale.java
@@ -44,6 +44,9 @@ import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.util.Spellbook;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -55,12 +58,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -778,9 +777,25 @@ public class DarknessOfHallowvale extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "7,000 Agility Experience", "6,000 Thieving Experience", "2,000 Construction Experience", "</br>", "3 x 2,000 Experience Tomes (Any Skill over level 30).");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.AGILITY, 7000),
+				new ExperienceReward(Skill.THIEVING, 6000),
+				new ExperienceReward(Skill.CONSTRUCTION, 2000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("3 x 2,000 Experience Tomes (Any skill over level 30).", ItemID.ANTIQUE_LAMP, 3)); //4447 is placeholder
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deathplateau/DeathPlateau.java
+++ b/src/main/java/com/questhelper/quests/deathplateau/DeathPlateau.java
@@ -310,6 +310,12 @@ public class DeathPlateau extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "3,000 Attack Experience", "</br>", "The ability to make claws.", "The ability to purchase and equip Climbing Boots.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/deathplateau/DeathPlateau.java
+++ b/src/main/java/com/questhelper/quests/deathplateau/DeathPlateau.java
@@ -39,6 +39,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -50,9 +54,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.WidgetInfo;
 
@@ -310,9 +313,30 @@ public class DeathPlateau extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "3,000 Attack Experience", "</br>", "The ability to make claws.", "The ability to purchase and equip Climbing Boots.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.ATTACK, 3000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A pair of Steel Claws", ItemID.STEEL_CLAWS, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("The ability to craft claws."),
+				new UnlockReward("The ability to purchase and equip Climbing Boots.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deathtothedorgeshuun/DeathToTheDorgeshuun.java
+++ b/src/main/java/com/questhelper/quests/deathtothedorgeshuun/DeathToTheDorgeshuun.java
@@ -42,6 +42,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -504,9 +507,28 @@ public class DeathToTheDorgeshuun extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2,000 Thieving Experience", "2,000 Ranging Experience", "</br>", "Unlocked Dorgeshuun Special Attacks.", "Access to H.A.M. Store Rooms.", "Access to Dorgesh-Kann");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.THIEVING, 2000),
+				new ExperienceReward(Skill.RANGED, 2000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to use Dorgeshuun Special Attacks"),
+				new UnlockReward("Access to H.A.M. Store Rooms."),
+				new UnlockReward("Access to Dorgesh-Kann.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deathtothedorgeshuun/DeathToTheDorgeshuun.java
+++ b/src/main/java/com/questhelper/quests/deathtothedorgeshuun/DeathToTheDorgeshuun.java
@@ -504,6 +504,12 @@ public class DeathToTheDorgeshuun extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,000 Thieving Experience", "2,000 Ranging Experience", "</br>", "Unlocked Dorgeshuun Special Attacks.", "Access to H.A.M. Store Rooms.", "Access to Dorgesh-Kann");
+	}
+
+	@Override
 	public List<String> getNotes()
 	{
 		return Collections.singletonList("If you plan on getting the H.A.M. robes yourself rather than buying them, make sure to do so after starting the quest. The drop rate for robes is considerably increased during the quest.");

--- a/src/main/java/com/questhelper/quests/demonslayer/DemonSlayer.java
+++ b/src/main/java/com/questhelper/quests/demonslayer/DemonSlayer.java
@@ -250,6 +250,12 @@ public class DemonSlayer extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "Silverlight");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/demonslayer/DemonSlayer.java
+++ b/src/main/java/com/questhelper/quests/demonslayer/DemonSlayer.java
@@ -32,6 +32,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -250,9 +252,15 @@ public class DemonSlayer extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "Silverlight");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Silverlight", ItemID.SILVERLIGHT, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
+++ b/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
@@ -572,6 +572,11 @@ public class DesertTreasure extends BasicQuestHelper
 		return Arrays.asList(combatGear, food, prayerPotions, energyOrStaminas, restorePotions);
 	}
 
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "20,000 Magic Experience", "</br>", "Ability to use Ancient Magicks.", "Ring of Visibility", "Ability to purchase an Ancient Staff (One time only).", "Access to Smoke Dungeon");
+	}
 
 	@Override
 	public List<String> getCombatRequirements()

--- a/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
+++ b/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
@@ -43,16 +43,19 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.lang.reflect.Array;
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullItemID;
@@ -573,9 +576,31 @@ public class DesertTreasure extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "20,000 Magic Experience", "</br>", "Ability to use Ancient Magicks.", "Ring of Visibility", "Ability to purchase an Ancient Staff (One time only).", "Access to Smoke Dungeon");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.MAGIC, 20000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Ring of Visibility", ItemID.RING_OF_VISIBILITY, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to use Ancient Magicks."),
+				new UnlockReward("Ability to purchase an Ancient Staff."),
+				new UnlockReward("Access to Smoke Dungeon.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deviousminds/DeviousMinds.java
+++ b/src/main/java/com/questhelper/quests/deviousminds/DeviousMinds.java
@@ -25,6 +25,7 @@
 package com.questhelper.quests.deviousminds;
 
 import com.questhelper.QuestHelperQuest;
+import com.questhelper.questhelpers.Quest;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
@@ -32,6 +33,8 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -219,9 +222,19 @@ public class DeviousMinds extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "5,000 Fletching Experience", "5,000 Runecrafting Experience", "6,500 Smithing Experience");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.FLETCHING, 5000),
+				new ExperienceReward(Skill.RUNECRAFT, 5000),
+				new ExperienceReward(Skill.SMITHING, 6500)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deviousminds/DeviousMinds.java
+++ b/src/main/java/com/questhelper/quests/deviousminds/DeviousMinds.java
@@ -219,6 +219,12 @@ public class DeviousMinds extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Fletching Experience", "5,000 Runecrafting Experience", "6,500 Smithing Experience");
+	}
+
+	@Override
 	public List<String> getNotes()
 	{
 		return Arrays.asList("You will need to enter the Wilderness briefly during the " +

--- a/src/main/java/com/questhelper/quests/doricsquest/DoricsQuest.java
+++ b/src/main/java/com/questhelper/quests/doricsquest/DoricsQuest.java
@@ -27,6 +27,10 @@ package com.questhelper.quests.doricsquest;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.NpcStep;
 
 import java.util.*;
@@ -36,6 +40,8 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
+import com.sun.tools.javac.code.Scope;
+import net.runelite.api.Item;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.Skill;
@@ -44,7 +50,7 @@ import net.runelite.api.coords.WorldPoint;
 @QuestDescriptor(
 	quest = QuestHelperQuest.DORICS_QUEST
 )
-public class DoricsQuest extends BasicQuestHelper
+public class  DoricsQuest extends BasicQuestHelper
 {
 	//Items Required
 	ItemRequirement clay, copper, iron;
@@ -98,9 +104,27 @@ public class DoricsQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,300 Mining Experience", "</br>", "180 x Coins", "</br>", "Use of Doric's Anvils");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.MINING, 1300));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("180 Coins", ItemID.COINS_995, 180));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Use of Doric's Anvil"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/doricsquest/DoricsQuest.java
+++ b/src/main/java/com/questhelper/quests/doricsquest/DoricsQuest.java
@@ -28,11 +28,9 @@ import com.questhelper.QuestHelperQuest;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.steps.NpcStep;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
@@ -97,6 +95,12 @@ public class DoricsQuest extends BasicQuestHelper
 		reqs.add(copper);
 		reqs.add(iron);
 		return reqs;
+	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,300 Mining Experience", "</br>", "180 x Coins", "</br>", "Use of Doric's Anvils");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dragonslayer/DragonSlayer.java
+++ b/src/main/java/com/questhelper/quests/dragonslayer/DragonSlayer.java
@@ -518,6 +518,12 @@ public class DragonSlayer extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "18,650, Strength Experience", "18,650 Defence Experience", "</br>", "The ability to equip a Green D'hide Body, Rune Platebody & Dragon Platebody.", "Access to Crandor.", "Access to the Corsair Cove Resource Area.", "Ability to receive Dragons as a slayer task.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/dragonslayer/DragonSlayer.java
+++ b/src/main/java/com/questhelper/quests/dragonslayer/DragonSlayer.java
@@ -41,6 +41,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -52,10 +55,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -518,9 +519,29 @@ public class DragonSlayer extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "18,650, Strength Experience", "18,650 Defence Experience", "</br>", "The ability to equip a Green D'hide Body, Rune Platebody & Dragon Platebody.", "Access to Crandor.", "Access to the Corsair Cove Resource Area.", "Ability to receive Dragons as a slayer task.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.STRENGTH, 18650),
+				new ExperienceReward(Skill.DEFENCE, 18650)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("The abiltiy to equip a Green D'hide Body, Rune Platebody & Dragon Platebody"),
+				new UnlockReward("Access to Crandor"),
+				new UnlockReward("Access to the Corsair Cove Resource Area."),
+				new UnlockReward("Ability to receive dragons as a slayer task.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
@@ -44,6 +44,10 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -1133,9 +1137,47 @@ public class DragonSlayerII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("5 Quest Points", "</br>", "25,000 Smithing Experience", "18,000 Mining Experience", "15,000 Agility Experience", "15,000 Thieving Experience", "4 x 25,000 Experience Tome (Any Combat Skill)", "</br>", "Access to the Myths Guild:", "A Locator Orb.", "Ability to make Super Antifire Potions.", "Access to Fountain of Uhld.", "Access to Wrath Altar.", "Ability to purchase Mythical Cape.", "Access to Adamant and Rune Dragons.", "Access to Vorkath.", "Ability to reforge the Dragon platebody and kiteshield.", "Ability to craft Ferocious gloves.", "Ability to further upgrade your Ava's device.", "Ability to teleport to Lithkren with the Digsite Pendant.");
+		return new QuestPointReward(5);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.SMITHING, 25000),
+				new ExperienceReward(Skill.MINING, 18000),
+				new ExperienceReward(Skill.AGILITY, 15000),
+				new ExperienceReward(Skill.THIEVING, 15000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("4 x 25,000 Experience Tome (Any Combat Skill).", ItemID.ANTIQUE_LAMP, 4), //4447 is placeholder
+				new ItemReward("A Locator Orb", ItemID.LOCATOR_ORB, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Myths Guild."),
+				new UnlockReward("Ability to make Super Antifire Potions"),
+				new UnlockReward("Access to the Fountain of Uhld."),
+				new UnlockReward("Access to the Wrath Altar."),
+				new UnlockReward("Ability to purchase the Mythical Cape"),
+				new UnlockReward("Access to Adamant and Rune Dragons"),
+				new UnlockReward("Access to Vorkath"),
+				new UnlockReward("Ability to re-forge the dragon platebody and kiteshield."),
+				new UnlockReward("Ability to craft Ferocious Gloves"),
+				new UnlockReward("Ability to further upgrade your Ava's device."),
+				new UnlockReward("Ability to teleport to Lithkren with the Digsite Pendant.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
@@ -1133,6 +1133,12 @@ public class DragonSlayerII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("5 Quest Points", "</br>", "25,000 Smithing Experience", "18,000 Mining Experience", "15,000 Agility Experience", "15,000 Thieving Experience", "4 x 25,000 Experience Tome (Any Combat Skill)", "</br>", "Access to the Myths Guild:", "A Locator Orb.", "Ability to make Super Antifire Potions.", "Access to Fountain of Uhld.", "Access to Wrath Altar.", "Ability to purchase Mythical Cape.", "Access to Adamant and Rune Dragons.", "Access to Vorkath.", "Ability to reforge the Dragon platebody and kiteshield.", "Ability to craft Ferocious gloves.", "Ability to further upgrade your Ava's device.", "Ability to teleport to Lithkren with the Digsite Pendant.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/dreammentor/DreamMentor.java
+++ b/src/main/java/com/questhelper/quests/dreammentor/DreamMentor.java
@@ -382,6 +382,12 @@ public class DreamMentor extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "15,000 Hitpoints Experience", "10,000 Magic Experience", "15,000 Experience Lamp (Combat, No Prayer or Attack)", "</br>", "Unlocked 7 New Lunar Spells.", "Can now bank with 'Birds-Eye' Jack without a seal of passage.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/dreammentor/DreamMentor.java
+++ b/src/main/java/com/questhelper/quests/dreammentor/DreamMentor.java
@@ -42,22 +42,25 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
+
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -382,9 +385,33 @@ public class DreamMentor extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "15,000 Hitpoints Experience", "10,000 Magic Experience", "15,000 Experience Lamp (Combat, No Prayer or Attack)", "</br>", "Unlocked 7 New Lunar Spells.", "Can now bank with 'Birds-Eye' Jack without a seal of passage.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.HITPOINTS, 15000),
+				new ExperienceReward(Skill.MAGIC, 10000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("15,000 Experience Lamp (Combat, No Prayer or Attack)", ItemID.ANTIQUE_LAMP, 1)); //4447 Is placeholder for filtering.
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("7 New Lunar Spells"),
+				new UnlockReward("Ability to bank without the Seal of Passage by talking to 'Birds-Eye-Jack'")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/druidicritual/DruidicRitual.java
+++ b/src/main/java/com/questhelper/quests/druidicritual/DruidicRitual.java
@@ -180,6 +180,12 @@ public class DruidicRitual extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Points", "</br>", "250 Herblore Experience", "</br>", "Access to the Herblore Skill.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/druidicritual/DruidicRitual.java
+++ b/src/main/java/com/questhelper/quests/druidicritual/DruidicRitual.java
@@ -34,18 +34,21 @@ import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.requirements.quest.QuestPointRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -180,9 +183,21 @@ public class DruidicRitual extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("4 Quest Points", "</br>", "250 Herblore Experience", "</br>", "Access to the Herblore Skill.");
+		return new QuestPointReward(4);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.HERBLORE, 250));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Herblore Skill"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dwarfcannon/DwarfCannon.java
+++ b/src/main/java/com/questhelper/quests/dwarfcannon/DwarfCannon.java
@@ -12,6 +12,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -22,10 +25,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -217,9 +218,24 @@ public class DwarfCannon extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "750 Crafting Experience", "</br>", "Ability to purchase and use the Drawf Multicannon.", "Ability to make cannonballs.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 750));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to purchase and use the Dwarf Multicannon."),
+				new UnlockReward("Ability to make cannonballs.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dwarfcannon/DwarfCannon.java
+++ b/src/main/java/com/questhelper/quests/dwarfcannon/DwarfCannon.java
@@ -217,6 +217,12 @@ public class DwarfCannon extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "750 Crafting Experience", "</br>", "Ability to purchase and use the Drawf Multicannon.", "Ability to make cannonballs.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/eadgarsruse/EadgarsRuse.java
+++ b/src/main/java/com/questhelper/quests/eadgarsruse/EadgarsRuse.java
@@ -589,6 +589,12 @@ public class EadgarsRuse extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "11,000 Herblore Experience", "</br>", "Ability to use Trollheim Teleport", "Ability to use Scrolls of Redirection to Trollheim.", "Ability to trade Goutweed to Sanfew for herbs.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/eadgarsruse/EadgarsRuse.java
+++ b/src/main/java/com/questhelper/quests/eadgarsruse/EadgarsRuse.java
@@ -40,6 +40,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -589,9 +592,25 @@ public class EadgarsRuse extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "11,000 Herblore Experience", "</br>", "Ability to use Trollheim Teleport", "Ability to use Scrolls of Redirection to Trollheim.", "Ability to trade Goutweed to Sanfew for herbs.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.HERBLORE, 11000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to use the Trollheim teleport"),
+				new UnlockReward("Ability to use Scrolls of Redirection to Trollheim."),
+				new UnlockReward("Ability to trade Goutweed to Sanfew for herbs.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/eaglespeak/EaglesPeak.java
+++ b/src/main/java/com/questhelper/quests/eaglespeak/EaglesPeak.java
@@ -450,6 +450,12 @@ public class EaglesPeak extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2,500 Hunter Experience", "</br>", "Ability to use Box Traps.", "Ability to use Eagle Transport System.", "Ability to hunt rabbits.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/eaglespeak/EaglesPeak.java
+++ b/src/main/java/com/questhelper/quests/eaglespeak/EaglesPeak.java
@@ -39,6 +39,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -450,9 +453,25 @@ public class EaglesPeak extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "2,500 Hunter Experience", "</br>", "Ability to use Box Traps.", "Ability to use Eagle Transport System.", "Ability to hunt rabbits.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.HUNTER, 2500));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to use Box Traps"),
+				new UnlockReward("Ability to use Eagle Transport System"),
+				new UnlockReward("Ability to hunt Rabbits.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/elementalworkshopi/ElementalWorkshopI.java
+++ b/src/main/java/com/questhelper/quests/elementalworkshopi/ElementalWorkshopI.java
@@ -43,6 +43,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -317,9 +321,33 @@ public class ElementalWorkshopI extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "5,000 Crafting Experience", "5,000 Smithing Experience", "</br>", "An Elemental Shield.", "Access to the Elemental Workshop.", "Ability to craft and wield elemental shields.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 5000),
+				new ExperienceReward(Skill.SMITHING, 5000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("An Elemental Shield", ItemID.ELEMENTAL_SHIELD, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Elemental Workshop."),
+				new UnlockReward("Ability to craft and wield Elemental equipment.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/elementalworkshopi/ElementalWorkshopI.java
+++ b/src/main/java/com/questhelper/quests/elementalworkshopi/ElementalWorkshopI.java
@@ -317,6 +317,12 @@ public class ElementalWorkshopI extends ComplexStateQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Crafting Experience", "5,000 Smithing Experience", "</br>", "An Elemental Shield.", "Access to the Elemental Workshop.", "Ability to craft and wield elemental shields.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/elementalworkshopii/ElementalWorkshopII.java
+++ b/src/main/java/com/questhelper/quests/elementalworkshopii/ElementalWorkshopII.java
@@ -634,6 +634,12 @@ public class ElementalWorkshopII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "7,500 Crafting Experience", "7,500 Smithing Experience", "</br>", "A Mind Helmet.", "Ability to make and equip Elemental Mind equipment.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/elementalworkshopii/ElementalWorkshopII.java
+++ b/src/main/java/com/questhelper/quests/elementalworkshopii/ElementalWorkshopII.java
@@ -44,6 +44,10 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -636,7 +640,34 @@ public class ElementalWorkshopII extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "7,500 Crafting Experience", "7,500 Smithing Experience", "</br>", "A Mind Helmet.", "Ability to make and equip Elemental Mind equipment.");
+		return Arrays.asList("1 Quest Point", "</br>", "7,500 Crafting Experience", "7,500 Smithing Experience",
+				"</br>", "A Mind Helmet.", "Ability to make and equip Elemental Mind equipment.");
+	}
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 7500),
+				new ExperienceReward(Skill.SMITHING, 7500)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Mind Helmet", ItemID.MIND_HELMET, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to craft and equip Mind Elemental Equipment"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/enakhraslament/EnakhrasLament.java
+++ b/src/main/java/com/questhelper/quests/enakhraslament/EnakhrasLament.java
@@ -40,6 +40,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Spellbook;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -500,9 +503,26 @@ public class EnakhrasLament extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "7,000 Crafting Experience", "7,000 Mining Experience", "7,000 Firemaking Experience", "7,000 Magic Experience", "</br>", "Akthanakos's Camulet");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 7000),
+				new ExperienceReward(Skill.MINING, 7000),
+				new ExperienceReward(Skill.FIREMAKING, 7000),
+				new ExperienceReward(Skill.MAGIC, 7000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Akthanakos's Camulet", ItemID.CAMULET, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/enakhraslament/EnakhrasLament.java
+++ b/src/main/java/com/questhelper/quests/enakhraslament/EnakhrasLament.java
@@ -500,6 +500,12 @@ public class EnakhrasLament extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "7,000 Crafting Experience", "7,000 Mining Experience", "7,000 Firemaking Experience", "7,000 Magic Experience", "</br>", "Akthanakos's Camulet");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/enchantedkey/EnchantedKey.java
+++ b/src/main/java/com/questhelper/quests/enchantedkey/EnchantedKey.java
@@ -100,6 +100,12 @@ public class EnchantedKey extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("Saradomin Mjolnir", "Guthix Mjolnir", "Zamorak Mjolnir", "</br>", "Various Runes & Essence", "Various Ores", "Various Arrows & Tips");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/enchantedkey/EnchantedKey.java
+++ b/src/main/java/com/questhelper/quests/enchantedkey/EnchantedKey.java
@@ -34,6 +34,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.questhelper.rewards.ItemReward;
 import net.runelite.api.ItemID;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.panel.PanelDetails;
@@ -100,9 +102,13 @@ public class EnchantedKey extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ItemReward> getItemRewards()
 	{
-		return Arrays.asList("Saradomin Mjolnir", "Guthix Mjolnir", "Zamorak Mjolnir", "</br>", "Various Runes & Essence", "Various Ores", "Various Arrows & Tips");
+		return Arrays.asList(
+				new ItemReward("Saradomin Mjolnir", ItemID.SARADOMIN_MJOLNIR, 1),
+				new ItemReward("Guthix Mjolnir", ItemID.GUTHIX_MJOLNIR, 1),
+				new ItemReward("Zamorak Mjolnir", ItemID.ZAMORAK_MJOLNIR, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/enlightenedjourney/EnlightenedJourney.java
+++ b/src/main/java/com/questhelper/quests/enlightenedjourney/EnlightenedJourney.java
@@ -246,6 +246,12 @@ public class EnlightenedJourney extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,000 Crafting Experience", "3,000 Farming Experience", "1,500 Woodcutting Experience", "4,000 Firemaking Experience", "</br>", "Bomber Jacket & Cap.", "Access to Hot Air Balloon transport system.", "Ability to make origami balloons.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/enlightenedjourney/EnlightenedJourney.java
+++ b/src/main/java/com/questhelper/quests/enlightenedjourney/EnlightenedJourney.java
@@ -41,6 +41,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedOwnerStep;
 import com.questhelper.steps.DetailedQuestStep;
@@ -246,9 +250,38 @@ public class EnlightenedJourney extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2,000 Crafting Experience", "3,000 Farming Experience", "1,500 Woodcutting Experience", "4,000 Firemaking Experience", "</br>", "Bomber Jacket & Cap.", "Access to Hot Air Balloon transport system.", "Ability to make origami balloons.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 2000),
+				new ExperienceReward(Skill.FARMING, 3000),
+				new ExperienceReward(Skill.WOODCUTTING, 1500),
+				new ExperienceReward(Skill.FIREMAKING, 4000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("Bomber Jacket", ItemID.BOMBER_JACKET, 1),
+				new ItemReward("Bomber Cap", ItemID.BOMBER_CAP, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Hot Air Balloon transport system."),
+				new UnlockReward("Ability to make origami balloons.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/entertheabyss/EnterTheAbyss.java
+++ b/src/main/java/com/questhelper/quests/entertheabyss/EnterTheAbyss.java
@@ -37,6 +37,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -47,11 +50,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
+import sun.jvm.hotspot.gc.z.ZCollectedHeap;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.ENTER_THE_ABYSS
@@ -181,9 +183,21 @@ public class EnterTheAbyss extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ExperienceReward> getExperienceRewards()
 	{
-		return Arrays.asList("1,000 Runecrafting Experience", "</br>", "Ability to enter the Abyss.", "A small pouch.");
+		return Collections.singletonList(new ExperienceReward(Skill.RUNECRAFT, 1000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A small rune pouch", ItemID.SMALL_POUCH, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to enter The Abyss"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/entertheabyss/EnterTheAbyss.java
+++ b/src/main/java/com/questhelper/quests/entertheabyss/EnterTheAbyss.java
@@ -181,6 +181,12 @@ public class EnterTheAbyss extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1,000 Runecrafting Experience", "</br>", "Ability to enter the Abyss.", "A small pouch.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ernestthechicken/ErnestTheChicken.java
+++ b/src/main/java/com/questhelper/quests/ernestthechicken/ErnestTheChicken.java
@@ -264,6 +264,12 @@ public class ErnestTheChicken extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Points", "</br>", "300 Coins", "</br>", "Access to the Killerwatt plane (Members Only).", "Ability to be assigned Killerwatts as a slayer task.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ernestthechicken/ErnestTheChicken.java
+++ b/src/main/java/com/questhelper/quests/ernestthechicken/ErnestTheChicken.java
@@ -38,11 +38,16 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
+
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -264,9 +269,24 @@ public class ErnestTheChicken extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("4 Quest Points", "</br>", "300 Coins", "</br>", "Access to the Killerwatt plane (Members Only).", "Ability to be assigned Killerwatts as a slayer task.");
+		return new QuestPointReward(4);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("300 Coins", ItemID.COINS_995, 300));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Killerwatt plane (Members Only)."),
+				new UnlockReward("Ability to be assigned Killerwatts as a Slayer task.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
+++ b/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
@@ -41,6 +41,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DigStep;
 import com.questhelper.steps.ItemStep;
@@ -53,16 +56,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.WidgetInfo;
 
 @QuestDescriptor(
-	quest = QuestHelperQuest.FAIRYTALE_I__GROWING_PAINS
+	quest = QuestHelperQuest.FAIRYTALE_I_GROWING_PAINS
 )
 public class FairytaleI extends BasicQuestHelper
 {
@@ -313,9 +313,25 @@ public class FairytaleI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "3,500 Farming Experience", "2,000 Attack Experience", "1,000 Magic Experience", "</br>", "Magic Secateurs");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.FARMING, 3500),
+				new ExperienceReward(Skill.ATTACK, 2000),
+				new ExperienceReward(Skill.MAGIC, 1000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Magic Secateurs", ItemID.MAGIC_SECATEURS, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
+++ b/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
@@ -313,6 +313,12 @@ public class FairytaleI extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "3,500 Farming Experience", "2,000 Attack Experience", "1,000 Magic Experience", "</br>", "Magic Secateurs");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
+++ b/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
@@ -62,7 +62,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.WidgetInfo;
 
 @QuestDescriptor(
-	quest = QuestHelperQuest.FAIRYTALE_I_GROWING_PAINS
+	quest = QuestHelperQuest.FAIRYTALE_I__GROWING_PAINS
 )
 public class FairytaleI extends BasicQuestHelper
 {

--- a/src/main/java/com/questhelper/quests/fairytaleii/FairytaleII.java
+++ b/src/main/java/com/questhelper/quests/fairytaleii/FairytaleII.java
@@ -380,6 +380,12 @@ public class FairytaleII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "3,500 Herblore Experience", "2,500 Thieving Experience", "2 x 2,500 Experience Lamps (Any Skill over level 30).", "</br>", "Access to Fairy Ring Network", "Access to Fairy Fixit's Fairy Enhancement Shop.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/fairytaleii/FairytaleII.java
+++ b/src/main/java/com/questhelper/quests/fairytaleii/FairytaleII.java
@@ -43,6 +43,10 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -380,9 +384,33 @@ public class FairytaleII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "3,500 Herblore Experience", "2,500 Thieving Experience", "2 x 2,500 Experience Lamps (Any Skill over level 30).", "</br>", "Access to Fairy Ring Network", "Access to Fairy Fixit's Fairy Enhancement Shop.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.HERBLORE, 3500),
+				new ExperienceReward(Skill.THIEVING, 2500)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("2 x 2,500 Experience Lamps (Any skill over level 30.)", ItemID.ANTIQUE_LAMP, 2)); //4447 Is placeholder for filter.
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Fairy Rings."),
+				new UnlockReward("Access to Fairy Fixit's Fairy Enhancement Store.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/familycrest/FamilyCrest.java
+++ b/src/main/java/com/questhelper/quests/familycrest/FamilyCrest.java
@@ -38,6 +38,8 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -328,9 +330,15 @@ public class FamilyCrest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "A pair of Steel Gauntlets.", "</br>", "For 25k Steel Gauntlets can be turned into:", "Cooking Gauntlets (Caleb)", "Goldsmith Gauntlets (Avan)", "Chaos Gauntlets (Johnathon)");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A pair of Steel Gauntlets", ItemID.STEEL_GAUNTLETS, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/familycrest/FamilyCrest.java
+++ b/src/main/java/com/questhelper/quests/familycrest/FamilyCrest.java
@@ -328,6 +328,12 @@ public class FamilyCrest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "A pair of Steel Gauntlets.", "</br>", "For 25k Steel Gauntlets can be turned into:", "Cooking Gauntlets (Caleb)", "Goldsmith Gauntlets (Avan)", "Chaos Gauntlets (Johnathon)");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/familypest/FamilyPest.java
+++ b/src/main/java/com/questhelper/quests/familypest/FamilyPest.java
@@ -36,6 +36,7 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -51,6 +52,7 @@ import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.coords.WorldPoint;
+import org.graalvm.compiler.nodes.memory.MemoryCheckpoint;
 
 @QuestDescriptor(
         quest = QuestHelperQuest.FAMILY_PEST
@@ -153,9 +155,9 @@ public class FamilyPest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<UnlockReward> getUnlockRewards()
 	{
-		return Arrays.asList("Ability to own all three Steel Gauntlets (Chaos, Cooking and Goldsmith Gauntlets) simultaneously.");
+		return Collections.singletonList(new UnlockReward("Abliity to own all three Steel Gauntlets simultaneously"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/familypest/FamilyPest.java
+++ b/src/main/java/com/questhelper/quests/familypest/FamilyPest.java
@@ -153,6 +153,12 @@ public class FamilyPest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("Ability to own all three Steel Gauntlets (Chaos, Cooking and Goldsmith Gauntlets) simultaneously.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/fightarena/FightArena.java
+++ b/src/main/java/com/questhelper/quests/fightarena/FightArena.java
@@ -36,6 +36,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -49,6 +52,7 @@ import java.util.Map;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -219,9 +223,27 @@ public class FightArena extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "12,175 Attack Experience", "2,175 Thieving Experience", "</br>", "1,000 Coins", "Khazard Armor");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.ATTACK, 12175),
+				new ExperienceReward(Skill.THIEVING, 2175)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("1,000 Coins", ItemID.COINS_995, 1000),
+				new ItemReward("Khazard Armor", ItemID.KHAZARD_ARMOUR, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/fightarena/FightArena.java
+++ b/src/main/java/com/questhelper/quests/fightarena/FightArena.java
@@ -219,6 +219,12 @@ public class FightArena extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "12,175 Attack Experience", "2,175 Thieving Experience", "</br>", "1,000 Coins", "Khazard Armor");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/fishingcontest/FishingContest.java
+++ b/src/main/java/com/questhelper/quests/fishingcontest/FishingContest.java
@@ -43,6 +43,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -275,9 +278,24 @@ public class FishingContest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2,437 Fishing Experience", "</br>", "Access to the underground White Wolf Mountain passage.", "Ability to catch minnows in The Fishing Guild. (82 Fishing)");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.FISHING, 2437));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the underground White Wolf Mountain passage"),
+				new UnlockReward("Ability to catch minnows in The Fishing Guild.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/fishingcontest/FishingContest.java
+++ b/src/main/java/com/questhelper/quests/fishingcontest/FishingContest.java
@@ -274,6 +274,11 @@ public class FishingContest extends BasicQuestHelper
 		return Arrays.asList(coins, redVineWorm, garlic, spade, fishingRod);
 	}
 
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,437 Fishing Experience", "</br>", "Access to the underground White Wolf Mountain passage.", "Ability to catch minnows in The Fishing Guild. (82 Fishing)");
+	}
 
 	@Override
 	public List<ItemRequirement> getItemRecommended()

--- a/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
@@ -953,6 +953,12 @@ public class ForgettableTale extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "5,000 Cooking Experience", "5,000 Farming Experience", "</br>", "2 x Dwarven Stout (m)");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
@@ -41,6 +41,8 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.ItemSlots;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -955,7 +957,22 @@ public class ForgettableTale extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "5,000 Cooking Experience", "5,000 Farming Experience", "</br>", "2 x Dwarven Stout (m)");
+		return Arrays.asList("2 Quest Points", "</br>", "5,000 Cooking Experience", "5,000 Farming Experience",
+				"</br>", "2 x Dwarven Stout (m)");
+	}
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 5000),
+				new ExperienceReward(Skill.FARMING, 5000)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
+++ b/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
@@ -41,6 +41,9 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.ItemSlots;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -608,9 +611,21 @@ public class GardenOfTranquillity extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "5,000 Farming Experience", "</br>", "Misc. Seeds", "Compost Potion (4)");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.FARMING, 5000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Compost Potion (4)", ItemID.COMPOST_POTION4, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
+++ b/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
@@ -606,6 +606,13 @@ public class GardenOfTranquillity extends BasicQuestHelper
 		reqs.add(new SkillRequirement(Skill.FARMING, 25));
 		return reqs;
 	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "5,000 Farming Experience", "</br>", "Misc. Seeds", "Compost Potion (4)");
+	}
+
 	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{

--- a/src/main/java/com/questhelper/quests/gertrudescat/GertrudesCat.java
+++ b/src/main/java/com/questhelper/quests/gertrudescat/GertrudesCat.java
@@ -240,6 +240,12 @@ public class GertrudesCat extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,525 Cooking Experience", "</br>", "A Kitten", "Chocolate Cake", "Stew", "Ability to buy and train kittens.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> steps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/gertrudescat/GertrudesCat.java
+++ b/src/main/java/com/questhelper/quests/gertrudescat/GertrudesCat.java
@@ -33,6 +33,10 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -49,6 +53,7 @@ import java.util.Map;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -240,9 +245,31 @@ public class GertrudesCat extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,525 Cooking Experience", "</br>", "A Kitten", "Chocolate Cake", "Stew", "Ability to buy and train kittens.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.COOKING, 1525));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("A pet Kitten", ItemID.PET_KITTEN, 1),
+				new ItemReward("Chocolate Cake", ItemID.CHOCOLATE_CAKE, 1),
+				new ItemReward("Stew", ItemID.STEW, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to raise kittens."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/gettingahead/GettingAhead.java
+++ b/src/main/java/com/questhelper/quests/gettingahead/GettingAhead.java
@@ -38,6 +38,10 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -50,10 +54,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -322,9 +324,30 @@ public class GettingAhead extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "4,000 Crafting Experience", "3,200 Construction Experience", "</br>", "3,000 Coins", "</br>", "Access to the tannery in Kebos Lowlands.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 4000),
+				new ExperienceReward(Skill.CONSTRUCTION, 3200)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("3,000 Coins", ItemID.COINS_995, 3000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the tannery on Kebos Lowlands"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/gettingahead/GettingAhead.java
+++ b/src/main/java/com/questhelper/quests/gettingahead/GettingAhead.java
@@ -322,6 +322,12 @@ public class GettingAhead extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "4,000 Crafting Experience", "3,200 Construction Experience", "</br>", "3,000 Coins", "</br>", "Access to the tannery in Kebos Lowlands.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ghostsahoy/GhostsAhoy.java
+++ b/src/main/java/com/questhelper/quests/ghostsahoy/GhostsAhoy.java
@@ -38,6 +38,10 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
@@ -445,9 +449,27 @@ public class GhostsAhoy extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "2,400 Prayer Experience", "</br>", "Ectophial", "Free passage into Port Phasmatys");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.PRAYER, 2400));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Ectophial", ItemID.ECTOPHIAL, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Free passage into Port Phasmatys"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/ghostsahoy/GhostsAhoy.java
+++ b/src/main/java/com/questhelper/quests/ghostsahoy/GhostsAhoy.java
@@ -445,6 +445,12 @@ public class GhostsAhoy extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2,400 Prayer Experience", "</br>", "Ectophial", "Free passage into Port Phasmatys");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/goblindiplomacy/GoblinDiplomacy.java
+++ b/src/main/java/com/questhelper/quests/goblindiplomacy/GoblinDiplomacy.java
@@ -36,19 +36,21 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -192,9 +194,21 @@ public class GoblinDiplomacy extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("5 Quest Points", "</br>", "200 Crafting Experience", "</br>", "A Gold Bar");
+		return new QuestPointReward(5);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 200));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Gold Bar", ItemID.GOLD_BAR, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/goblindiplomacy/GoblinDiplomacy.java
+++ b/src/main/java/com/questhelper/quests/goblindiplomacy/GoblinDiplomacy.java
@@ -192,6 +192,12 @@ public class GoblinDiplomacy extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("5 Quest Points", "</br>", "200 Crafting Experience", "</br>", "A Gold Bar");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/grimtales/GrimTales.java
+++ b/src/main/java/com/questhelper/quests/grimtales/GrimTales.java
@@ -384,6 +384,12 @@ public class GrimTales extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "4,000 Farming Experience", "5,000 Herblore Experience", "5,000 Hitpoints Experience", "14,000 Woodcutting Experience", "6,000 Agility Experience", "6,000 Thieving Experience", "</br>", "Dwarven Helmet");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/grimtales/GrimTales.java
+++ b/src/main/java/com/questhelper/quests/grimtales/GrimTales.java
@@ -41,6 +41,9 @@ import com.questhelper.requirements.WidgetModelRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -384,9 +387,28 @@ public class GrimTales extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "4,000 Farming Experience", "5,000 Herblore Experience", "5,000 Hitpoints Experience", "14,000 Woodcutting Experience", "6,000 Agility Experience", "6,000 Thieving Experience", "</br>", "Dwarven Helmet");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.FARMING, 4000),
+				new ExperienceReward(Skill.HERBLORE, 5000),
+				new ExperienceReward(Skill.HITPOINTS, 5000),
+				new ExperienceReward(Skill.WOODCUTTING, 14000),
+				new ExperienceReward(Skill.AGILITY, 6000),
+				new ExperienceReward(Skill.THIEVING, 6000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Dwarven Helmet", ItemID.DWARVEN_HELMET, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
+++ b/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
@@ -43,16 +43,17 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -390,9 +391,24 @@ public class HauntedMine extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "22,000 Strength Experience", "</br>", "Ability to create the Salve Amulet.", "Access to Tarn's Lair");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.STRENGTH, 22000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to create the Salve Amulet"),
+				new UnlockReward("Ability to access Tarn's Lair")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
+++ b/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
@@ -390,6 +390,12 @@ public class HauntedMine extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "22,000 Strength Experience", "</br>", "Ability to create the Salve Amulet.", "Access to Tarn's Lair");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/hazeelcult/HazeelCult.java
+++ b/src/main/java/com/questhelper/quests/hazeelcult/HazeelCult.java
@@ -38,6 +38,9 @@ import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
@@ -52,6 +55,7 @@ import java.util.Map;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -326,9 +330,21 @@ public class HazeelCult extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,500 Thieving Experience", "</br>", "2,000 Coins");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.THIEVING, 1500));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("2,000 Coins", ItemID.COINS_995, 2000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/hazeelcult/HazeelCult.java
+++ b/src/main/java/com/questhelper/quests/hazeelcult/HazeelCult.java
@@ -326,6 +326,12 @@ public class HazeelCult extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,500 Thieving Experience", "</br>", "2,000 Coins");
+	}
+
+	@Override
 	public List<String> getNotes()
 	{
 		return Collections.singletonList("If you sided with Hazeel and are being guided to help Ceril, just click the" +

--- a/src/main/java/com/questhelper/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/quests/heroesquest/HeroesQuest.java
@@ -476,6 +476,12 @@ public class HeroesQuest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "3,075 Attack Experience", "3,075 Defence Experience", "3,075 Strength Experience", "3,075 Hitpoints Experience", "2,075 Range Experience", "2,725 Fishing Experience", "2,825 Cooking Experience", "1,575 Woodcutting Experience", "1,575 Firemaking Experience", "2,257 Smithing Experience", "2,575 Mining Experience", "1,325 Herblore Experience", "</br>", "Access to the Heros Guild.", "Ability to use the Fountain of Rune.", "Ability to use Charge Dragonstone Jewellery scrolls.", "Ability to purchase and equip Dragon Battleaxes and Maces.");
+	}
+
+	@Override
 	public List<String> getNotes()
 	{
 		ArrayList<String> reqs = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/quests/heroesquest/HeroesQuest.java
@@ -44,6 +44,9 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -56,11 +59,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -476,9 +476,38 @@ public class HeroesQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "3,075 Attack Experience", "3,075 Defence Experience", "3,075 Strength Experience", "3,075 Hitpoints Experience", "2,075 Range Experience", "2,725 Fishing Experience", "2,825 Cooking Experience", "1,575 Woodcutting Experience", "1,575 Firemaking Experience", "2,257 Smithing Experience", "2,575 Mining Experience", "1,325 Herblore Experience", "</br>", "Access to the Heros Guild.", "Ability to use the Fountain of Rune.", "Ability to use Charge Dragonstone Jewellery scrolls.", "Ability to purchase and equip Dragon Battleaxes and Maces.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.ATTACK, 3075),
+				new ExperienceReward(Skill.DEFENCE, 3075),
+				new ExperienceReward(Skill.STRENGTH, 3075),
+				new ExperienceReward(Skill.RANGED, 2075),
+				new ExperienceReward(Skill.HITPOINTS, 3075),
+				new ExperienceReward(Skill.FISHING, 2725),
+				new ExperienceReward(Skill.COOKING, 2825),
+				new ExperienceReward(Skill.WOODCUTTING, 1575),
+				new ExperienceReward(Skill.FIREMAKING, 1575),
+				new ExperienceReward(Skill.SMITHING, 2257),
+				new ExperienceReward(Skill.MINING, 2275),
+				new ExperienceReward(Skill.HERBLORE, 1325)
+		);
+	}
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Hero's Guild."),
+				new UnlockReward("Ability to use the Fountain of Rune."),
+				new UnlockReward("Ability to use Charge Dragonstone Jewellery scrolls."),
+				new UnlockReward("Ability to purchase and equip Dragon Battleaxes and Maces.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/holygrail/HolyGrail.java
+++ b/src/main/java/com/questhelper/quests/holygrail/HolyGrail.java
@@ -336,6 +336,12 @@ public class HolyGrail extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "11,000 Prayer Experience", "15,300 Defence Experience", "</br>", "Access to the Fisher Realm.", "Ability to put King Arthur picture on the wall in the POH.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/holygrail/HolyGrail.java
+++ b/src/main/java/com/questhelper/quests/holygrail/HolyGrail.java
@@ -32,6 +32,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.requirements.conditional.Conditions;
@@ -336,9 +339,27 @@ public class HolyGrail extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "11,000 Prayer Experience", "15,300 Defence Experience", "</br>", "Access to the Fisher Realm.", "Ability to put King Arthur picture on the wall in the POH.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.PRAYER, 11000),
+				new ExperienceReward(Skill.DEFENCE, 15300)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Fisher Realm."),
+				new UnlockReward("Ability to put King Arthur picture on the wall in the POH.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
+++ b/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
@@ -41,6 +41,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.npc.NpcHintArrowRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -331,9 +334,29 @@ public class HorrorFromTheDeep extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "4,662 Magic Experience", "4,662 Strength Experience", "4,662 Ranged Experience", "</br>", "A damaged God Book of your choice.", "Access to The Lighthouse.", "Ability to get Dagannoth as a slayer task.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.MAGIC, 4662),
+				new ExperienceReward(Skill.STRENGTH, 4662),
+				new ExperienceReward(Skill.RANGED, 4662)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("A damaged God Book of your choice."),
+				new UnlockReward("Access to The Lighthouse"),
+				new UnlockReward("Ability to receive Dagannoth as a Slayer task.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
+++ b/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
@@ -331,6 +331,12 @@ public class HorrorFromTheDeep extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "4,662 Magic Experience", "4,662 Strength Experience", "4,662 Ranged Experience", "</br>", "A damaged God Book of your choice.", "Access to The Lighthouse.", "Ability to get Dagannoth as a slayer task.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
+++ b/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
@@ -432,6 +432,12 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "4,500 Thieving Experience", "4,000 Agility Experience", "4,000 Woodcutting Experience", "</br>", "Catspeak Amulet", "Access to the city of Sophanem.", "Ability to take carpet rides from Pollnivneach to Sophanem and Menaphos.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
+++ b/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
@@ -44,6 +44,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -55,11 +59,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -432,9 +433,34 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "4,500 Thieving Experience", "4,000 Agility Experience", "4,000 Woodcutting Experience", "</br>", "Catspeak Amulet", "Access to the city of Sophanem.", "Ability to take carpet rides from Pollnivneach to Sophanem and Menaphos.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.THIEVING, 4500),
+				new ExperienceReward(Skill.AGILITY, 4000),
+				new ExperienceReward(Skill.WOODCUTTING, 4000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Catspeak Amulet", ItemID.CATSPEAK_AMULET, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the city of Sophanem."),
+				new UnlockReward("Ability to take carpet rides from Pollnivneah to Sophanem and Menaphos.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/impcatcher/ImpCatcher.java
+++ b/src/main/java/com/questhelper/quests/impcatcher/ImpCatcher.java
@@ -25,11 +25,9 @@
 package com.questhelper.quests.impcatcher;
 
 import com.questhelper.QuestHelperQuest;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
@@ -85,6 +83,12 @@ public class ImpCatcher extends BasicQuestHelper
 		reqs.add(yellowBead);
 
 		return reqs;
+	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "875 Magic Experience", "</br>", "An Amulet of Accuracy");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/impcatcher/ImpCatcher.java
+++ b/src/main/java/com/questhelper/quests/impcatcher/ImpCatcher.java
@@ -28,8 +28,14 @@ import com.questhelper.QuestHelperQuest;
 
 import java.util.*;
 
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
+import net.runelite.api.Item;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.panel.PanelDetails;
@@ -86,9 +92,21 @@ public class ImpCatcher extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "875 Magic Experience", "</br>", "An Amulet of Accuracy");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.MAGIC, 875));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("An Amulet of Accuracy", ItemID.AMULET_OF_ACCURACY, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/inaidofthemyreque/InAidOfTheMyreque.java
+++ b/src/main/java/com/questhelper/quests/inaidofthemyreque/InAidOfTheMyreque.java
@@ -567,6 +567,12 @@ public class InAidOfTheMyreque extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2,000 Attack Experience", "2,000 Strength Experience", "2,000 Crafting Experience", "2,000 Defence Experience", "</br>", "Access to Temple Trekking Minigame.", "Gadderhammer", "Ability to make the Rod of Ivandis.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/inaidofthemyreque/InAidOfTheMyreque.java
+++ b/src/main/java/com/questhelper/quests/inaidofthemyreque/InAidOfTheMyreque.java
@@ -42,6 +42,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.util.Spellbook;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -567,9 +570,28 @@ public class InAidOfTheMyreque extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "2,000 Attack Experience", "2,000 Strength Experience", "2,000 Crafting Experience", "2,000 Defence Experience", "</br>", "Access to Temple Trekking Minigame.", "Gadderhammer", "Ability to make the Rod of Ivandis.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.ATTACK, 2000),
+				new ExperienceReward(Skill.STRENGTH, 2000),
+				new ExperienceReward(Skill.CRAFTING, 2000),
+				new ExperienceReward(Skill.DEFENCE, 2000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards() {
+		return Arrays.asList(
+				new UnlockReward("Access to Temple Trekking Minigame."),
+				new UnlockReward("Ability to make the Rod of Ivandis")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
+++ b/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
@@ -39,6 +39,7 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ItemReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -237,9 +238,9 @@ public class InSearchOfKnowledge extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ItemReward> getItemRewards()
 	{
-		return Arrays.asList("10,000 Experience Lamp (Any Skill over level 40).");
+		return Collections.singletonList(new ItemReward("10,000 Experience Lamp (any skill over level 40).", ItemID.ANTIQUE_LAMP, 1)); //4447 Is placeholder for filter.
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
+++ b/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
@@ -237,6 +237,12 @@ public class InSearchOfKnowledge extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("10,000 Experience Lamp (Any Skill over level 40).");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/insearchofthemyreque/InSearchOfTheMyreque.java
+++ b/src/main/java/com/questhelper/quests/insearchofthemyreque/InSearchOfTheMyreque.java
@@ -40,6 +40,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -348,9 +351,27 @@ public class InSearchOfTheMyreque extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "600 Attack Experience", "600 Defence Experience", "600 Strength Experience", "600 Hitpoints Experience", "600 Crafting Experience", "</br>", "A quick route to Mor'ton");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.ATTACK, 600),
+				new ExperienceReward(Skill.DEFENCE, 600),
+				new ExperienceReward(Skill.STRENGTH, 600),
+				new ExperienceReward(Skill.HITPOINTS, 600),
+				new ExperienceReward(Skill.CRAFTING, 600)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("A quick route to Mor'ton"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/insearchofthemyreque/InSearchOfTheMyreque.java
+++ b/src/main/java/com/questhelper/quests/insearchofthemyreque/InSearchOfTheMyreque.java
@@ -348,6 +348,12 @@ public class InSearchOfTheMyreque extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "600 Attack Experience", "600 Defence Experience", "600 Strength Experience", "600 Hitpoints Experience", "600 Crafting Experience", "</br>", "A quick route to Mor'ton");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
+++ b/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
@@ -34,6 +34,8 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -48,6 +50,7 @@ import java.util.Map;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -256,9 +259,15 @@ public class JunglePotion extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "775 Herblore Experience");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.HERBLORE, 775));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
+++ b/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
@@ -256,6 +256,12 @@ public class JunglePotion extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "775 Herblore Experience");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> steps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
+++ b/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
@@ -422,6 +422,12 @@ public class KingsRansom extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "33,000 Defence Experience", "5,000 Magic Experience", "5,000 Experience Lamp (Any skill over 50).");
+	}
+
+	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
+++ b/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
@@ -40,17 +40,19 @@ import com.questhelper.requirements.WidgetModelRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
 import com.questhelper.steps.WidgetStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.text.CollationElementIterator;
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -422,9 +424,30 @@ public class KingsRansom extends BasicQuestHelper
 	}
 
 	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.DEFENCE, 33000),
+				new ExperienceReward(Skill.MAGIC, 5000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("5,000 Experience Lamp (any skill over 50).", ItemID.ANTIQUE_LAMP, 1)); //4447 is Placeholder
+	}
+	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "33,000 Defence Experience", "5,000 Magic Experience", "5,000 Experience Lamp (Any skill over 50).");
+		return Arrays.asList("1 Quest Point", "</br>", "33,000 Defence Experience", "5,000 Magic Experience",
+				"5,000 Experience Lamp (Any skill over 50).");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
+++ b/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
@@ -443,12 +443,6 @@ public class KingsRansom extends BasicQuestHelper
 	{
 		return Collections.singletonList(new ItemReward("5,000 Experience Lamp (any skill over 50).", ItemID.ANTIQUE_LAMP, 1)); //4447 is Placeholder
 	}
-	@Override
-	public List<String> getQuestRewards()
-	{
-		return Arrays.asList("1 Quest Point", "</br>", "33,000 Defence Experience", "5,000 Magic Experience",
-				"5,000 Experience Lamp (Any skill over 50).");
-	}
 
 	@Override
 	public List<Requirement> getGeneralRequirements()

--- a/src/main/java/com/questhelper/quests/lairoftarnrazorlor/LairOfTarnRazorlor.java
+++ b/src/main/java/com/questhelper/quests/lairoftarnrazorlor/LairOfTarnRazorlor.java
@@ -41,6 +41,7 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -324,6 +325,12 @@ public class LairOfTarnRazorlor extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("5,000 Slayer Experience", "</br>", "Tarn's Diary, granting the ability to enchant Salve Amulets.");
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.SLAYER, 5000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/lairoftarnrazorlor/LairOfTarnRazorlor.java
+++ b/src/main/java/com/questhelper/quests/lairoftarnrazorlor/LairOfTarnRazorlor.java
@@ -321,6 +321,12 @@ public class LairOfTarnRazorlor extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("5,000 Slayer Experience", "</br>", "Tarn's Diary, granting the ability to enchant Salve Amulets.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
@@ -48,17 +48,19 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Spellbook;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -945,7 +947,27 @@ public class LegendsQuest extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("4 Quest Points", "</br>", "4 x 7650 Experience Lamps (Choice of Attack, Defence, Strength, Hitpoints, Prayer, Magic, Woodcutting, Crafting, Smithing, Herblore, Agility, Thieving.)");
+		return Arrays.asList("4 Quest Points", "</br>",
+				"4 x 7650 Experience Lamps (Choice of Attack, Defence, Strength, Hitpoints, Prayer, Magic," +
+						" Woodcutting, Crafting, Smithing, Herblore, Agility, Thieving.)");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(4);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("4 x 7,650 Experience Lamps (Choice of Attack, Defence, Strength, Hitpoints, Prayer, Magic, Woodcutting, Crafting, Smithing, Herblore, Agility or Thieving", ItemID.ANTIQUE_LAMP, 4)); //4447 Is placeholder for filtering.
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Kharazi Jungle"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
@@ -943,6 +943,12 @@ public class LegendsQuest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Points", "</br>", "4 x 7650 Experience Lamps (Choice of Attack, Defence, Strength, Hitpoints, Prayer, Magic, Woodcutting, Crafting, Smithing, Herblore, Agility, Thieving.)");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/lostcity/LostCity.java
+++ b/src/main/java/com/questhelper/quests/lostcity/LostCity.java
@@ -38,6 +38,8 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -204,9 +206,19 @@ public class LostCity extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "Access to Zanaris", "Ability to craft Cosmic Runes", "Ability to buy and wield Dragon Longswords & Dragon Daggers.");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Zanaris."),
+				new UnlockReward("Ability to craft Cosmic Runes"),
+				new UnlockReward("Ability to buy and wield Dragon Daggers & Longswords")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/lostcity/LostCity.java
+++ b/src/main/java/com/questhelper/quests/lostcity/LostCity.java
@@ -204,6 +204,12 @@ public class LostCity extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "Access to Zanaris", "Ability to craft Cosmic Runes", "Ability to buy and wield Dragon Longswords & Dragon Daggers.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/src/main/java/com/questhelper/quests/lunardiplomacy/LunarDiplomacy.java
@@ -42,6 +42,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedOwnerStep;
 import com.questhelper.steps.DetailedQuestStep;
@@ -919,9 +923,38 @@ public class LunarDiplomacy extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "5,000 Magic Experience", "5,000 Runecraft Experience", "</br>", "50 x Astral Runes", "</br>", "A Seal of Passage", "Lunar Equipment", "Access to Lunar Island.", "Access to the Lunar Spellbook.", "Access to the Astral Altar.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.MAGIC, 5000),
+				new ExperienceReward(Skill.RUNECRAFT, 5000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("50 x Astral Runes", ItemID.ASTRAL_RUNE, 50),
+				new ItemReward("A Seal of Passage", ItemID.SEAL_OF_PASSAGE, 1),
+				new ItemReward("A set of Lunar Equipment", -1, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Lunar Island"),
+				new UnlockReward("Access to the Lunar Spellbook"),
+				new UnlockReward("Access to the Astral Altar")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/src/main/java/com/questhelper/quests/lunardiplomacy/LunarDiplomacy.java
@@ -919,6 +919,12 @@ public class LunarDiplomacy extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "5,000 Magic Experience", "5,000 Runecraft Experience", "</br>", "50 x Astral Runes", "</br>", "A Seal of Passage", "Lunar Equipment", "Access to Lunar Island.", "Access to the Lunar Spellbook.", "Access to the Astral Altar.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
+++ b/src/main/java/com/questhelper/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
@@ -44,6 +44,9 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -599,9 +602,31 @@ public class MakingFriendsWithMyArm extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "2,000 Construction Experience", "5,000 Firemaking Experience", "10,000 Mining Experience", "10,000 Agility Experience", "</br>", "Access to the Salt Mines.", "Ability to build fire pits.", "Ability to tune a house portal to Troll Stronghold.", "Access to a disease free herb patch in Weis.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CONSTRUCTION, 2000),
+				new ExperienceReward(Skill.FIREMAKING, 5000),
+				new ExperienceReward(Skill.MINING, 10000),
+				new ExperienceReward(Skill.AGILITY, 10000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Salt Mines."),
+				new UnlockReward("Ability to build fire pits"),
+				new UnlockReward("Ability to tune a house portal to Troll Stronghold."),
+				new UnlockReward("Access to a disease free herb patch in Weis.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
+++ b/src/main/java/com/questhelper/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
@@ -599,6 +599,12 @@ public class MakingFriendsWithMyArm extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "2,000 Construction Experience", "5,000 Firemaking Experience", "10,000 Mining Experience", "10,000 Agility Experience", "</br>", "Access to the Salt Mines.", "Ability to build fire pits.", "Ability to tune a house portal to Troll Stronghold.", "Access to a disease free herb patch in Weis.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/makinghistory/MakingHistory.java
+++ b/src/main/java/com/questhelper/quests/makinghistory/MakingHistory.java
@@ -38,6 +38,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.util.ComplexRequirementBuilder;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
 import com.questhelper.requirements.conditional.Conditions;
@@ -55,10 +58,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -275,9 +276,27 @@ public class MakingHistory extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "1,000 Crafting Experience", "1,000 Prayer Experience", "</br>",  "750 Coins", "An Enchanted Key");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 1000),
+				new ExperienceReward(Skill.PRAYER, 1000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("750 Coins", ItemID.COINS_995, 750),
+				new ItemReward("An Enchanted Key", ItemID.ENCHANTED_KEY, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/makinghistory/MakingHistory.java
+++ b/src/main/java/com/questhelper/quests/makinghistory/MakingHistory.java
@@ -275,6 +275,12 @@ public class MakingHistory extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "1,000 Crafting Experience", "1,000 Prayer Experience", "</br>",  "750 Coins", "An Enchanted Key");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/merlinscrystal/MerlinsCrystal.java
+++ b/src/main/java/com/questhelper/quests/merlinscrystal/MerlinsCrystal.java
@@ -39,6 +39,8 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -312,9 +314,15 @@ public class MerlinsCrystal extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("6 Quest Points", "</br>", "Excalibur");
+		return new QuestPointReward(6);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Excalibur", ItemID.EXCALIBUR, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/merlinscrystal/MerlinsCrystal.java
+++ b/src/main/java/com/questhelper/quests/merlinscrystal/MerlinsCrystal.java
@@ -312,6 +312,12 @@ public class MerlinsCrystal extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("6 Quest Points", "</br>", "Excalibur");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/misthalinmystery/MisthalinMystery.java
+++ b/src/main/java/com/questhelper/quests/misthalinmystery/MisthalinMystery.java
@@ -378,6 +378,12 @@ public class MisthalinMystery extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "600 Crafting Experience", "</br>", "Uncut Ruby", "Uncut Emerald", "Uncut Sapphire");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/misthalinmystery/MisthalinMystery.java
+++ b/src/main/java/com/questhelper/quests/misthalinmystery/MisthalinMystery.java
@@ -37,6 +37,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -49,10 +52,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -378,9 +379,25 @@ public class MisthalinMystery extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "600 Crafting Experience", "</br>", "Uncut Ruby", "Uncut Emerald", "Uncut Sapphire");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 600));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("Uncut Ruby", ItemID.UNCUT_RUBY, 1),
+				new ItemReward("Uncut Emerald", ItemID.UNCUT_EMERALD, 1),
+				new ItemReward("Uncut Sapphire", ItemID.UNCUT_SAPPHIRE, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -41,6 +41,10 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -52,10 +56,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.WidgetInfo;
 
@@ -735,7 +737,33 @@ public class MonkeyMadnessI extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "55,000 Combat Experience", "</br>", "10,000 Coins", "3 Diamonds", "</br>", "Ability to buy and wield the Dragon Scimitar.", "Full Access to Ape Atoll.");
+		return Arrays.asList("3 Quest Points", "</br>", "55,000 Combat Experience", "</br>", "10,000 Coins", "3 Diamonds",
+				"</br>", "Ability to buy and wield the Dragon Scimitar.", "Full Access to Ape Atoll.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("55,000 Experience Combat Lamp (Over multiple Skills)", ItemID.ANTIQUE_LAMP, 1), //4447 is placeholder for filter
+				new ItemReward("10,000 Coins", ItemID.COINS_995, 10000),
+				new ItemReward("3 Diamonds", ItemID.DIAMOND, 3)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to purchase and wield the Dragon Scimitar."),
+				new UnlockReward("Full access to Ape Atoll.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -733,6 +733,12 @@ public class MonkeyMadnessI extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "55,000 Combat Experience", "</br>", "10,000 Coins", "3 Diamonds", "</br>", "Ability to buy and wield the Dragon Scimitar.", "Full Access to Ape Atoll.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/monkeymadnessii/MonkeyMadnessII.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessii/MonkeyMadnessII.java
@@ -50,6 +50,10 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -718,10 +722,44 @@ public class MonkeyMadnessII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("4 Quest Points", "</br>", "25,000 Slayer Experience", "20,000 Agility Experience", "15,000 Thieving Experience", "15,000 Hunter Experience", "2 x 50,000 Experience Lamp (Any Combat Skill).", "</br>", "A Royal sead pod", "A pet monkey", "</br>", "Access to Demonic Gorillas.", "New Glider Location.", "Access to bank on Ape Atoll.", "Ability to wield the Heavy Ballista", "Access to Meniacal Monkey Hunting Area");
+		return new QuestPointReward(4);
 	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.SLAYER, 25000),
+				new ExperienceReward(Skill.AGILITY, 20000),
+				new ExperienceReward(Skill.THIEVING, 15000),
+				new ExperienceReward(Skill.HUNTER, 15000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("2 x 50,000 Experience Lamps (Any Combat Skill)", ItemID.ANTIQUE_LAMP, 2), //4447 is placeholder for filter
+				new ItemReward("A Royal Seed Pod", ItemID.ROYAL_SEED_POD, 1),
+				new ItemReward("A pet monkey", ItemID.MONKEY_19556, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Demonic Gorillas"),
+				new UnlockReward("A new Gnome Glider location"),
+				new UnlockReward("Access to a bank on Ape Atoll"),
+				new UnlockReward("Ability to wield the Heavy Ballista"),
+				new UnlockReward("Access to Maniacal Monkey hunting area")
+		);
+	}
+
 
 	@Override
 	public List<Requirement> getGeneralRequirements()

--- a/src/main/java/com/questhelper/quests/monkeymadnessii/MonkeyMadnessII.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessii/MonkeyMadnessII.java
@@ -718,6 +718,12 @@ public class MonkeyMadnessII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Points", "</br>", "25,000 Slayer Experience", "20,000 Agility Experience", "15,000 Thieving Experience", "15,000 Hunter Experience", "2 x 50,000 Experience Lamp (Any Combat Skill).", "</br>", "A Royal sead pod", "A pet monkey", "</br>", "Access to Demonic Gorillas.", "New Glider Location.", "Access to bank on Ape Atoll.", "Ability to wield the Heavy Ballista", "Access to Meniacal Monkey Hunting Area");
+	}
+
+	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/monksfriend/MonksFriend.java
+++ b/src/main/java/com/questhelper/quests/monksfriend/MonksFriend.java
@@ -156,6 +156,12 @@ public class MonksFriend extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,000 Woodcutting Experience", "</br>", "8 Law Runes");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/monksfriend/MonksFriend.java
+++ b/src/main/java/com/questhelper/quests/monksfriend/MonksFriend.java
@@ -34,6 +34,9 @@ import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -48,6 +51,7 @@ import java.util.Map;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -156,9 +160,21 @@ public class MonksFriend extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2,000 Woodcutting Experience", "</br>", "8 Law Runes");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.WOODCUTTING, 2000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("8 Law Runes", ItemID.LAW_RUNE, 8));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
+++ b/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
@@ -400,6 +400,12 @@ public class MountainDaughter extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "1,000 Attack Experience", "2,000 Prayer Experience", "</br>", "A Bearhead", "Access to The Mountain Camp.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
+++ b/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
@@ -40,6 +40,10 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -52,10 +56,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.Skill;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -400,9 +402,30 @@ public class MountainDaughter extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "1,000 Attack Experience", "2,000 Prayer Experience", "</br>", "A Bearhead", "Access to The Mountain Camp.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.ATTACK, 1000),
+				new ExperienceReward(Skill.PRAYER, 2000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Bearhead", ItemID.BEARHEAD, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Mountain Camp"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
+++ b/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
@@ -470,6 +470,12 @@ public class MourningsEndPartI extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "25,000 Thieving Experience", "25,000 Hitpoints Experience", "</br>", "Elf Teleport Crystal", "Access to the Mourner HQ");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
+++ b/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
@@ -32,6 +32,10 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ObjectStep;
@@ -470,9 +474,30 @@ public class MourningsEndPartI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "25,000 Thieving Experience", "25,000 Hitpoints Experience", "</br>", "Elf Teleport Crystal", "Access to the Mourner HQ");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.THIEVING, 25000),
+				new ExperienceReward(Skill.HITPOINTS, 25000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Elven Teleport Crystal", ItemID.TELEPORT_CRYSTAL_4, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Mourner HQ"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/quests/mourningsendpartii/MourningsEndPartII.java
@@ -1011,6 +1011,12 @@ public class MourningsEndPartII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "20,000 Agility Experience", "</br>", "A Crystal Trinket", "A Death Talisman", "</br>", "Access to Dark Beasts", "Ability to craft Death Runes");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/quests/mourningsendpartii/MourningsEndPartII.java
@@ -40,6 +40,10 @@ import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -1013,7 +1017,38 @@ public class MourningsEndPartII extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "20,000 Agility Experience", "</br>", "A Crystal Trinket", "A Death Talisman", "</br>", "Access to Dark Beasts", "Ability to craft Death Runes");
+		return Arrays.asList("2 Quest Points", "</br>", "20,000 Agility Experience", "</br>", "A Crystal Trinket",
+				"A Death Talisman", "</br>", "Access to Dark Beasts", "Ability to craft Death Runes");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.AGILITY, 20000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("A Crystal Trinket", ItemID.CRYSTAL_TRINKET, 1),
+				new ItemReward("A Death Talisman", ItemID.DEATH_TALISMAN, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to craft Death Runes."),
+				new UnlockReward("Ability kill Dark Beasts and receive them as a slayer task.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/murdermystery/MurderMystery.java
+++ b/src/main/java/com/questhelper/quests/murdermystery/MurderMystery.java
@@ -307,6 +307,12 @@ public class MurderMystery extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "1,406 Crafting Experience", "</br>", "2,000 Coins");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/murdermystery/MurderMystery.java
+++ b/src/main/java/com/questhelper/quests/murdermystery/MurderMystery.java
@@ -34,10 +34,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
@@ -307,9 +308,21 @@ public class MurderMystery extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "1,406 Crafting Experience", "</br>", "2,000 Coins");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 1406));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("2,000 Coins", ItemID.COINS_995, 2000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
+++ b/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
@@ -31,6 +31,7 @@ import com.questhelper.Zone;
 import com.questhelper.banktab.BankSlotIcons;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
+import com.questhelper.quests.coldwar.ColdWar;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
@@ -42,17 +43,18 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -473,9 +475,24 @@ public class MyArmsBigAdventure extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "10,000 Herblore Experience", "5,000 Farming Experience", "</br", "Access to a disease-free herb patch on top of the Troll Stronghold.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.HERBLORE, 10000),
+				new ExperienceReward(Skill.FARMING, 5000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to a disease-free herb patch on top of the Troll Stronghold."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
+++ b/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
@@ -473,6 +473,12 @@ public class MyArmsBigAdventure extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "10,000 Herblore Experience", "5,000 Farming Experience", "</br", "Access to a disease-free herb patch on top of the Troll Stronghold.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/naturespirit/NatureSpirit.java
+++ b/src/main/java/com/questhelper/quests/naturespirit/NatureSpirit.java
@@ -318,6 +318,12 @@ public class NatureSpirit extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "3,000 Crafting Experience", "2,000 Defence Experiecne", "2,000 Hitpoints Experience", "</br>", "Access to Mort Myre Swamp", "Ability to fight Ghasts.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/naturespirit/NatureSpirit.java
+++ b/src/main/java/com/questhelper/quests/naturespirit/NatureSpirit.java
@@ -41,6 +41,9 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -320,7 +323,33 @@ public class NatureSpirit extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "3,000 Crafting Experience", "2,000 Defence Experiecne", "2,000 Hitpoints Experience", "</br>", "Access to Mort Myre Swamp", "Ability to fight Ghasts.");
+		return Arrays.asList("2 Quest Points", "</br>", "3,000 Crafting Experience", "2,000 Defence Experiecne",
+				"2,000 Hitpoints Experience", "</br>", "Access to Mort Myre Swamp", "Ability to fight Ghasts.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 3000),
+				new ExperienceReward(Skill.DEFENCE, 2000),
+				new ExperienceReward(Skill.HITPOINTS, 2000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Mort Myre Swamp"),
+				new UnlockReward("Ability to fight Ghasts.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/observatoryquest/ObservatoryQuest.java
+++ b/src/main/java/com/questhelper/quests/observatoryquest/ObservatoryQuest.java
@@ -230,6 +230,12 @@ public class ObservatoryQuest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2,250 Crafting Experience", "</br>", "A Reward depending on which constellation you observed.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/observatoryquest/ObservatoryQuest.java
+++ b/src/main/java/com/questhelper/quests/observatoryquest/ObservatoryQuest.java
@@ -37,6 +37,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -48,11 +51,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.SpriteID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -230,9 +230,21 @@ public class ObservatoryQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "2,250 Crafting Experience", "</br>", "A Reward depending on which constellation you observed.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 2250));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("A reward depending on which constellation you observed."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/olafsquest/OlafsQuest.java
+++ b/src/main/java/com/questhelper/quests/olafsquest/OlafsQuest.java
@@ -43,6 +43,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
@@ -51,11 +55,9 @@ import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
 import com.questhelper.steps.WidgetStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -296,9 +298,27 @@ public class OlafsQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "12,000 Defence Experience", "</br>", "20,000 Coins", "4 x Rubies", "</br>", "Access to Brine Rats and the ability to receive Brine Rats as a slayer task.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.DEFENCE, 12000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("4 x Rubies", ItemID.RUBY, 4));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Brine Rats and the ability to receive them as a slayer task."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/olafsquest/OlafsQuest.java
+++ b/src/main/java/com/questhelper/quests/olafsquest/OlafsQuest.java
@@ -296,6 +296,12 @@ public class OlafsQuest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "12,000 Defence Experience", "</br>", "20,000 Coins", "4 x Rubies", "</br>", "Access to Brine Rats and the ability to receive Brine Rats as a slayer task.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/onesmallfavour/OneSmallFavour.java
+++ b/src/main/java/com/questhelper/quests/onesmallfavour/OneSmallFavour.java
@@ -841,6 +841,12 @@ public class OneSmallFavour extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2 x 10,000 Experience Lamps (Any skill over 30).", "</br>", "A steel keyring.", "The ability to make Guthix Rest tea.", "Gnome Glider in Feldip Hills.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/onesmallfavour/OneSmallFavour.java
+++ b/src/main/java/com/questhelper/quests/onesmallfavour/OneSmallFavour.java
@@ -39,6 +39,9 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -841,9 +844,27 @@ public class OneSmallFavour extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "2 x 10,000 Experience Lamps (Any skill over 30).", "</br>", "A steel keyring.", "The ability to make Guthix Rest tea.", "Gnome Glider in Feldip Hills.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("2 x 10,000 Experience Lamps (Any skill over level 30)", ItemID.ANTIQUE_LAMP, 2), //4447 is placeholder for filter
+				new ItemReward("A Steel Keyring", ItemID.STEEL_KEY_RING, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("The ability to make Guthix Rest tea."),
+				new UnlockReward("Gnome Glider in Feldip Hills.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/piratestreasure/PiratesTreasure.java
+++ b/src/main/java/com/questhelper/quests/piratestreasure/PiratesTreasure.java
@@ -30,6 +30,8 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
@@ -137,9 +139,18 @@ public class PiratesTreasure extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "A Gold Ring", "An Emerald", "450 Coins");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("A Gold Ring", ItemID.GOLD_RING, 1),
+				new ItemReward("450 Coins", ItemID.COINS_995, 450)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/piratestreasure/PiratesTreasure.java
+++ b/src/main/java/com/questhelper/quests/piratestreasure/PiratesTreasure.java
@@ -137,6 +137,12 @@ public class PiratesTreasure extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "A Gold Ring", "An Emerald", "450 Coins");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/plaguecity/PlagueCity.java
+++ b/src/main/java/com/questhelper/quests/plaguecity/PlagueCity.java
@@ -375,6 +375,12 @@ public class PlagueCity extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,425 Mining Experience", "Ability to use Ardougne teleport spell and tablets.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/plaguecity/PlagueCity.java
+++ b/src/main/java/com/questhelper/quests/plaguecity/PlagueCity.java
@@ -36,6 +36,9 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -47,10 +50,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -378,6 +379,24 @@ public class PlagueCity extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("1 Quest Point", "</br>", "2,425 Mining Experience", "Ability to use Ardougne teleport spell and tablets.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.MINING, 2426));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to use Ardougne teleport spell and tablets"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
+++ b/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
@@ -36,6 +36,10 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -50,6 +54,7 @@ import java.util.Map;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -345,6 +350,30 @@ public class PriestInPeril extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("1 Quest Point", "</br>", "1,406 Prayer Experience", "</br>", "Wolfbane Dagger", "</br>", "Access to Canifis and Morytania");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.PRAYER, 1406));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Wolfbane Dagger", ItemID.WOLFBANE, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Canifis and Morytania"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
+++ b/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
@@ -342,6 +342,12 @@ public class PriestInPeril extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,406 Prayer Experience", "</br>", "Wolfbane Dagger", "</br>", "Access to Canifis and Morytania");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/princealirescue/PrinceAliRescue.java
+++ b/src/main/java/com/questhelper/quests/princealirescue/PrinceAliRescue.java
@@ -37,6 +37,9 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -253,9 +256,24 @@ public class PrinceAliRescue extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "700 Coins", "</br>", "Free use of the Al Kharid toll gates", "Access to Sorceress's Garden Minigame (Members)");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("700 Coins", ItemID.COINS_995, 700));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Free use of the Al Kharid toll gates."),
+				new UnlockReward("Access to Sorceress's Garden Minigame (Members)")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/princealirescue/PrinceAliRescue.java
+++ b/src/main/java/com/questhelper/quests/princealirescue/PrinceAliRescue.java
@@ -253,6 +253,12 @@ public class PrinceAliRescue extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "700 Coins", "</br>", "Free use of the Al Kharid toll gates", "Access to Sorceress's Garden Minigame (Members)");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManI.java
+++ b/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManI.java
@@ -38,6 +38,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -52,11 +54,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.SpriteID;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.Subscribe;
@@ -373,6 +372,21 @@ public class RagAndBoneManI extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("1 Quest Point", "</br>", "500 Cooking Experience", "500 Prayer Experience");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 500),
+				new ExperienceReward(Skill.PRAYER, 500)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManI.java
+++ b/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManI.java
@@ -370,6 +370,12 @@ public class RagAndBoneManI extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "500 Cooking Experience", "500 Prayer Experience");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManII.java
@@ -44,6 +44,9 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -883,6 +886,27 @@ public class RagAndBoneManII extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("1 Quest Point", "</br>", "5,000 Prayer Experience", "</br>", "A Bonesack", "A Ram Skull Helm");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.PRAYER, 5000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("A Bonesack", ItemID.BONESACK, 1),
+				new ItemReward("A Ram Skull Helm", ItemID.RAM_SKULL_HELM, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManII.java
@@ -880,6 +880,12 @@ public class RagAndBoneManII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Prayer Experience", "</br>", "A Bonesack", "A Ram Skull Helm");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ratcatchers/RatCatchers.java
+++ b/src/main/java/com/questhelper/quests/ratcatchers/RatCatchers.java
@@ -487,6 +487,12 @@ public class RatCatchers extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "4,500 Thieving Experience", "</br>", "A Rat Pole", "Access to Rat Pits", "Ability to train Overgrown cats into Wily and Lazy Cats.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/ratcatchers/RatCatchers.java
+++ b/src/main/java/com/questhelper/quests/ratcatchers/RatCatchers.java
@@ -42,21 +42,19 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
-import net.runelite.api.SpriteID;
+
+import java.util.*;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -487,9 +485,30 @@ public class RatCatchers extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "4,500 Thieving Experience", "</br>", "A Rat Pole", "Access to Rat Pits", "Ability to train Overgrown cats into Wily and Lazy Cats.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.THIEVING, 4500));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Rat Pole", ItemID.RAT_POLE, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Rat Pits"),
+				new UnlockReward("Ability to train Overgrown Cats into Wiley and Lazy Cats")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDAwowogei.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDAwowogei.java
@@ -43,6 +43,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -290,9 +292,21 @@ public class RFDAwowogei extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<ExperienceReward> getExperienceRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "10,000 Cooking Experience", "10,000 Agility Experience", "</br>", "Ability to teleport to Ape Atoll", "Further access to the Culinaromancer's Chest");
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 10000),
+				new ExperienceReward(Skill.AGILITY, 10000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to teleport to Ape Atoll"),
+				new UnlockReward("Further access to the Culinaromancer's Chest")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDAwowogei.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDAwowogei.java
@@ -289,6 +289,11 @@ public class RFDAwowogei extends BasicQuestHelper
 		return req;
 	}
 
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "10,000 Cooking Experience", "10,000 Agility Experience", "</br>", "Ability to teleport to Ape Atoll", "Further access to the Culinaromancer's Chest");
+	}
 
 	@Override
 	public List<PanelDetails> getPanels()

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
@@ -245,6 +245,12 @@ public class RFDDwarf extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "1,000 Cooking Experience", "1,000 Slayer Experience", "</br>", "A Dwarven Rock Cake", "Increased access to the Culinaromancer's Chest");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
@@ -39,6 +39,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -51,11 +55,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.Client;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -245,9 +246,30 @@ public class RFDDwarf extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "1,000 Cooking Experience", "1,000 Slayer Experience", "</br>", "A Dwarven Rock Cake", "Increased access to the Culinaromancer's Chest");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 1000),
+				new ExperienceReward(Skill.SLAYER, 1000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Dwarven Rock Cake", ItemID.DWARVEN_ROCK_CAKE, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Increased access to the Culinaromancer's Chest"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDEvilDave.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDEvilDave.java
@@ -188,6 +188,12 @@ public class RFDEvilDave extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "7,000 Cooking Experience", "</br>", "The ability to catch hell rats.", "The ability to make spicy stew.", "The ability to own a hell-cat", "Further access to the Culinaromancer's Chest.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDEvilDave.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDEvilDave.java
@@ -40,20 +40,17 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import net.runelite.api.Client;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import java.util.*;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -188,9 +185,26 @@ public class RFDEvilDave extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "7,000 Cooking Experience", "</br>", "The ability to catch hell rats.", "The ability to make spicy stew.", "The ability to own a hell-cat", "Further access to the Culinaromancer's Chest.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.COOKING, 7000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to catch Hell Rats"),
+				new UnlockReward("Ability to make spicy stews"),
+				new UnlockReward("Ability to own a hell-cat"),
+				new UnlockReward("Further access to the Culinaromancer's Chest")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
@@ -39,15 +39,16 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -176,9 +177,21 @@ public class RFDFinal extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "20,000 Experience Lamp (Any Skill over level 50)", "</br>", "Full access to the Culinaromancer's Chest");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("20,000 Experience Lamp (Any skill over level 50)", ItemID.ANTIQUE_LAMP, 1)); //4447 is placeholder for filter
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Full access to the Culinaromancer's Chest"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
@@ -176,6 +176,12 @@ public class RFDFinal extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "20,000 Experience Lamp (Any Skill over level 50)", "</br>", "Full access to the Culinaromancer's Chest");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDGoblins.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDGoblins.java
@@ -43,6 +43,8 @@ import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
+
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -254,7 +256,12 @@ public class RFDGoblins extends BasicQuestHelper
 		reqs.add(new QuestRequirement(QuestHelperQuest.GOBLIN_DIPLOMACY, QuestState.FINISHED));
 
 		return reqs;
+	}
 
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,000 Cooking Experience", "1,000 Farming Experience", "1,000 Crafting Experience", "</br>", "Further access to the Culinaromancer's Chest");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDGoblins.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDGoblins.java
@@ -38,6 +38,9 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -45,16 +48,9 @@ import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import net.runelite.api.Client;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+import java.util.*;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -259,9 +255,25 @@ public class RFDGoblins extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,000 Cooking Experience", "1,000 Farming Experience", "1,000 Crafting Experience", "</br>", "Further access to the Culinaromancer's Chest");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 1000),
+				new ExperienceReward(Skill.FARMING, 1000),
+				new ExperienceReward(Skill.CRAFTING, 1000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Further access to the Culinaromancer's Chest"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDLumbridgeGuide.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDLumbridgeGuide.java
@@ -176,6 +176,12 @@ public class RFDLumbridgeGuide extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,500 Cooking Experience", "2,500 Magic Experience", "</br>", "Further Access to the Culinaromancer's Chest.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDLumbridgeGuide.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDLumbridgeGuide.java
@@ -33,19 +33,21 @@ import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.quest.QuestPointRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
 import com.questhelper.requirements.conditional.Conditions;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.ObjectID;
@@ -176,9 +178,24 @@ public class RFDLumbridgeGuide extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "2,500 Cooking Experience", "2,500 Magic Experience", "</br>", "Further Access to the Culinaromancer's Chest.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 2500),
+				new ExperienceReward(Skill.MAGIC, 2500)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Further access to the Culinaromancer's Chest"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDPiratePete.java
@@ -43,6 +43,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -320,9 +324,35 @@ public class RFDPiratePete extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,000 Cooking Experience", "1,000 Crafting Experience", "1,000 Fishing Experience", "1,000 Smithing Experience", "</br>", "Diving apparatus", "Access to Mogre Camp", "Increased access to the Culinaromancer's Chest");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 1000),
+				new ExperienceReward(Skill.CRAFTING, 1000),
+				new ExperienceReward(Skill.FISHING, 1000),
+				new ExperienceReward(Skill.SMITHING, 1000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Diving Apparatus", ItemID.DIVING_APPARATUS, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Mogre Camp"),
+				new UnlockReward("Increased access to the Culinaromancer's Chest")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDPiratePete.java
@@ -320,6 +320,12 @@ public class RFDPiratePete extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,000 Cooking Experience", "1,000 Crafting Experience", "1,000 Fishing Experience", "1,000 Smithing Experience", "</br>", "Diving apparatus", "Access to Mogre Camp", "Increased access to the Culinaromancer's Chest");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
@@ -350,6 +350,12 @@ public class RFDSirAmikVarze extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "4,000 Cooking Experience", "4,000 Hitpoints Experience", "</br>", "Access to the Evil Chicken's Lair", "Further access to the Culinaromancer's Chest");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
@@ -42,6 +42,9 @@ import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -55,12 +58,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.Client;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.Player;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -350,9 +349,27 @@ public class RFDSirAmikVarze extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "4,000 Cooking Experience", "4,000 Hitpoints Experience", "</br>", "Access to the Evil Chicken's Lair", "Further access to the Culinaromancer's Chest");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 4000),
+				new ExperienceReward(Skill.HITPOINTS, 4000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Evil Chickens Lair"),
+				new UnlockReward("Further acces to the Culinaromancer's Chest")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSkrachUglogwee.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSkrachUglogwee.java
@@ -40,6 +40,9 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -256,7 +259,36 @@ public class RFDSkrachUglogwee extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,500 Woodcutting Experience", "1,500 Cooking Experience", "1,500 Crafting Experience", "1,500 Ranged Experience", "</br>", "New method of travel between Karamja and Feldip Hills.", "Further access to the Culinaromancer's Chest.");
+		return Arrays.asList("1 Quest Point", "</br>", "1,500 Woodcutting Experience",
+				"1,500 Cooking Experience", "1,500 Crafting Experience", "1,500 Ranged Experience",
+				"</br>", "New method of travel between Karamja and Feldip Hills.",
+				"Further access to the Culinaromancer's Chest.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.WOODCUTTING, 1500),
+				new ExperienceReward(Skill.COOKING, 1500),
+				new ExperienceReward(Skill.CRAFTING, 1500),
+				new ExperienceReward(Skill.RANGED, 1500)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("New method of travel between Karamja and Feldip Hills."),
+				new UnlockReward("Increased access to the Culinaromancer's Chest.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSkrachUglogwee.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSkrachUglogwee.java
@@ -254,6 +254,12 @@ public class RFDSkrachUglogwee extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,500 Woodcutting Experience", "1,500 Cooking Experience", "1,500 Crafting Experience", "1,500 Ranged Experience", "</br>", "New method of travel between Karamja and Feldip Hills.", "Further access to the Culinaromancer's Chest.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDStart.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDStart.java
@@ -139,6 +139,12 @@ public class RFDStart extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "Access to the Culinaromancer's Chest");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDStart.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDStart.java
@@ -31,19 +31,20 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.requirements.quest.QuestPointRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -139,9 +140,15 @@ public class RFDStart extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "Access to the Culinaromancer's Chest");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Culinaromancer's Chest"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recruitmentdrive/RecruitmentDrive.java
+++ b/src/main/java/com/questhelper/quests/recruitmentdrive/RecruitmentDrive.java
@@ -385,6 +385,12 @@ public class RecruitmentDrive extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,000 Prayer Experience", "1,000 Agility Experience", "1,000 Herblore Experience", "</br>", "Initiate Helm", "3000 Coins & A Makeover Voucher (If Male when starting Quest)", "</br>", "Ability to respawn at Falador.", "Access to Initiate Armor");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> steps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/recruitmentdrive/RecruitmentDrive.java
+++ b/src/main/java/com/questhelper/quests/recruitmentdrive/RecruitmentDrive.java
@@ -41,6 +41,10 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.ItemSlots;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -52,10 +56,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.QuestState;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -387,7 +389,45 @@ public class RecruitmentDrive extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,000 Prayer Experience", "1,000 Agility Experience", "1,000 Herblore Experience", "</br>", "Initiate Helm", "3000 Coins & A Makeover Voucher (If Male when starting Quest)", "</br>", "Ability to respawn at Falador.", "Access to Initiate Armor");
+		return Arrays.asList("1 Quest Point", "</br>", "1,000 Prayer Experience", "1,000 Agility Experience",
+				"1,000 Herblore Experience", "</br>", "Initiate Helm",
+				"3000 Coins & A Makeover Voucher (If Male when starting Quest)", "</br>",
+				"Ability to respawn at Falador.", "Access to Initiate Armor");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.PRAYER, 1000),
+				new ExperienceReward(Skill.AGILITY, 1000),
+				new ExperienceReward(Skill.HERBLORE, 1000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("Initiate Helm", ItemID.INITIATE_SALLET, 1),
+				new ItemReward("3000 Coins", ItemID.COINS_995, 3000),
+				new ItemReward("Makeover Voucher (If male when starting quest)", ItemID.MAKEOVER_VOUCHER, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to respawn in Falador"),
+				new UnlockReward("Access to Initiate Armor")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/regicide/Regicide.java
+++ b/src/main/java/com/questhelper/quests/regicide/Regicide.java
@@ -75,7 +75,7 @@ public class Regicide extends BasicQuestHelper
 		barrelBombFused, barrelBombUnfused, iorwerthsMessage;
 
 	//Items Recommended
-	ItemRequirement food, staminaPotions, coins, antipoisons, faladorTeleport, westArdougneTeleport, summerPie;
+	ItemRequirement food, staminaPotions, coins, antipoisons, faladorTeleport, westArdougneTeleport, summerPie, axe;
 
 	Requirement inCastleFloor2, inWestArdougne, isBeforeRockslide1, isBeforeRockslide2, isBeforeRockslide3,
 		isBeforeBridge, isNorthEastOfBridge, haveOilyCloth, haveFireArrow, haveLitArrow, haveLitArrowEquipped,
@@ -247,7 +247,8 @@ public class Regicide extends BasicQuestHelper
 		limestone = new ItemRequirement("Limestone", ItemID.LIMESTONE);
 		limestone.setTooltip("You can mine some in the mine north of the Digsite");
 		stripOfCloth = new ItemRequirement("Strip of cloth", ItemID.STRIP_OF_CLOTH);
-		stripOfCloth.setTooltip("Made on a loom with 4 balls of wool");
+		stripOfCloth.setTooltip("Made on a loom with 4 balls of wool.");
+		stripOfCloth.appendToTooltip("There is a loom available at the Falador Farm");
 		pestle = new ItemRequirement("Pestle and mortar", ItemID.PESTLE_AND_MORTAR);
 		gloves = new ItemRequirement("Gloves which fully cover your hand", ItemID.LEATHER_GLOVES);
 		gloves.addAlternates(ItemID.BARROWS_GLOVES, ItemID.DRAGON_GLOVES, ItemID.RUNE_GLOVES, ItemID.ADAMANT_GLOVES, ItemID.MITHRIL_GLOVES,
@@ -255,12 +256,14 @@ public class Regicide extends BasicQuestHelper
 			ItemID.FEROCIOUS_GLOVES, ItemID.GRACEFUL_GLOVES, ItemID.GRANITE_GLOVES);
 		gloves.setTooltip("The following gloves are valid:");
 		gloves.appendToTooltip("All RFD Gloves");
-		gloves.appendToTooltip("Hard Leather Gloves");
+		gloves.appendToTooltip("Leather Gloves");
 		gloves.appendToTooltip("Ferocious Gloves");
 		gloves.appendToTooltip("Graceful Gloves");
 		gloves.appendToTooltip("Granite Gloves");
 		pot = new ItemRequirement("Pot", ItemID.POT);
-		cookedRabbit =  new ItemRequirement("Cooked rabbit", ItemID.COOKED_RABBIT);
+		cookedRabbit =  new ItemRequirement("Cooked rabbit (Obtainable during quest)", ItemID.COOKED_RABBIT);
+		cookedRabbit.setTooltip("Raw Rabbit can be killed around Isafdar or purchased from the");
+		cookedRabbit.appendToTooltip(" Charter Ship near the Tyras Camp for 50gp.");
 
 		antipoisons = new ItemRequirement("Antidotes/antipoisons", ItemCollections.getAntipoisons(), -1);
 		antipoisons.setTooltip("No amount specified. Bring as many doses as you feel comfortable bringing.");
@@ -269,6 +272,7 @@ public class Regicide extends BasicQuestHelper
 		summerPie = new ItemRequirement("Summer pie as food + agility boost", ItemID.SUMMER_PIE, -1);
 		summerPie.addAlternates(ItemID.HALF_A_SUMMER_PIE);
 		summerPie.setTooltip("This is, most likely, not needed if you have 70+ Agility. Bring more if you have lower Agility.");
+		axe = new ItemRequirement("An Axe to cook raw rabbit in case you fail too many obstacles.", ItemCollections.getAxes(), 1);
 
 		crystalPendant = new ItemRequirement("Crystal pendant", ItemID.CRYSTAL_PENDANT);
 		crystalPendant.setTooltip("You can get another from Lord Iorwerth");

--- a/src/main/java/com/questhelper/quests/regicide/Regicide.java
+++ b/src/main/java/com/questhelper/quests/regicide/Regicide.java
@@ -41,6 +41,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -900,9 +904,33 @@ public class Regicide extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("3 Quest Points", "</br>", "13,750 Agility Experience", "</br>", "15,000 Coins", "</br>", "Access to Tirannwn & Arandar", "Ability to wield the Dragon Halberd", "Ability to charter a ship to Port Tyras.", "The ability to use Iorwerth camp teleport scrolls.", "The ability to use Zul-Andra teleport scrolls and battle Zulrah.");
+		return new QuestPointReward(3);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.AGILITY, 13750));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("15,000 Coins", ItemID.COINS_995, 15000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Tirannwn & Arandar"),
+				new UnlockReward("Ability to wield the Dragon Halberd"),
+				new UnlockReward("Ability to charter a ship to Port Tyras."),
+				new UnlockReward("Ability to use Iorwerth Camp teleport scrolls."),
+				new UnlockReward("Ability to use Zul-Andra teleport scrolls and battle Zulrah.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/regicide/Regicide.java
+++ b/src/main/java/com/questhelper/quests/regicide/Regicide.java
@@ -896,6 +896,12 @@ public class Regicide extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "13,750 Agility Experience", "</br>", "15,000 Coins", "</br>", "Access to Tirannwn & Arandar", "Ability to wield the Dragon Halberd", "Ability to charter a ship to Port Tyras.", "The ability to use Iorwerth camp teleport scrolls.", "The ability to use Zul-Andra teleport scrolls and battle Zulrah.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/romeoandjuliet/RomeoAndJuliet.java
+++ b/src/main/java/com/questhelper/quests/romeoandjuliet/RomeoAndJuliet.java
@@ -29,6 +29,7 @@ import com.questhelper.Zone;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
@@ -145,9 +146,9 @@ public class RomeoAndJuliet extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("5 Quest Points");
+		return new QuestPointReward(5);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/romeoandjuliet/RomeoAndJuliet.java
+++ b/src/main/java/com/questhelper/quests/romeoandjuliet/RomeoAndJuliet.java
@@ -145,6 +145,12 @@ public class RomeoAndJuliet extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("5 Quest Points");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/rovingelves/RovingElves.java
+++ b/src/main/java/com/questhelper/quests/rovingelves/RovingElves.java
@@ -230,6 +230,12 @@ public class RovingElves extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "10,000 Strength Experience", "</br>", "A used Crystal Shield or Crystal Bow");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/rovingelves/RovingElves.java
+++ b/src/main/java/com/questhelper/quests/rovingelves/RovingElves.java
@@ -39,6 +39,9 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -230,9 +233,24 @@ public class RovingElves extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "10,000 Strength Experience", "</br>", "A used Crystal Shield or Crystal Bow");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.STRENGTH, 10000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("A used Crystal Shield", ItemID.CRYSTAL_SHIELD, 1),
+				new ItemReward("or Crystal Bow", ItemID.CRYSTAL_BOW, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/royaltrouble/RoyalTrouble.java
+++ b/src/main/java/com/questhelper/quests/royaltrouble/RoyalTrouble.java
@@ -41,17 +41,18 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -612,7 +613,30 @@ public class RoyalTrouble extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "5,000 Agility Experience", "5,000 Slayer Experience", "5,000 Hitpoints Experience", "</br>", "Enhanced rewards from Managing Miscellania.");
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Agility Experience", "5,000 Slayer Experience",
+				"5,000 Hitpoints Experience", "</br>", "Enhanced rewards from Managing Miscellania.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.AGILITY, 5000),
+				new ExperienceReward(Skill.SLAYER, 5000),
+				new ExperienceReward(Skill.HITPOINTS, 5000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Increased rewards from Managing Miscellania"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/royaltrouble/RoyalTrouble.java
+++ b/src/main/java/com/questhelper/quests/royaltrouble/RoyalTrouble.java
@@ -610,6 +610,12 @@ public class RoyalTrouble extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Agility Experience", "5,000 Slayer Experience", "5,000 Hitpoints Experience", "</br>", "Enhanced rewards from Managing Miscellania.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/rumdeal/RumDeal.java
+++ b/src/main/java/com/questhelper/quests/rumdeal/RumDeal.java
@@ -445,6 +445,12 @@ public class RumDeal extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "7,000 Fishing Experience", "7,000 Prayer Experience", "7,000 Farming Experience", "</br>", "A Holy Wrench");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/rumdeal/RumDeal.java
+++ b/src/main/java/com/questhelper/quests/rumdeal/RumDeal.java
@@ -42,17 +42,18 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -445,9 +446,25 @@ public class RumDeal extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "7,000 Fishing Experience", "7,000 Prayer Experience", "7,000 Farming Experience", "</br>", "A Holy Wrench");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.FISHING, 7000),
+				new ExperienceReward(Skill.PRAYER, 7000),
+				new ExperienceReward(Skill.FARMING, 7000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("A Holy Wrench", ItemID.HOLY_WRENCH, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/runemysteries/RuneMysteries.java
+++ b/src/main/java/com/questhelper/quests/runemysteries/RuneMysteries.java
@@ -30,18 +30,20 @@ import com.questhelper.QuestHelperQuest;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
+import com.questhelper.quests.coldwar.ColdWar;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -151,9 +153,24 @@ public class RuneMysteries extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "Air talisman", "</br>", "Ability to use Runecrafting Skill.", "Ability to mine Rune and Pure Essence");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Air Talisman", ItemID.AIR_TALISMAN, 1));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to use Runecrafting Skill."),
+				new UnlockReward("Ability to mine Rune and Pure Essence.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/runemysteries/RuneMysteries.java
+++ b/src/main/java/com/questhelper/quests/runemysteries/RuneMysteries.java
@@ -151,6 +151,12 @@ public class RuneMysteries extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "Air talisman", "</br>", "Ability to use Runecrafting Skill.", "Ability to mine Rune and Pure Essence");
+	}
+
+	@Override
 	public List<ItemRequirement> getItemRecommended()
 	{
 		ArrayList<ItemRequirement> reqs = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/scorpioncatcher/ScorpionCatcher.java
+++ b/src/main/java/com/questhelper/quests/scorpioncatcher/ScorpionCatcher.java
@@ -15,6 +15,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
@@ -264,7 +267,26 @@ public class ScorpionCatcher extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "6,625 Strength Experience", "</br>", "Ability to have Thormac turn a battlestaff into a mystic staff for 40,000 coins.");
+		return Arrays.asList("1 Quest Point", "</br>", "6,625 Strength Experience", "</br>",
+				"Ability to have Thormac turn a battlestaff into a mystic staff for 40,000 coins.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.STRENGTH, 6625));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to have Thormac turn a Battlestaff into a Mystic Staff for 40,000 Coins."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/scorpioncatcher/ScorpionCatcher.java
+++ b/src/main/java/com/questhelper/quests/scorpioncatcher/ScorpionCatcher.java
@@ -20,11 +20,9 @@ import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -261,6 +259,12 @@ public class ScorpionCatcher extends BasicQuestHelper
 	public ArrayList<String> getCombatRequirements()
 	{
 		return new ArrayList<>(Collections.singletonList("The ability to run past level 172 black demons and level 64 poison spiders"));
+	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "6,625 Strength Experience", "</br>", "Ability to have Thormac turn a battlestaff into a mystic staff for 40,000 coins.");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/seaslug/SeaSlug.java
+++ b/src/main/java/com/questhelper/quests/seaslug/SeaSlug.java
@@ -252,6 +252,12 @@ public class SeaSlug extends BasicQuestHelper
 	{
 		return Collections.singletonList(new SkillRequirement(Skill.FIREMAKING, 30, true));
 	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "7,125 Fishing Experience", "</br>", "Access to the Fishing Platform");
+	}
 	
 	@Override
 	public List<PanelDetails> getPanels()

--- a/src/main/java/com/questhelper/quests/seaslug/SeaSlug.java
+++ b/src/main/java/com/questhelper/quests/seaslug/SeaSlug.java
@@ -35,6 +35,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -254,11 +257,23 @@ public class SeaSlug extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "7,125 Fishing Experience", "</br>", "Access to the Fishing Platform");
+		return new QuestPointReward(1);
 	}
-	
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.FISHING, 7125));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to the Fishing Platform"));
+	}
+
 	@Override
 	public List<PanelDetails> getPanels()
 	{

--- a/src/main/java/com/questhelper/quests/shadesofmortton/ShadesOfMortton.java
+++ b/src/main/java/com/questhelper/quests/shadesofmortton/ShadesOfMortton.java
@@ -36,6 +36,9 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -327,7 +330,29 @@ public class ShadesOfMortton extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("3 Quest Point", "</br>", "2,000 Crafting Experience", "2,000 Herblore Experience", "</br>", "Ability to play the Shades of Mort'ton minigame.");
+		return Arrays.asList("3 Quest Point", "</br>", "2,000 Crafting Experience", "2,000 Herblore Experience",
+				"</br>", "Ability to play the Shades of Mort'ton minigame.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.CRAFTING, 2000),
+				new ExperienceReward(Skill.HERBLORE, 2000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to play the Shades of Mort'ton Minigame"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shadesofmortton/ShadesOfMortton.java
+++ b/src/main/java/com/questhelper/quests/shadesofmortton/ShadesOfMortton.java
@@ -325,6 +325,12 @@ public class ShadesOfMortton extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Point", "</br>", "2,000 Crafting Experience", "2,000 Herblore Experience", "</br>", "Ability to play the Shades of Mort'ton minigame.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -40,6 +40,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedOwnerStep;
 import com.questhelper.steps.DetailedQuestStep;
@@ -363,7 +365,23 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "10,000 Experience Lamp (Any combat skill except Prayer)", "</br>", "Darklight", "Six Cut Gems if you use a chisel on the demon's throne.");
+		return Arrays.asList("1 Quest Point", "</br>", "10,000 Experience Lamp (Any combat skill except Prayer)",
+				"</br>", "Darklight", "Six Cut Gems if you use a chisel on the demon's throne.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("10,000 Experience Lamp (Any combat skill except Prayer)", ItemID.ANTIQUE_LAMP, 1), //4447 is placeholder for filter
+				new ItemReward("Darklight", ItemID.DARKLIGHT, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -361,6 +361,12 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "10,000 Experience Lamp (Any combat skill except Prayer)", "</br>", "Darklight", "Six Cut Gems if you use a chisel on the demon's throne.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/sheepherder/SheepHerder.java
+++ b/src/main/java/com/questhelper/quests/sheepherder/SheepHerder.java
@@ -245,6 +245,12 @@ public class SheepHerder extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Point", "</br>", "3,100 Coins");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/sheepherder/SheepHerder.java
+++ b/src/main/java/com/questhelper/quests/sheepherder/SheepHerder.java
@@ -38,6 +38,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -245,9 +247,15 @@ public class SheepHerder extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("4 Quest Point", "</br>", "3,100 Coins");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("3,180 Coins", ItemID.COINS_995, 3180));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/sheepshearer/SheepShearer.java
+++ b/src/main/java/com/questhelper/quests/sheepshearer/SheepShearer.java
@@ -26,12 +26,16 @@ package com.questhelper.quests.sheepshearer;
 
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.panel.PanelDetails;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.NpcStep;
 
 import java.util.*;
 
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
@@ -140,9 +144,21 @@ public class SheepShearer extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "150 Crafting Experience", "</br>", "60 Coins");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 150));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("60 Coins", ItemID.COINS_995, 60));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/sheepshearer/SheepShearer.java
+++ b/src/main/java/com/questhelper/quests/sheepshearer/SheepShearer.java
@@ -27,9 +27,9 @@ package com.questhelper.quests.sheepshearer;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.steps.NpcStep;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
@@ -37,9 +37,6 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.SHEEP_SHEARER
@@ -140,6 +137,12 @@ public class SheepShearer extends BasicQuestHelper
 		reqs.add(twentyBallsOfWool);
 		reqs.add(shears);
 		return reqs;
+	}
+
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "150 Crafting Experience", "</br>", "60 Coins");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
+++ b/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
@@ -36,6 +36,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -201,9 +203,15 @@ public class ShieldOfArravBlackArmGang extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "600 Coins");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("600 Coins", ItemID.COINS_995, 600));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
+++ b/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
@@ -201,6 +201,12 @@ public class ShieldOfArravBlackArmGang extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "600 Coins");
+	}
+
+	@Override
 	public boolean isCompleted()
 	{
 		boolean partComplete = super.isCompleted();

--- a/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
+++ b/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
@@ -28,6 +28,8 @@ import com.questhelper.QuestHelperQuest;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -207,9 +209,15 @@ public class ShieldOfArravPhoenixGang extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "600 Coins");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("600 Coins", ItemID.COINS_995, 600));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
+++ b/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
@@ -207,6 +207,12 @@ public class ShieldOfArravPhoenixGang extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "600 Coins");
+	}
+
+	@Override
 	public boolean isCompleted()
 	{
 		boolean partComplete = super.isCompleted();

--- a/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
+++ b/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
@@ -397,6 +397,12 @@ public class ShiloVillage extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Point", "</br>", "3,875 Crafting Experience", "</br>", "Access to Shilo Village", "Ability to mine the gem rocks in Shilo Village");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
+++ b/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
@@ -46,6 +46,9 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -397,9 +400,24 @@ public class ShiloVillage extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Point", "</br>", "3,875 Crafting Experience", "</br>", "Access to Shilo Village", "Ability to mine the gem rocks in Shilo Village");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 3875));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Shilo Village"),
+				new UnlockReward("Ability to mine gem rocks in Shilo Village")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
+++ b/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
@@ -857,6 +857,12 @@ public class SinsOfTheFather extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Point", "</br>", "3 x 15,000 Experience Tomes (Any skill above 60)", "</br>", "A Blisterwood Flail", "</br>", "Access to Darkmeyer and the Daeyalt Essence Mine", "Darkmeyer teleport via Drakan's Medallion.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
+++ b/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
@@ -40,6 +40,9 @@ import com.questhelper.requirements.player.InInstanceRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.WidgetTextRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -50,10 +53,9 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.Operation;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -61,8 +63,6 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-
-import java.util.HashMap;
 
 @QuestDescriptor(
         quest = QuestHelperQuest.SINS_OF_THE_FATHER
@@ -857,9 +857,27 @@ public class SinsOfTheFather extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Point", "</br>", "3 x 15,000 Experience Tomes (Any skill above 60)", "</br>", "A Blisterwood Flail", "</br>", "Access to Darkmeyer and the Daeyalt Essence Mine", "Darkmeyer teleport via Drakan's Medallion.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("3 x 15,000 Experince Tomes (Any skill above 60)", ItemID.ANTIQUE_LAMP, 3), //4447 is placeholder for filter
+				new ItemReward("A Blisterwood Flail", ItemID.BLISTERWOOD_FLAIL, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Darkmeyer and the Daeyalt Essence Mine"),
+				new UnlockReward("Darkmeyer teleport via Drakan's Medallion.")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/skippyandthemogres/SkippyAndTheMogres.java
+++ b/src/main/java/com/questhelper/quests/skippyandthemogres/SkippyAndTheMogres.java
@@ -32,6 +32,7 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -135,9 +136,12 @@ public class SkippyAndTheMogres extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public List<UnlockReward> getUnlockRewards()
 	{
-		return Arrays.asList("Ability to kill Mogres", "</br>", "Ability to recieve Mogres as a Slayer task.");
+		return Arrays.asList(
+				new UnlockReward("Ability to kill Mogres"),
+				new UnlockReward("Ability to recieve Mogres as a Slayer task")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/skippyandthemogres/SkippyAndTheMogres.java
+++ b/src/main/java/com/questhelper/quests/skippyandthemogres/SkippyAndTheMogres.java
@@ -135,6 +135,12 @@ public class SkippyAndTheMogres extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("Ability to kill Mogres", "</br>", "Ability to recieve Mogres as a Slayer task.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
+++ b/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
@@ -1428,6 +1428,12 @@ public class SongOfTheElves extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Point", "</br>", "20,000 Agility Experience", "20,000 Contruction Experience", "20,000 Farming Experience", "20,000 Herblore Experience", "20,000 Mining Experience", "20,000 Smithing Experience", "20,000 Woodcutting Experience", "</br>", "Access to Prifddinas:", "</br>", "Ability to fight Zalcano", "Access to The Gauntlet", "Access to Trahaearn Mine.", "Access to Iorwerth Dungeon.", "Ability to respawn at Prifddinas.", "Ability to move POH to Prifddinas.", "Prifddinas Teleport added to Crystal Teleport Seed.", "Ability to make Divine Potions", "Ability to make crystal tools, weapons and armor.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels() {
 		List<PanelDetails> allSteps = new ArrayList<>();
 		allSteps.add(new PanelDetails("Starting off", Arrays.asList(talkToEdmond, talkToLathas, talkToEdmondAgain, talkToAlrena,

--- a/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
+++ b/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
@@ -43,6 +43,9 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.ItemSlots;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
@@ -1428,9 +1431,51 @@ public class SongOfTheElves extends BasicQuestHelper
 	}
 
 	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(4);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.AGILITY, 20000),
+				new ExperienceReward(Skill.CONSTRUCTION, 20000),
+				new ExperienceReward(Skill.CONSTRUCTION, 20000),
+				new ExperienceReward(Skill.FARMING, 20000),
+				new ExperienceReward(Skill.HERBLORE, 20000),
+				new ExperienceReward(Skill.MINING, 20000),
+				new ExperienceReward(Skill.SMITHING, 20000),
+				new ExperienceReward(Skill.WOODCUTTING, 20000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to Prifddinas"),
+				new UnlockReward("Ability to fight Zalcano"),
+				new UnlockReward("Access to The Gauntlet"),
+				new UnlockReward("Access to Trahaearn Mine"),
+				new UnlockReward("Access to Iorwerth Dungeon"),
+				new UnlockReward("Ability to respawn at Prifddinas"),
+				new UnlockReward("Ability to move POH to Prifddinas"),
+				new UnlockReward("Prifddinas Teleport added to Crystal Teleport Seed"),
+				new UnlockReward("Ability to make Divine Potions"),
+				new UnlockReward("Ability to make Crystal Tools, Weapons and Armor")
+		);
+	}
+
+	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("4 Quest Point", "</br>", "20,000 Agility Experience", "20,000 Contruction Experience", "20,000 Farming Experience", "20,000 Herblore Experience", "20,000 Mining Experience", "20,000 Smithing Experience", "20,000 Woodcutting Experience", "</br>", "Access to Prifddinas:", "</br>", "Ability to fight Zalcano", "Access to The Gauntlet", "Access to Trahaearn Mine.", "Access to Iorwerth Dungeon.", "Ability to respawn at Prifddinas.", "Ability to move POH to Prifddinas.", "Prifddinas Teleport added to Crystal Teleport Seed.", "Ability to make Divine Potions", "Ability to make crystal tools, weapons and armor.");
+		return Arrays.asList("Access to Prifddinas:", "</br>", "Ability to fight Zalcano",
+				"Access to The Gauntlet", "Access to Trahaearn Mine.", "Access to Iorwerth Dungeon.",
+				"Ability to respawn at Prifddinas.", "Ability to move POH to Prifddinas.",
+				"Prifddinas Teleport added to Crystal Teleport Seed.", "Ability to make Divine Potions",
+				"Ability to make crystal tools, weapons and armor.");
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/spiritsoftheelid/SpiritsOfTheElid.java
+++ b/src/main/java/com/questhelper/quests/spiritsoftheelid/SpiritsOfTheElid.java
@@ -327,6 +327,12 @@ public class SpiritsOfTheElid extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Point", "</br>", " 8,000 Prayer Experience", "1,000 Thieving Experience", "1,000 Magic Experience", "</br>", "Access to Nardah's fountain and shrine.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/spiritsoftheelid/SpiritsOfTheElid.java
+++ b/src/main/java/com/questhelper/quests/spiritsoftheelid/SpiritsOfTheElid.java
@@ -39,16 +39,17 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -329,7 +330,31 @@ public class SpiritsOfTheElid extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("2 Quest Point", "</br>", " 8,000 Prayer Experience", "1,000 Thieving Experience", "1,000 Magic Experience", "</br>", "Access to Nardah's fountain and shrine.");
+		return Arrays.asList("2 Quest Point", "</br>", " 8,000 Prayer Experience",
+				"1,000 Thieving Experience", "1,000 Magic Experience", "</br>",
+				"Access to Nardah's fountain and shrine.");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.PRAYER, 8000),
+				new ExperienceReward(Skill.THIEVING, 1000),
+				new ExperienceReward(Skill.MAGIC, 1000)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Nardah's Fountain and Shrine"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/swansong/SwanSong.java
+++ b/src/main/java/com/questhelper/quests/swansong/SwanSong.java
@@ -42,16 +42,18 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -316,6 +318,37 @@ public class SwanSong extends BasicQuestHelper
 	public List<String> getQuestRewards()
 	{
 		return Arrays.asList("2 Quest Point", "</br>", "15,000 Magic Experience", "</br>", "");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.MAGIC, 15000),
+				new ExperienceReward(Skill.PRAYER, 10000),
+				new ExperienceReward(Skill.FISHING, 10000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("25,000 Coins", ItemID.COINS_995, 25000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Access to the Piscatoris Fishing Colony"),
+				new UnlockReward("The ability to fish Monkfish")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/swansong/SwanSong.java
+++ b/src/main/java/com/questhelper/quests/swansong/SwanSong.java
@@ -313,6 +313,12 @@ public class SwanSong extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Point", "</br>", "15,000 Magic Experience", "</br>", "");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -568,6 +568,12 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "5,000 Cooking Experience", "5,000 Fishing Experience", "2,500 Attack Experience", "2,500 Strength Experience", "</br>", "2,000 Coins", "Ability to catch and cook Karambwans.", "Ability to use Tai bwo wannai teleport scrolls.", "Ability to complete the Smithing Section of Barbarian Training.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -46,6 +46,10 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -568,9 +572,36 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "5,000 Cooking Experience", "5,000 Fishing Experience", "2,500 Attack Experience", "2,500 Strength Experience", "</br>", "2,000 Coins", "Ability to catch and cook Karambwans.", "Ability to use Tai bwo wannai teleport scrolls.", "Ability to complete the Smithing Section of Barbarian Training.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.COOKING, 5000),
+				new ExperienceReward(Skill.FISHING, 5000),
+				new ExperienceReward(Skill.ATTACK, 2500),
+				new ExperienceReward(Skill.STRENGTH, 2500)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("2,000 Coins", ItemID.COINS_995, 2000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to catch and cook Karambwans"),
+				new UnlockReward("Ability to use Tai Bwo Wannai teleport scrolls"),
+				new UnlockReward("Ability to complete the smithing section of Barbarian Training")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/taleoftherighteous/TaleOfTheRighteous.java
+++ b/src/main/java/com/questhelper/quests/taleoftherighteous/TaleOfTheRighteous.java
@@ -32,6 +32,8 @@ import com.questhelper.requirements.player.FavourRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
@@ -327,9 +329,19 @@ public class TaleOfTheRighteous extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "8,000 Coins", "Shayzien favour certificate", "A Memoir Page");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("8,000 Coins", ItemID.COINS_995, 8000),
+				new ItemReward("Shayzien Favour Certificate", ItemID.SHAYZIEN_FAVOUR_CERTIFICATE, 1),
+				new ItemReward("A Memoir Page", ItemID.KHAREDSTS_MEMOIRS, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/taleoftherighteous/TaleOfTheRighteous.java
+++ b/src/main/java/com/questhelper/quests/taleoftherighteous/TaleOfTheRighteous.java
@@ -327,6 +327,12 @@ public class TaleOfTheRighteous extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "8,000 Coins", "Shayzien favour certificate", "A Memoir Page");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/tearsofguthix/TearsOfGuthix.java
+++ b/src/main/java/com/questhelper/quests/tearsofguthix/TearsOfGuthix.java
@@ -38,16 +38,17 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -190,9 +191,21 @@ public class TearsOfGuthix extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,000 Crafting Experience", "</br>", "Access to Tears of Guthix");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.CRAFTING, 1000));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Tears of Guthix"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/tearsofguthix/TearsOfGuthix.java
+++ b/src/main/java/com/questhelper/quests/tearsofguthix/TearsOfGuthix.java
@@ -190,6 +190,12 @@ public class TearsOfGuthix extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,000 Crafting Experience", "</br>", "Access to Tears of Guthix");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/templeofikov/TempleOfIkov.java
+++ b/src/main/java/com/questhelper/quests/templeofikov/TempleOfIkov.java
@@ -390,6 +390,12 @@ public class TempleOfIkov extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "10,500 Ranged Experience", "8,000 Fletching Experience", "Boots of Lightness");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/templeofikov/TempleOfIkov.java
+++ b/src/main/java/com/questhelper/quests/templeofikov/TempleOfIkov.java
@@ -43,6 +43,10 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -390,9 +394,24 @@ public class TempleOfIkov extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "10,500 Ranged Experience", "8,000 Fletching Experience", "Boots of Lightness");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.RANGED, 10500),
+				new ExperienceReward(Skill.FLETCHING, 8000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("Boots of Lightness", ItemID.BOOTS_OF_LIGHTNESS, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theascentofarceuus/TheAscentOfArceuus.java
+++ b/src/main/java/com/questhelper/quests/theascentofarceuus/TheAscentOfArceuus.java
@@ -39,6 +39,9 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.npc.NpcHintArrowRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -280,9 +283,28 @@ public class TheAscentOfArceuus extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Points", "</br>", "1,500 Hunter Experience", "500 Runecrafting Experience" , "</br>", "2,000 Coins", "Arceuus favour certificate.", "A Kharedst's Memoirs page.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.HUNTER, 1500),
+				new ExperienceReward(Skill.RUNECRAFT, 500)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("2,000 Coins", ItemID.COINS_995, 2000),
+				new ItemReward("Arceuus Favour Certificate", ItemID.ARCEUUS_FAVOUR_CERTIFICATE, 1),
+				new ItemReward("A Kharedst's Memoirs page", ItemID.KHAREDSTS_MEMOIRS, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theascentofarceuus/TheAscentOfArceuus.java
+++ b/src/main/java/com/questhelper/quests/theascentofarceuus/TheAscentOfArceuus.java
@@ -280,6 +280,12 @@ public class TheAscentOfArceuus extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Points", "</br>", "1,500 Hunter Experience", "500 Runecrafting Experience" , "</br>", "2,000 Coins", "Arceuus favour certificate.", "A Kharedst's Memoirs page.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thecorsaircurse/TheCorsairCurse.java
+++ b/src/main/java/com/questhelper/quests/thecorsaircurse/TheCorsairCurse.java
@@ -365,6 +365,12 @@ public class TheCorsairCurse extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "Access to Yusuf's bank in the Corsair Cove.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thecorsaircurse/TheCorsairCurse.java
+++ b/src/main/java/com/questhelper/quests/thecorsaircurse/TheCorsairCurse.java
@@ -37,17 +37,17 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.DigStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -365,9 +365,15 @@ public class TheCorsairCurse extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "Access to Yusuf's bank in the Corsair Cove.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Access to Yusuf's Bank in the Corsair Cove."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thedepthsofdespair/TheDepthsOfDespair.java
+++ b/src/main/java/com/questhelper/quests/thedepthsofdespair/TheDepthsOfDespair.java
@@ -241,6 +241,12 @@ public class TheDepthsOfDespair extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,500 Agility Experience", "</br>", "4,000 Coins", "Hosidius favour certificate.", "A page for Kharedst's Memoirs.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thedepthsofdespair/TheDepthsOfDespair.java
+++ b/src/main/java/com/questhelper/quests/thedepthsofdespair/TheDepthsOfDespair.java
@@ -40,6 +40,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -241,9 +244,25 @@ public class TheDepthsOfDespair extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("1 Quest Point", "</br>", "1,500 Agility Experience", "</br>", "4,000 Coins", "Hosidius favour certificate.", "A page for Kharedst's Memoirs.");
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.AGILITY, 1500));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("4,000 Coins", ItemID.COINS_995, 4000),
+				new ItemReward("Hosidius Favour Certificate", ItemID.HOSIDIUS_FAVOUR_CERTIFICATE, 1),
+				new ItemReward("A Kharedst's Memoirs page", ItemID.KHAREDSTS_MEMOIRS, 1)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thedigsite/TheDigSite.java
+++ b/src/main/java/com/questhelper/quests/thedigsite/TheDigSite.java
@@ -516,6 +516,12 @@ public class TheDigSite extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "15,300 Mining Experience", "2,000 Herblore Experience", "</br>", "2 Gold Bars", "</br>", "The ability to do Varrock Museum specimen cleaning.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thedigsite/TheDigSite.java
+++ b/src/main/java/com/questhelper/quests/thedigsite/TheDigSite.java
@@ -39,6 +39,10 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ItemStep;
@@ -516,9 +520,30 @@ public class TheDigSite extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getQuestRewards()
+	public QuestPointReward getQuestPointReward()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "15,300 Mining Experience", "2,000 Herblore Experience", "</br>", "2 Gold Bars", "</br>", "The ability to do Varrock Museum specimen cleaning.");
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.MINING, 15300),
+				new ExperienceReward(Skill.HERBLORE, 2000)
+		);
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Collections.singletonList(new ItemReward("2 x Gold Bars", ItemID.GOLD_BAR, 2));
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("Ability to clean specimens in the Varrock Museum"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
+++ b/src/main/java/com/questhelper/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
@@ -37,6 +37,9 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -308,7 +311,32 @@ public class TheEyesOfGlouphrie extends BasicQuestHelper
 	@Override
 	public List<String> getQuestRewards()
 	{
-		return Arrays.asList("2 Quest Points", "</br>", "12,000 Magic Experience", "2,500 Woodcutting Experience", "6,000 Runecraft Experience",  "250 Construction Experience", "</br>", "A Crystal Saw Seed");
+		return Arrays.asList("2 Quest Points", "</br>", "12,000 Magic Experience",
+				"2,500 Woodcutting Experience", "6,000 Runecraft Experience",
+				"250 Construction Experience", "</br>", "A Crystal Saw Seed");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.MAGIC, 12000),
+				new ExperienceReward(Skill.WOODCUTTING, 2500),
+				new ExperienceReward(Skill.RUNECRAFT, 6000),
+				new ExperienceReward(Skill.CONSTRUCTION, 250)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Collections.singletonList(new UnlockReward("A Crystal Saw Seed"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
+++ b/src/main/java/com/questhelper/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
@@ -306,6 +306,12 @@ public class TheEyesOfGlouphrie extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "12,000 Magic Experience", "2,500 Woodcutting Experience", "6,000 Runecraft Experience",  "250 Construction Experience", "</br>", "A Crystal Saw Seed");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thefeud/TheFeud.java
+++ b/src/main/java/com/questhelper/quests/thefeud/TheFeud.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Kerpackie
  * Copyright (c) 2020, Patyfatycake <https://github.com/Patyfatycake/>
  * All rights reserved.
  *
@@ -18,10 +19,11 @@
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABI`LITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package com.questhelper.quests.thefeud;
 
 import com.questhelper.QuestDescriptor;
@@ -46,113 +48,158 @@ import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.ObjectID;
-import net.runelite.api.Player;
-import net.runelite.api.Skill;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
+
 @QuestDescriptor(
-	quest = QuestHelperQuest.THE_FEUD
+		quest = QuestHelperQuest.THE_FEUD
 )
+
 public class TheFeud extends BasicQuestHelper
 {
-	//Item Requirements
-	private ItemRequirement coins, unspecifiedCoins, gloves, headPiece, fakeBeard, desertDisguise,
-		shantyPass, beer, oakBlackjack, glovesEquipped, disguiseEquipped, doorKeys,
-		highlightedCoins, snakeCharmHighlighted, snakeBasket, snakeBasketFull,
-		redHotSauce, dung, poisonHighlighted;
+
+	//Items Requirements
+	ItemRequirement coins, unspecifiedCoins, gloves, headPiece, fakeBeard, desertDisguise,
+			shantyPass, beer, oakBlackjack, glovesEquipped, disguiseEquipped, doorKeys,
+			highlightedCoins, snakeCharmHighlighted, snakeBasket, snakeBasketFull,
+			redHotSauce, bucket, dung, poisonHighlighted;
 
 	//Items Recommended
-	private ItemRequirement combatGear;
+	ItemRequirement combatGear;
 
-	private Conditions hasDisguise, hasDisguiseComponents, doesNotHaveDisguise, doesNotHaveDisguiseComponents,
-		notThroughShantyGate;
+	Requirement throughShantyGate, inPollniveach, oakBlackjackEquipped, desertDisguiseCondition, hasShantyPass, hasOakBlackjack, snakeCharm, hasSnakeBasket,
+			hasSnakeBasketFull, hasRedHotSauce, hasBucket, doesNotHaveBucket, hasDungInventory;
 
-	private QuestStep startQuest, buyDisguiseGear, createDisguise, goToPollniveachStep;
+	Conditions hasDisguiseComponents, doesNotHaveDisguise, doesNotHaveDisguiseComponents, notThroughShantyGate, hasDisguise;
 
-	private ObjectStep hideBehindCactus, openTheDoor, goUpStairs, crackTheSafe,
-		giveCoinToSnakeCharmer, getDung, poisonTheDrink;
+	ObjectCondition dungNearby;
 
-	private NpcStep drunkenAli, talkToThug, talkToBandit, talkToCamelman,
-		talkToBanditReturnedCamel, talkToMenaphiteReturnedCamel, talkToAliTheOperator,
-		pickpocketVillager, pickPocketVillagerWithUrchin, getBlackjackFromAli, blackJackVillager,
-		talkToAliToGetSecondJob, giveTheJewelsToAli, talkMenaphiteToFindTraitor, tellAliYouFoundTraitor,
-		talkToAliTheBarman, talkToAliTheHag, catchSnake, givePoisonToAliTheHag,
-		talkToAliTheKebabSalesman, givenDungToHag, tellAliOperatorPoisoned,
-		talkToMenaphiteLeader, talkToAVillager, talkToBanditLeader, talkToAVillagerToSpawnMayor,
-		talkToMayor, finishQuest;
+	QuestStep startQuest, buyDisguiseGear, createDisguise, goToPollniveachStep, goToShanty;
 
-	private Requirement desertDisguiseCondition, hasShantyPass, hasOakBlackjack, oakBlackjackEquipped,
-		snakeCharm, hasSnakeBasket, hasSnakeBasketFull, hasRedHotSauce, hasBucket, doesNotHaveBucket,
-		hasDungInInventory;
+	DetailedQuestStep getBucket, equipBlackjack, killMenaphiteThug, killBanditChampion;
 
-	private Requirement throughShantyGate;
+	NpcStep buyShantyPass, talkToRugMerchant, drunkenAli, talkToThug, talkToBandit, talkToCamelman, talkToBanditReturnedCamel, talkToMenaphiteReturnedCamel,
+			talkToAliTheOperator, pickpocketVillager, pickPocketVillagerWithUrchin, getBlackjackFromAli, blackjackVillager,
+			talkToAliToGetSecondJob, giveTheJewelsToAli, talkMenaphiteToFindTraitor, tellAliYouFoundTraitor, talkToAliTheBarman,
+			talkToAliTheHag, catchSnake, givePoisonToAliTheHag, talkToAliTheKebabSalesman, givenDungToHag, tellAliOperatorPoisoned,
+			talkToMenaphiteLeader, talkToAVillager, talkToBanditLeader, talkToAVillagerToSpawnMayor, talkToMayor, finishQuest;
 
-	private DetailedQuestStep getBucket;
+	ObjectStep hideBehindCactus, pickupDung, openTheDoor, goUpStairs, crackTheSafe, goDownStairs, giveCoinToSnakeCharmer, getDung, poisonTheDrink;
 
-	private VarbitRequirement talkedToThug, talkedToBandit, talkedToBanditReturn, doorOpen, traitorFound,
-		talkedToBarman, talkedToAliTheHag, givenPoisonToHag, menaphiteThugAlive, talkedToVillagerAboutMenaphite,
-		banditChampionSpawned, mayorSpawned;
+	VarbitRequirement talkedToThug, talkedToBandit, talkedToBanditReturn, doorOpen, traitorFound, talkedToBarman, talkedToAliTheHag,
+			givenPoisonToHag, menaphiteThugAlive, talkedToVillagerAboutMenaphite, banditChampionSpawned, mayorSpawned;
 
 	//Zones
-	private ZoneRequirement shantyPassZoneRequirement, pollniveachZoneRequirement, secondFloorMansion;
+	ZoneRequirement pollniveachZoneRequirement, secondFloorMansion;
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
 	{
-		setupVarbits();
+		loadZones();
 		setupItemRequirements();
-		setupZones();
 		setupConditions();
-
-		return getSteps();
-	}
-
-	private Map<Integer, QuestStep> getSteps()
-	{
+		setupSteps();
+		setupVarBits();
 		Map<Integer, QuestStep> steps = new HashMap<>();
 
-		steps.put(0, startQuest = getStartQuest());
-		steps.put(1, getPollnivneachStep());
-		steps.put(2, findBeef());
-		steps.put(3, buyCamels());
-		steps.put(4, talkToGangsAgain());
-		steps.put(5, getFirstJob());
-		steps.put(6, pickPocketVillager());
-		QuestStep pickPocketWithUrchin = pickPocketVillagerWithUrchin();
-		steps.put(7, pickPocketWithUrchin);
-		steps.put(8, pickPocketWithUrchin);
-		QuestStep blackjack = blackjackVillager();
-		steps.put(9, blackjack);
-		steps.put(10, blackjack);
-		steps.put(11, blackjack);
-		steps.put(12, getSecondJob());
-		steps.put(13, secondJob());
-		steps.put(14, openTheDoor());
-		steps.put(15, returnTheJewels());
-		steps.put(16, findTraitor());
-		steps.put(17, talkToBarman());
-		steps.put(18, getDung());
-		steps.put(22, poisonTheDrink());
-		steps.put(23, tellOperatorPoisoned());
-		steps.put(24, killToughGuy());
-		steps.put(25, talkToVillager());
-		steps.put(26, talkToVillagerToSpawnMayor());
-		steps.put(27, finishQuest());
+		steps.put(0, startQuest);
+
+		ConditionalStep goToPollniveach = new ConditionalStep(this, buyShantyPass);
+		goToPollniveach.addStep(inPollniveach, drunkenAli);
+		goToPollniveach.addStep(throughShantyGate, talkToRugMerchant);
+		goToPollniveach.addStep(new Conditions(notThroughShantyGate, hasShantyPass), goToShanty);
+		goToPollniveach.addStep(new Conditions(notThroughShantyGate, doesNotHaveDisguise, doesNotHaveDisguiseComponents), buyDisguiseGear);
+		goToPollniveach.addStep(new Conditions(notThroughShantyGate, doesNotHaveDisguise, hasDisguiseComponents), createDisguise);
+		steps.put(1, goToPollniveach);
+
+		ConditionalStep findBeef = new ConditionalStep(this, talkToThug);
+		findBeef.addStep(talkedToBandit, talkToCamelman);
+		findBeef.addStep(talkedToThug, talkToBandit);
+		steps.put(2, findBeef);
+
+		steps.put(3, talkToCamelman);
+
+		ConditionalStep returnCamels = new ConditionalStep(this, talkToBanditReturnedCamel);
+		returnCamels.addStep(talkedToBanditReturn, talkToMenaphiteReturnedCamel);
+		steps.put(4, returnCamels);
+
+		steps.put(5, talkToAliTheOperator);
+		steps.put(6, pickpocketVillager);
+
+		steps.put(7, pickPocketVillagerWithUrchin);
+		steps.put(8, pickPocketVillagerWithUrchin);
+
+		ConditionalStep blackjackVillagerStep = new ConditionalStep(this, getBlackjackFromAli);
+		blackjackVillagerStep.addStep(oakBlackjackEquipped, blackjackVillager);
+		blackjackVillagerStep.addStep(hasOakBlackjack, equipBlackjack);
+		steps.put(9, blackjackVillagerStep);
+		steps.put(10, blackjackVillagerStep);
+		steps.put(11, blackjackVillagerStep);
+
+		steps.put(12, talkToAliToGetSecondJob);
+		steps.put(13, hideBehindCactus);
+
+		ConditionalStep heist = new ConditionalStep(this, openTheDoor);
+		heist.addStep(secondFloorMansion, crackTheSafe);
+		heist.addStep(doorOpen, goUpStairs);
+		steps.put(14, heist);
+
+		ConditionalStep returnTheJewels = new ConditionalStep(this, giveTheJewelsToAli);
+		returnTheJewels.addStep(secondFloorMansion, goDownStairs);
+		steps.put(15, returnTheJewels);
+
+		ConditionalStep findTraitor = new ConditionalStep(this, talkMenaphiteToFindTraitor);
+		findTraitor.addStep(traitorFound, tellAliYouFoundTraitor);
+		steps.put(16, findTraitor);
+
+		ConditionalStep getSnake = new ConditionalStep(this, talkToAliTheBarman);
+		getSnake.addStep(givenPoisonToHag, talkToAliTheKebabSalesman);
+		getSnake.addStep(hasSnakeBasketFull, givePoisonToAliTheHag);
+		getSnake.addStep(new Conditions(talkedToAliTheHag, snakeCharm, hasSnakeBasket), catchSnake);
+		getSnake.addStep(talkedToAliTheHag, giveCoinToSnakeCharmer);
+		getSnake.addStep(talkedToBarman, talkToAliTheHag);
+		steps.put(17, getSnake);
+
+		ConditionalStep camelDung = new ConditionalStep(this, talkToAliTheKebabSalesman);
+		camelDung.addStep(new Conditions(givenPoisonToHag, hasDungInventory), givenDungToHag);
+		camelDung.addStep(new Conditions(givenPoisonToHag, hasRedHotSauce, hasBucket, dungNearby), pickupDung);
+		camelDung.addStep(new Conditions(givenPoisonToHag, hasRedHotSauce, hasBucket), getDung);
+		camelDung.addStep(new Conditions(givenPoisonToHag, hasRedHotSauce, doesNotHaveBucket), getBucket);
+		steps.put(18, camelDung);
+
+		steps.put(22, poisonTheDrink);
+		steps.put(23, tellAliOperatorPoisoned);
+
+		ConditionalStep killThug = new ConditionalStep(this, talkToMenaphiteLeader);
+		killThug.addStep(menaphiteThugAlive, killMenaphiteThug);
+		steps.put(24, killThug);
+
+		ConditionalStep killChampion = new ConditionalStep(this, talkToAVillager);
+		killChampion.addStep(banditChampionSpawned, killBanditChampion);
+		killChampion.addStep(talkedToVillagerAboutMenaphite, talkToBanditLeader);
+		steps.put(25, killChampion);
+
+		ConditionalStep spawnMayor = new ConditionalStep(this, talkToAVillagerToSpawnMayor);
+		spawnMayor.addStep(mayorSpawned, talkToMayor);
+		steps.put(26, spawnMayor);
+
+		steps.put(27, finishQuest);
+
 		return steps;
 	}
 
-	private void setupVarbits()
+	public void setupVarBits()
 	{
-		//318 drunk ali beer count
+		//318 Drunk Ali beer count 0->1->2->3
 
 		// 315 -> 2 Talked to thug -> 3 Talked to bandit
 		talkedToThug = new VarbitRequirement(315, 2);
@@ -163,6 +210,9 @@ public class TheFeud extends BasicQuestHelper
 		doorOpen = new VarbitRequirement(320, 1);
 
 		//Varbit 325 keeps track of correctly entered safe values
+		//UPDATE: 325 keeps track of amount of numbers input. Even if they are incorrect
+		//this VarBit updates.
+		//TODO: Overlay for safe cracking.
 
 		// Varbit 342 when found Traitor
 		traitorFound = new VarbitRequirement(342, 1);
@@ -173,7 +223,8 @@ public class TheFeud extends BasicQuestHelper
 		// 345 and 328 when talking to hag
 		talkedToAliTheHag = new VarbitRequirement(328, 1);
 		givenPoisonToHag = new VarbitRequirement(328, 2);
-		// 335 = POisoned drink
+
+		// 335 = Poisoned drink
 
 		//322 Menaphite
 		menaphiteThugAlive = new VarbitRequirement(322, 1);
@@ -186,398 +237,262 @@ public class TheFeud extends BasicQuestHelper
 		mayorSpawned = new VarbitRequirement(343, 2);
 	}
 
-	private void setupZones()
-	{
-		Zone shantyPassZone = new Zone(new WorldPoint(3297, 3116, 0), new WorldPoint(3313, 3132, 0));
-		Zone pollniveachZone = new Zone(new WorldPoint(3320, 2926, 0), new WorldPoint(3381, 3006, 0));
-		Zone secondFloor = new Zone(new WorldPoint(3366, 2965, 1), new WorldPoint(3375, 2979, 1));
-
-		shantyPassZoneRequirement = new ZoneRequirement(shantyPassZone);
-		pollniveachZoneRequirement = new ZoneRequirement(pollniveachZone);
-		secondFloorMansion = new ZoneRequirement(secondFloor);
-	}
-
-	private QuestStep finishQuest()
-	{
-		finishQuest = talkToAliStep("Talk to Ali Morrisane to finish the quest.");
-		return finishQuest;
-	}
-
-	private QuestStep talkToVillagerToSpawnMayor()
-	{
-		talkToAVillagerToSpawnMayor = new NpcStep(this, NpcID.VILLAGER, "Talk to a villager and they will be angry still.", true);
-		talkToAVillagerToSpawnMayor.addAlternateNpcs(NpcID.VILLAGER_3554, NpcID.VILLAGER_3555, NpcID.VILLAGER_3557, NpcID.VILLAGER_3558, NpcID.VILLAGER_3560);
-		talkToMayor = new NpcStep(this, NpcID.ALI_THE_MAYOR, new WorldPoint(3360, 2972, 0), "Talk to the mayor and get your due congratulations.");
-
-		ConditionalStep conditionalStep = new ConditionalStep(this, talkToAVillagerToSpawnMayor);
-		conditionalStep.addStep(mayorSpawned, talkToMayor);
-		return conditionalStep;
-	}
-
-	private QuestStep talkToVillager()
-	{
-		talkToAVillager = new NpcStep(this, NpcID.VILLAGER, "Talk to a villager and they will be angry you broke the power of balance.", true);
-		talkToAVillager.addAlternateNpcs(NpcID.VILLAGER_3554, NpcID.VILLAGER_3555, NpcID.VILLAGER_3557, NpcID.VILLAGER_3558, NpcID.VILLAGER_3560);
-
-		talkToBanditLeader = new NpcStep(this, NpcID.BANDIT_LEADER, new WorldPoint(3353, 3002, 0),
-			"Talk to the bandit leader and be prepared to the fight a bandit champion. You can safe spot him with the stool.");
-
-		DetailedQuestStep killBanditChampion = new DetailedQuestStep(this, "Kill the bandit champion spawned, you can safe spot him with the stool. \n If he's not spawned then talk to the Bandit Leader again.");
-		ConditionalStep conditionalStep = new ConditionalStep(this, talkToAVillager);
-		conditionalStep.addStep(banditChampionSpawned, killBanditChampion);
-		conditionalStep.addStep(talkedToVillagerAboutMenaphite, talkToBanditLeader);
-		talkToBanditLeader.addSubSteps(killBanditChampion);
-
-		return conditionalStep;
-	}
-
-	private QuestStep killToughGuy()
-	{
-		talkToMenaphiteLeader = new NpcStep(this, NpcID.MENAPHITE_LEADER, "Talk to the Menaphite leader and prepare for a fight against a tough guy. You can safespot him inside the tent by using a chair.");
-		DetailedQuestStep killMenaphiteThug = new DetailedQuestStep(this, "Kill the Menaphite thug.  You can safespot him inside the tent by using a chair, if he's not spawned then talk to the Menaphite leader again.");
-		ConditionalStep conditionalStep = new ConditionalStep(this, talkToMenaphiteLeader);
-		conditionalStep.addStep(menaphiteThugAlive, killMenaphiteThug);
-		talkToMenaphiteLeader.addSubSteps(killMenaphiteThug);
-
-		return conditionalStep;
-	}
-
-	private QuestStep tellOperatorPoisoned()
-	{
-		tellAliOperatorPoisoned = talkToAliTheOperatorStep("Talk to Ali the Operator and tell him he is dead.");
-		return tellAliOperatorPoisoned;
-	}
-
-	private QuestStep poisonTheDrink()
-	{
-		poisonTheDrink = new ObjectStep(this, ObjectID.TABLE_6246, new WorldPoint(3356, 2957, 0), "Use the poison on the beer glass to kill Traiterous Ali.", poisonHighlighted);
-		poisonTheDrink.addIcon(ItemID.HAGS_POISON);
-		return poisonTheDrink;
-	}
-
-	private QuestStep getDung()
-	{
-		talkToAliTheKebabSalesman = new NpcStep(this, NpcID.ALI_THE_KEBAB_SELLER, new WorldPoint(3352, 2975, 0),
-			"Talk to Ali the Kebab Salesman to get a special sauce to use.");
-		talkToAliTheKebabSalesman.addDialogStep("Would you sell me that bottle of special kebab sauce?");
-		talkToAliTheKebabSalesman.addDialogStep("No thanks, I'm good.");
-
-		getBucket = new DetailedQuestStep(this, new WorldPoint(3346, 2966, 0), "Pick up a bucket to grab the dung with.");
-
-		ObjectCondition dungNearby = new ObjectCondition(ObjectID.DUNG);
-		ItemRequirement bucket = new ItemRequirement("Bucket", ItemID.BUCKET);
-		ObjectStep pickupDung = new ObjectStep(this, ObjectID.DUNG,
-			"Use the bucket on the dung.", bucket.highlighted());
-		pickupDung.addIcon(ItemID.BUCKET);
-
-		getDung = new ObjectStep(this, ObjectID.TROUGH_6256, new WorldPoint(3343, 2960, 0), "Use the Red Hot Sauce on the Trough and wait for a Camel to poop out the dung.\n Only pickup brown/Ugthanki dung, if you plan to do \"My Arm's Big Adventure\" or \"Forgettable Tale of a Drunken Dwarf\" then you may want to grab four more Ugthanki dung.",
-			redHotSauce);
-		getDung.addSubSteps(getBucket, pickupDung);
-		getDung.addIcon(ItemID.RED_HOT_SAUCE);
-		givenDungToHag = talkToAliTheHagStep("Talk to Ali the Hag and give her your dung.", dung);
-
-		ConditionalStep conditionalStep = new ConditionalStep(this, talkToAliTheKebabSalesman);
-
-		conditionalStep.addStep(new Conditions(givenPoisonToHag, hasDungInInventory), givenDungToHag);
-		conditionalStep.addStep(new Conditions(givenPoisonToHag, hasRedHotSauce, hasBucket, dungNearby), pickupDung);
-		conditionalStep.addStep(new Conditions(givenPoisonToHag, hasRedHotSauce, hasBucket), getDung);
-		conditionalStep.addStep(new Conditions(givenPoisonToHag, hasRedHotSauce, doesNotHaveBucket), getBucket);
-		return conditionalStep;
-	}
-
-	private QuestStep talkToBarman()
-	{
-		talkToAliTheBarman = new NpcStep(this, NpcID.ALI_THE_BARMAN, new WorldPoint(3361, 2956, 0),
-			"Talk to Ali the barman to find out where Traiterous Ali is.");
-		talkToAliTheBarman.addDialogStep("I'm looking for Traitorous Ali.");
-		talkToAliTheBarman.addDialogStep("No thanks I'm ok.");
-		talkToAliTheHag = talkToAliTheHagStep("Talk to Ali the Hag to ask her to make some poison for you.");
-		giveCoinToSnakeCharmer = new ObjectStep(this, ObjectID.MONEY_POT, new WorldPoint(3355, 2953, 0),
-			"Use money on the money pot to attract the snake charmers attention.", highlightedCoins);
-		giveCoinToSnakeCharmer.addIcon(ItemID.COINS);
-		catchSnake = new NpcStep(this, NpcID.DESERT_SNAKE, new WorldPoint(3332, 2958, 0),
-			"Use the Snake Charm on a snake to capture it.", true,
-			snakeCharmHighlighted, snakeBasket);
-		catchSnake.addIcon(ItemID.SNAKE_CHARM);
-
-		givePoisonToAliTheHag = talkToAliTheHagStep("Give the snake to Ali the Hag.", snakeBasketFull);
-		ConditionalStep conditionalStep = new ConditionalStep(this, talkToAliTheBarman);
-
-		conditionalStep.addStep(givenPoisonToHag, talkToAliTheKebabSalesman);
-		conditionalStep.addStep(hasSnakeBasketFull, givePoisonToAliTheHag);
-		conditionalStep.addStep(new Conditions(talkedToAliTheHag, snakeCharm, hasSnakeBasket), catchSnake);
-		conditionalStep.addStep(talkedToAliTheHag, giveCoinToSnakeCharmer);
-		conditionalStep.addStep(talkedToBarman, talkToAliTheHag);
-		return conditionalStep;
-	}
-
-	private QuestStep findTraitor()
-	{
-		talkMenaphiteToFindTraitor = talkToMenaphiteStep("Talk to a Menaphite member to find the traitor.");
-		tellAliYouFoundTraitor = talkToAliTheOperatorStep("Talk to Ali and tell him you have found the traitor.");
-		ConditionalStep conditionalStep = new ConditionalStep(this, talkMenaphiteToFindTraitor);
-		conditionalStep.addStep(traitorFound, tellAliYouFoundTraitor);
-		return conditionalStep;
-	}
-
-	private QuestStep returnTheJewels()
-	{
-		ObjectStep goDownStairs = new ObjectStep(this, ObjectID.STAIRCASE_6245, "Go down the stairs.");
-		giveTheJewelsToAli = talkToAliTheOperatorStep("Give Ali the Operator the jewels to get your final task from him.");
-		giveTheJewelsToAli.addSubSteps(goDownStairs);
-		ConditionalStep conditionalStep = new ConditionalStep(this, giveTheJewelsToAli);
-		conditionalStep.addStep(secondFloorMansion, goDownStairs);
-		return conditionalStep;
-	}
-
-	private QuestStep openTheDoor()
-	{
-
-		openTheDoor = new ObjectStep(this, 6238, "Open the door.", doorKeys);
-		openTheDoor.addAlternateObjects(6240);
-		openTheDoor.addIcon(ItemID.KEYS);
-
-		goUpStairs = new ObjectStep(this, ObjectID.STAIRCASE_6244, "Go up the stairs.");
-		crackTheSafe = new ObjectStep(this, 6276, "Search the painting to reveal the safe. Enter the code 1, 1, 2, 3, 5, 8.");
-
-		crackTheSafe.addSubSteps(goUpStairs);
-		ConditionalStep stealStep = new ConditionalStep(this, openTheDoor);
-		stealStep.addStep(secondFloorMansion, crackTheSafe);
-		stealStep.addStep(doorOpen, goUpStairs);
-		return stealStep;
-	}
-
-	private QuestStep getSecondJob()
-	{
-		talkToAliToGetSecondJob = talkToAliTheOperatorStep("Talk to Ali the Operator to get the second job.");
-		return talkToAliToGetSecondJob;
-	}
-
-	private QuestStep secondJob()
-	{
-		hideBehindCactus = new ObjectStep(this, ObjectID.CACTUS_6277, new WorldPoint(3364, 2968, 0)
-			, "Hide behind the cactus", glovesEquipped, disguiseEquipped);
-		return new ConditionalStep(this, hideBehindCactus);
-	}
-
-	private QuestStep blackjackVillager()
-	{
-		getBlackjackFromAli = talkToAliTheOperatorStep("Talk to Ali the Operator to get a blackjack.");
-		getBlackjackFromAli.addDialogStep("Yeah, I could do with a bit of advice.");
-
-		blackJackVillager = new NpcStep(this, NpcID.VILLAGER, "Lure a villager to secluded place, knock them out and then pickpocket them.", true);
-		blackJackVillager.addAlternateNpcs(NpcID.VILLAGER_3555, NpcID.VILLAGER_3557, NpcID.VILLAGER_3558, NpcID.VILLAGER_3560);
-
-		DetailedQuestStep equipBlackjack = new DetailedQuestStep(this, "Equip your oak blackjack in your inventory.", oakBlackjack);
-
-		ConditionalStep blackjackVillagerStep = new ConditionalStep(this, getBlackjackFromAli);
-		blackjackVillagerStep.addStep(oakBlackjackEquipped, blackJackVillager);
-		blackjackVillagerStep.addStep(hasOakBlackjack, equipBlackjack);
-		blackJackVillager.addSubSteps(equipBlackjack);
-
-		return blackjackVillagerStep;
-	}
-
-	private QuestStep pickPocketVillagerWithUrchin()
-	{
-		pickPocketVillagerWithUrchin = new NpcStep(this, NpcID.STREET_URCHIN, "Talk to a street urchin and get them to distract a villager, once he has them distracted pickpocket them from behind.", true);
-		return pickPocketVillagerWithUrchin;
-	}
-
-	private QuestStep pickPocketVillager()
-	{
-		pickpocketVillager = new NpcStep(this, NpcID.VILLAGER, new WorldPoint(3356, 2962, 0), "Pickpocket a villager.", true);
-		pickpocketVillager.setHideWorldArrow(true);
-		pickpocketVillager.addAlternateNpcs(NpcID.VILLAGER_3555, NpcID.VILLAGER_3558);
-
-		return pickpocketVillager;
-	}
-
-	private QuestStep getFirstJob()
-	{
-		talkToAliTheOperator = talkToAliTheOperatorStep("Talk to Ali the Operator to get a job from him.");
-		talkToAliTheOperator.addDialogStep("Yes, of course, those bandits should be taught a lesson.");
-		return talkToAliTheOperator;
-	}
-
-	private QuestStep talkToGangsAgain()
-	{
-		talkToBanditReturnedCamel = talkToBanditStep("Tell the bandits that the Menaphites have agreed to return the camel.");
-		talkToMenaphiteReturnedCamel = talkToMenaphiteStep("Tell the Menaphites the bandits have agreed to return the camel.");
-		ConditionalStep firstJob = new ConditionalStep(this, talkToBanditReturnedCamel);
-		firstJob.addStep(talkedToBanditReturn, talkToMenaphiteReturnedCamel);
-		return firstJob;
-	}
-
-	private void setupConditions()
-	{
-		ItemRequirements fakeBeardCondition = new ItemRequirements(fakeBeard);
-		ItemRequirements headPieceCondition = new ItemRequirements(headPiece);
-		desertDisguiseCondition = new ItemRequirements(desertDisguise);
-		doesNotHaveDisguise = new Conditions(LogicType.NAND, desertDisguiseCondition);
-		hasSnakeBasketFull = new ItemRequirements(snakeBasketFull);
-		hasSnakeBasket = new ItemRequirements(snakeBasket);
-		snakeCharm = new ItemRequirements(snakeCharmHighlighted);
-		hasShantyPass = new ItemRequirements(shantyPass);
-		hasOakBlackjack = new ItemRequirements(oakBlackjack);
-		oakBlackjackEquipped = new ItemRequirements(new ItemRequirement("Oak Blackjack", ItemID.OAK_BLACKJACK, 1, true));
-		hasRedHotSauce = new ItemRequirements(redHotSauce);
-		hasDisguiseComponents = new Conditions(fakeBeardCondition, headPieceCondition);
-		doesNotHaveDisguiseComponents = new Conditions(LogicType.NAND, fakeBeardCondition,
-			headPieceCondition);
-		hasDisguise = new Conditions(desertDisguiseCondition);
-		hasBucket = new ItemRequirements(new ItemRequirement("Bucket", ItemID.BUCKET));
-		doesNotHaveBucket = new ComplexRequirement(LogicType.NOR, "", new ItemRequirement("Bucket", ItemID.BUCKET));
-		throughShantyGate = RequirementBuilder.builder()
-			.check(client -> {
-				Player player = client.getLocalPlayer();
-				return player != null && player.getWorldLocation().getY() < 3116;
-		}).build();
-		notThroughShantyGate = new Conditions(LogicType.NAND, throughShantyGate);
-		hasDungInInventory = new ItemRequirements(dung);
-		combatGear = new ItemRequirement("Combat gear for fighting", -1, -1);
-		combatGear.setDisplayItemId(BankSlotIcons.getCombatGear());
-	}
-
-	private void setupItemRequirements()
+	public void setupItemRequirements()
 	{
 		coins = new ItemRequirement("Coins", ItemID.COINS_995, 800);
 		unspecifiedCoins = new ItemRequirement("Coins", ItemID.COINS_995, -1);
+		highlightedCoins = new ItemRequirement("Coins", ItemID.COINS_995);
+		highlightedCoins.setHighlightInInventory(true);
 		gloves = new ItemRequirement("Gloves", ItemID.LEATHER_GLOVES);
+		glovesEquipped = new ItemRequirement("Gloves", ItemID.LEATHER_GLOVES, 1, true);
 		headPiece = new ItemRequirement("Kharidian Headpiece", ItemID.KHARIDIAN_HEADPIECE);
 		headPiece.setHighlightInInventory(true);
 		fakeBeard = new ItemRequirement("Fake Beard", ItemID.FAKE_BEARD);
 		fakeBeard.setHighlightInInventory(true);
-		shantyPass = new ItemRequirement("Shantay Pass", ItemID.SHANTAY_PASS);
 		desertDisguise = new ItemRequirement("Desert Disguise", ItemID.DESERT_DISGUISE);
-		beer = new ItemRequirement("Beer", ItemID.BEER);
+		disguiseEquipped = new ItemRequirement("Desert Disguise", ItemID.DESERT_DISGUISE, 1, true);
+		shantyPass = new ItemRequirement("Shanty Pass", ItemID.SHANTAY_PASS);
+		beer = new ItemRequirement("Beer", ItemID.BEER, 3);
 		beer.setHighlightInInventory(true);
-		doorKeys = new ItemRequirement("Keys", ItemID.KEYS);
-		doorKeys.setHighlightInInventory(true);
-		highlightedCoins = new ItemRequirement("Coins", ItemID.COINS_995);
-		highlightedCoins.setHighlightInInventory(true);
-		snakeCharmHighlighted = new ItemRequirement("Snake Charm", ItemID.SNAKE_CHARM);
-		snakeCharmHighlighted.setHighlightInInventory(true);
-		glovesEquipped = new ItemRequirement("Gloves", ItemID.LEATHER_GLOVES, 1, true);
-		disguiseEquipped = new ItemRequirement("Disguise", ItemID.DESERT_DISGUISE, 1, true);
 		oakBlackjack = new ItemRequirement("Oak Blackjack", ItemID.OAK_BLACKJACK);
 		oakBlackjack.setHighlightInInventory(true);
+		oakBlackjackEquipped = new ItemRequirement("Oak Blackjack", ItemID.OAK_BLACKJACK, 1, true);
+		doorKeys = new ItemRequirement("Keys", ItemID.KEYS);
+		doorKeys.setHighlightInInventory(true);
+		snakeCharmHighlighted = new ItemRequirement("Snake Charm", ItemID.SNAKE_CHARM);
+		snakeCharmHighlighted.setHighlightInInventory(true);
 		snakeBasket = new ItemRequirement("Snake Basket", ItemID.SNAKE_BASKET);
-		snakeBasketFull = new ItemRequirement("Snake Basket(Full)", ItemID.SNAKE_BASKET_FULL);
+		snakeBasketFull = new ItemRequirement("Snake Basket (Full)", ItemID.SNAKE_BASKET_FULL);
 		redHotSauce = new ItemRequirement("Red Hot Sauce", ItemID.RED_HOT_SAUCE);
 		redHotSauce.setHighlightInInventory(true);
+		bucket = new ItemRequirement("Bucket", ItemID.BUCKET);
 		dung = new ItemRequirement("Dung", ItemID.UGTHANKI_DUNG);
 		poisonHighlighted = new ItemRequirement("Hag's Poison", ItemID.HAGS_POISON);
 		poisonHighlighted.setHighlightInInventory(true);
 	}
 
-	private QuestStep buyCamels()
+	public void loadZones()
 	{
-		talkToCamelman = new NpcStep(this, NpcID.ALI_THE_CAMEL_MAN, new WorldPoint(3350, 2966, 0),
-			"Talk to ali the camel man to try and get two camels to solve the dispute");
+		Zone pollniveachZone = new Zone(new WorldPoint(3320, 2926, 0), new WorldPoint(3381, 3006, 0));
+		Zone secondFloor = new Zone(new WorldPoint(3366, 2965, 1), new WorldPoint(3375, 2979, 1));
+
+		pollniveachZoneRequirement = new ZoneRequirement(pollniveachZone);
+		secondFloorMansion = new ZoneRequirement(secondFloor);
+	}
+
+	public void setupConditions()
+	{
+		//Disguise
+		ItemRequirements hasFakeBeard = new ItemRequirements(fakeBeard);
+		ItemRequirements hasFakeHeadPiece = new ItemRequirements(headPiece);
+		hasDisguiseComponents = new Conditions(hasFakeBeard, hasFakeHeadPiece);
+		desertDisguiseCondition = new ItemRequirements(desertDisguise);
+		doesNotHaveDisguise = new Conditions(LogicType.NAND, desertDisguiseCondition);
+		doesNotHaveDisguiseComponents = new Conditions(LogicType.NAND, hasFakeBeard, hasFakeHeadPiece);
+		hasDisguise = new Conditions(desertDisguiseCondition);
+
+		//Shanty
+		hasShantyPass = new ItemRequirements(shantyPass);
+		notThroughShantyGate = new Conditions(LogicType.NAND, throughShantyGate);
+		throughShantyGate = RequirementBuilder.builder()
+				.check(client -> {
+					Player player = client.getLocalPlayer();
+					return player != null && player.getWorldLocation().getY() < 3116;
+				}).build();
+
+		//Blackjack
+		hasOakBlackjack = new ItemRequirements(oakBlackjack);
+		oakBlackjackEquipped = new ItemRequirements(new ItemRequirement("Oak Blackjack", ItemID.OAK_BLACKJACK, 1, true));
+
+		//Snakes
+		hasSnakeBasket = new ItemRequirements(snakeBasket);
+		hasSnakeBasketFull = new ItemRequirements(snakeBasketFull);
+		snakeCharm = new ItemRequirements(snakeCharmHighlighted);
+
+		//Dung
+		hasBucket = new ItemRequirements(bucket);
+		doesNotHaveBucket = new ComplexRequirement(LogicType.NOR, "", new ItemRequirement("Bucket", ItemID.BUCKET));
+		hasRedHotSauce = new ItemRequirements(redHotSauce);
+		hasDungInventory = new ItemRequirements(dung);
+		dungNearby = new ObjectCondition(ObjectID.DUNG);
+
+		//Combat Gear
+		combatGear = new ItemRequirement("Combat Gear \n Bring Range or Mage Gear if safe spotting.", -1, -1 );
+		combatGear.setDisplayItemId(BankSlotIcons.getCombatGear());
+	}
+
+	public void setupSteps()
+	{
+		//Step 0-1
+		//Start Quest & Purchase Disguise
+		startQuest = new NpcStep(this, NpcID.ALI_MORRISANE, new WorldPoint(3304, 3211, 0), "Talk to  Ali Morrisane in Al Kahrid to start the quest.");
+		startQuest.addDialogStep("If you are, then why are you still selling goods from a stall?");
+		startQuest.addDialogStep("I'd like to help you but");
+		startQuest.addDialogStep("I'll find you your help.");
+
+		buyDisguiseGear = new NpcStep(this, NpcID.ALI_MORRISANE, new WorldPoint(3304, 3211, 0), "Buy a Kharidian Headpiece and a Fake Beard to create a disguise.", unspecifiedCoins);
+		buyDisguiseGear.addDialogStep("Okay.");
+
+		createDisguise = new DetailedQuestStep(this, "Create a disguise by using the Kharidian Headpiece on the Fake Beard.", headPiece, fakeBeard);
+
+		//To Pollniveach
+		goToShanty = new ObjectStep(this, ObjectID.SHANTAY_PASS, new WorldPoint(3304, 3116, 0), "Go through Shanty Pass.", shantyPass);
+		buyShantyPass = new NpcStep(this, NpcID.SHANTAY, new WorldPoint(3303, 3122, 0), "Buy a shanty pass from Shantay.", unspecifiedCoins);
+
+		talkToRugMerchant = new NpcStep(this, NpcID.RUG_MERCHANT, new WorldPoint(3311, 3109, 0),"Talk to the rug merchant and travel to Pollnivneach via magic carpet.", unspecifiedCoins);
+		talkToRugMerchant.addDialogStep("Pollnivneach");
+
+		goToPollniveachStep = new DetailedQuestStep(this, "Go through Shanty Pass and travel to Pollnivneach.");
+		goToPollniveachStep.addSubSteps(buyShantyPass, goToShanty, talkToRugMerchant);
+
+		//Drunken Ali
+		drunkenAli = new NpcStep(this, NpcID.DRUNKEN_ALI, new WorldPoint(3360, 2957, 0), "Buy 3 beers from the bartender and use them on Drunken Ali to get him to explain where his son is.", beer);
+		drunkenAli.addIcon(ItemID.BEER);
+
+		//Step 2
+		//Find Beef
+		talkToThug = new NpcStep(this, NpcID.MENAPHITE_THUG, new WorldPoint(3347, 2955, 0), "Talk to a Menaphite Thug to figure out how their dispute started with the bandits.", true);
+		talkToBandit = new NpcStep(this, NpcID.BANDIT_734, new WorldPoint(3362, 2993, 0),"Talk to a bandit to figure out their issues with the Menaphites.", true);
+
+		//Step 3
+		//Buy Camels
+		talkToCamelman = new NpcStep(this, NpcID.ALI_THE_CAMEL_MAN, new WorldPoint(3350, 2966, 0), "Talk to Ali the Camel Man to try and get two camels to solve the dispute");
 		talkToCamelman.addDialogStep("Are those camels around the side for sale?");
 		talkToCamelman.addDialogStep("What price do you want for both of them?");
 		talkToCamelman.addDialogStep("Would 500 gold coins for the pair of them do?");
-		return talkToCamelman;
-	}
 
-	private QuestStep findBeef()
-	{
-		talkToThug = talkToMenaphiteStep("Talk to a Menaphite Thug to figure out how their dispute started with the bandits.");
-		talkToBandit = talkToBanditStep("Talk to a bandit to figure out their issues with the Menaphites.");
 
-		ConditionalStep firstJobStep = new ConditionalStep(this, talkToThug);
-		firstJobStep.addStep(talkedToBandit, talkToCamelman);
-		firstJobStep.addStep(talkedToThug, talkToBandit);
+		//Step 4
+		//Return Camels
+		talkToBanditReturnedCamel = new NpcStep(this, NpcID.BANDIT_734, new WorldPoint(3362, 2993, 0),"Tell the bandits that the Menaphites have agreed to return the camel.", true);
+		talkToMenaphiteReturnedCamel = new NpcStep(this, NpcID.MENAPHITE_THUG, new WorldPoint(3347, 2955, 0), "Tell the Menaphites that the bandits have agreed to return the camel.", true);
 
-		return firstJobStep;
-	}
+		//Step 5
+		//Get First Job
+		talkToAliTheOperator = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0),"Talk to Ali the Operator to get a job from him.");
+		talkToAliTheOperator.addDialogStep("Yes, of course, those bandits should be taught a lesson.");
 
-	private QuestStep getPollnivneachStep()
-	{
-		QuestStep goToShanty = new ObjectStep(this, ObjectID.SHANTAY_PASS, new WorldPoint(3304, 3116, 0), "Go through Shanty Pass.", shantyPass);
-		buyDisguiseGear = talkToAliStep("Buy a Kharidian Headpiece and a Fake Beard to create a disguise.", unspecifiedCoins);
-		NpcStep buyShantypass = new NpcStep(this, NpcID.SHANTAY, new WorldPoint(3303, 3122, 0),
-			"Buy a shanty pass from Shantay.", unspecifiedCoins);
-		buyDisguiseGear.addDialogStep("Okay.");
-		createDisguise = new DetailedQuestStep(this, "Create a disguise by using the Kharidian Headpiece on the Fake Beard. This is used later in the quest.",
-			headPiece, fakeBeard);
+		//Step 6
+		//Pickpocket Villager
+		pickpocketVillager = new NpcStep(this, NpcID.VILLAGER, new WorldPoint(3356, 2962, 0), "Pickpocket a villager.", true);
+		pickpocketVillager.setHideWorldArrow(true);
+		pickpocketVillager.addAlternateNpcs(NpcID.VILLAGER_3555, NpcID.VILLAGER_3558);
 
-		goToPollniveachStep = new DetailedQuestStep(this, "Go through shanty pass and travel to Pollnivneach.");
-		NpcStep talkToRugMerchant = new NpcStep(this, NpcID.RUG_MERCHANT, new WorldPoint(3311, 3109, 0),
-			"Talk to the rug merchant and travel to Pollnivneach via magic carpet.", unspecifiedCoins);
-		talkToRugMerchant.addDialogStep("Pollnivneach");
+		//Step 7 -> 8
+		//Pickpocket with Urchin
+		pickPocketVillagerWithUrchin = new NpcStep(this, NpcID.STREET_URCHIN, "Talk to a street urchin and get them to distract a villager, once he has them distracted pickpocket them from behind.", true);
 
-		drunkenAli = new NpcStep(this, NpcID.DRUNKEN_ALI, new WorldPoint(3360, 2957, 0),
-			"Buy 3 beers from the bartender and use them on Drunken Ali to get him to explain where his son is.",
-			beer);
-		drunkenAli.addIcon(ItemID.BEER);
-		goToPollniveachStep.addSubSteps(buyShantypass);
-		goToPollniveachStep.addSubSteps(goToShanty);
-		goToPollniveachStep.addSubSteps(talkToRugMerchant);
+		//Step 9 -> 11
+		//Blackjack
+		getBlackjackFromAli = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0), ("Talk to Ali the Operator to get a blackjack."));
+		getBlackjackFromAli.addDialogStep("Yeah, I could do with a bit of advice.");
 
-		ConditionalStep conditionalStep = new ConditionalStep(this, buyShantypass);
-		conditionalStep.addStep(pollniveachZoneRequirement, drunkenAli);
-		conditionalStep.addStep(throughShantyGate, talkToRugMerchant);
-		conditionalStep.addStep(new Conditions(notThroughShantyGate, hasShantyPass), goToShanty);
-		conditionalStep.addStep(new Conditions(notThroughShantyGate, doesNotHaveDisguise, doesNotHaveDisguiseComponents), buyDisguiseGear);
-		conditionalStep.addStep(new Conditions(notThroughShantyGate, doesNotHaveDisguise, hasDisguiseComponents), createDisguise);
+		equipBlackjack = new DetailedQuestStep(this, "Equip your oak blackjack in your inventory.", oakBlackjack);
 
-		return conditionalStep;
-	}
+		blackjackVillager = new NpcStep(this, NpcID.VILLAGER, "Lure a villager to secluded place or an empty building, knock them out and then pickpocket them.", true);
+		blackjackVillager.addAlternateNpcs(NpcID.VILLAGER_3555, NpcID.VILLAGER_3557, NpcID.VILLAGER_3558, NpcID.VILLAGER_3560);
+		blackjackVillager.addSubSteps(equipBlackjack);
 
-	private QuestStep getStartQuest()
-	{
-		NpcStep talkToAli = talkToAliStep("Talk to Ali Morrisane to start the quest.");
-		talkToAli.addDialogStep("If you are, then why are you still selling goods from a stall?");
-		talkToAli.addDialogStep("I'd like to help you but.....");
-		talkToAli.addDialogStep("I'll find you your help.");
-		return talkToAli;
-	}
+		//Step 12
+		//Get Second Job
+		talkToAliToGetSecondJob = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0), "Talk to Ali the Operator to get the second job.");
 
-	private NpcStep talkToAliTheHagStep(String text, ItemRequirement... itemRequirements)
-	{
-		return new NpcStep(this, NpcID.ALI_THE_HAG, new WorldPoint(3345, 2986, 0), text, itemRequirements);
-	}
+		//Step 13
+		//Hide Behind Cactus - Second Job
+		hideBehindCactus = new ObjectStep(this, ObjectID.CACTUS_6277, new WorldPoint(3364, 2968, 0), "Hide behind the cactus", glovesEquipped, disguiseEquipped);
 
-	private NpcStep talkToAliTheOperatorStep(String text)
-	{
-		return new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0), text);
-	}
+		//Step 14
+		//Open the Door
+		openTheDoor = new ObjectStep(this, 6238, "Open the door.", doorKeys);
+		openTheDoor.addAlternateObjects(6240);
+		openTheDoor.addIcon(ItemID.KEYS);
 
-	private NpcStep talkToMenaphiteStep(String text)
-	{
-		NpcStep step = new NpcStep(this, NpcID.MENAPHITE_THUG, new WorldPoint(3347, 2955, 0), text, true);
-		step.addAlternateNpcs(NpcID.MENAPHITE_THUG_3550);
-		return step;
-	}
+		goUpStairs = new ObjectStep(this, ObjectID.STAIRCASE_6244, "Go up the stairs.");
 
-	private NpcStep talkToBanditStep(String text)
-	{
-		return new NpcStep(this, NpcID.BANDIT_734, new WorldPoint(3362, 2993, 0), text, true);
-	}
+		crackTheSafe = new ObjectStep(this, 6276, "Search the painting to reveal the safe. Enter the code 1, 1, 2, 3, 5, 8.");
+		crackTheSafe.addSubSteps(goUpStairs);
 
-	private NpcStep talkToAliStep(String text, ItemRequirement... requirements)
-	{
-		return new NpcStep(this, NpcID.ALI_MORRISANE, new WorldPoint(3304, 3211, 0), text, requirements);
-	}
+		//Step 15
+		//Return the Jewels
+		goDownStairs = new ObjectStep(this, ObjectID.STAIRCASE_6245, "Go down the stairs.");
 
-	@Override
-	public List<ItemRequirement> getItemRequirements()
-	{
-		return Arrays.asList(coins, gloves);
-	}
+		giveTheJewelsToAli = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0), "Give Ali the Operator the jewels to get your final task from him.");
+		giveTheJewelsToAli.addSubSteps(goDownStairs);
 
-	@Override
-	public List<ItemRequirement> getItemRecommended()
-	{
-		return Collections.singletonList(combatGear);
-	}
+		//Step 16
+		//Find Traitor
+		talkMenaphiteToFindTraitor =  new NpcStep(this, NpcID.MENAPHITE_THUG, new WorldPoint(3347, 2955, 0),"Talk to a Menaphite member to find the traitor.", true);
+		tellAliYouFoundTraitor = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0),"Talk to Ali and tell him you have found the traitor.");
 
-	@Override
-	public List<String> getCombatRequirements()
-	{
-		return Arrays.asList("Bandit champion (level 70) - Safespottable", "Tough Guy (level 75) - Safespottable");
+		//Step 17
+		//Get Snake & Talk to Barman
+		talkToAliTheBarman = new NpcStep(this, NpcID.ALI_THE_BARMAN, new WorldPoint(3361, 2956, 0), "Talk to Ali the Barman to find outwhere Traitorous Ali is.");
+		talkToAliTheBarman.addDialogStep(("I'm looking for Traitorous Ali."));
+		talkToAliTheBarman.addDialogStep("No thanks I'm ok.");
+
+		talkToAliTheHag = new NpcStep(this, NpcID.ALI_THE_HAG, new WorldPoint(3345, 2986, 0), "Talk to Ali the Hag to ask her to make some poison for you.");
+
+		giveCoinToSnakeCharmer = new ObjectStep(this, ObjectID.MONEY_POT, new WorldPoint(3355, 2953, 0), "Talk to Ali the Hag to ask her to make some poison for you.", highlightedCoins);
+		giveCoinToSnakeCharmer.addIcon(ItemID.COINS);
+
+		catchSnake = new NpcStep(this, NpcID.DESERT_SNAKE, new WorldPoint(3332, 2958, 0), "Use the Snake Charm on a snake to capture it.", true, snakeCharmHighlighted, snakeBasket);
+		catchSnake.addIcon(ItemID.SNAKE_CHARM);
+
+		givePoisonToAliTheHag = new NpcStep(this, NpcID.ALI_THE_HAG, new WorldPoint(3345, 2986, 0), "Give the snake to Ali the Hag.", snakeBasketFull);
+
+		//Step 18
+		//Camel Dung - Get Dung
+		talkToAliTheKebabSalesman = new NpcStep(this, NpcID.ALI_THE_KEBAB_SELLER, new WorldPoint(3352, 2975, 0), "Talk to Ali the Kebab Salesman to get a special sauce to use.");
+		talkToAliTheKebabSalesman.addDialogStep("Would you sell me that bottle of special kebab sauce?");
+		talkToAliTheKebabSalesman.addDialogStep("No thanks, I'm good.");
+
+		getBucket = new DetailedQuestStep(this, new WorldPoint(3346, 2966, 0), "Pick up a bucket to grab the dung");
+
+		pickupDung = new ObjectStep(this, ObjectID.DUNG, "Use the bucket on the dung.", bucket.highlighted());
+		pickupDung.addIcon(ItemID.BUCKET);
+
+		getDung = new ObjectStep(this, ObjectID.TROUGH_6256, new WorldPoint(3343, 2960, 0), "Use the Red Hot Sauce on the Trough and wait for a Camel to poop out the dung.\n Only pickup brown/Ugthanki dung, if you plan to do \"My Arm's Big Adventure\" or \"Forgettable Tale of a Drunken Dwarf\" then you may want to grab four more Ugthanki dung.", redHotSauce);
+		getDung.addSubSteps(getBucket, pickupDung);
+		getDung.addIcon(ItemID.RED_HOT_SAUCE);
+
+		givenDungToHag = new NpcStep(this, NpcID.ALI_THE_HAG, new WorldPoint(3345, 2986, 0), "Talk to Ali the Hag and give her your dung.", dung);
+
+		//Step 22
+		//Poison The Drink
+		poisonTheDrink = new ObjectStep(this, ObjectID.TABLE_6246, new WorldPoint(3356, 2957, 0), "Use the poison on the beer glass to kill Traiterous Ali.", poisonHighlighted);
+		poisonTheDrink.addIcon(ItemID.HAGS_POISON);
+
+		//Step 23
+		//Tell Ali The Operator Poisoned
+		tellAliOperatorPoisoned = new NpcStep(this, NpcID.ALI_THE_OPERATOR, new WorldPoint(3332, 2948, 0), "Talk to Ali the Operator and tell him he is dead.");
+
+		//Step 24
+		//Kill Thug
+		talkToMenaphiteLeader = new NpcStep(this, NpcID.MENAPHITE_LEADER, "Talk to the Menaphite Leader and prepare for a fight against a tough guy. You can safespot him inside the tent by using a chair.");
+		talkToMenaphiteLeader.addSubSteps(killMenaphiteThug);
+
+		killMenaphiteThug = new DetailedQuestStep(this, "Kill the Menahite Thug. You can safespot him inside the tent by using a chair, if he's not spawned then talk to the Menaphite Leader again.");
+
+		//Step 25
+		//Kill Champion - Talk to Villager
+		talkToAVillager = new NpcStep(this, NpcID.VILLAGER, "Talk to a villager and they will be angry you broke the balance of power.", true);
+		talkToAVillager.addAlternateNpcs(NpcID.VILLAGER_3554, NpcID.VILLAGER_3555, NpcID.VILLAGER_3557, NpcID.VILLAGER_3558, NpcID.VILLAGER_3560);
+
+		talkToBanditLeader = new NpcStep(this, NpcID.BANDIT_LEADER, new WorldPoint(3353, 3002, 0), "Talk to the Bandit Leader and be prepared to fight a Bandit Champion. You can safe spot him with the stool.");
+		talkToBanditLeader.addSubSteps(killBanditChampion);
+
+		killBanditChampion = new DetailedQuestStep(this, "Kill the Bandit Champion, you can safe spot him with the stool. \n If he's not spawned then talk to the Bandit Leader again.");
+
+		//Step 26
+		//Spawn Mayor
+		talkToAVillagerToSpawnMayor  = new NpcStep(this, NpcID.VILLAGER, "Talk to a villager and they will be angry still.", true);
+		talkToAVillagerToSpawnMayor.addAlternateNpcs(NpcID.VILLAGER_3554, NpcID.VILLAGER_3555, NpcID.VILLAGER_3557, NpcID.VILLAGER_3558, NpcID.VILLAGER_3560);
+
+		talkToMayor = new NpcStep(this, NpcID.ALI_THE_MAYOR, new WorldPoint(3360, 2972, 0), "Talk to Ali the Mayor and get your due congratulations.");
+
+		//Step 27
+		//Finish Quest
+		finishQuest = new NpcStep(this, NpcID.ALI_MORRISANE, new WorldPoint(3304, 3211, 0), "Talk to  Ali Morrisane in Al Kahrid to finish the quest.");
 	}
 
 	@Override
@@ -587,49 +502,28 @@ public class TheFeud extends BasicQuestHelper
 	}
 
 	@Override
+	public List<ItemRequirement> getItemRequirements()
+	{
+		return Arrays.asList(coins, gloves, combatGear);
+	}
+
+	@Override
+	public List<String> getCombatRequirements()
+	{
+		return Arrays.asList("Bandit Champion (level 70) - Safespottable", "Tough Guy (level 75) - Safespottable");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
-		List<PanelDetails> steps = new ArrayList<>();
+		List<PanelDetails> allSteps = new ArrayList<>();
+		allSteps.add(new PanelDetails("Starting out", Collections.singletonList(startQuest), unspecifiedCoins));
+		allSteps.add(new PanelDetails("Pollnivneach", Arrays.asList(buyDisguiseGear, createDisguise, goToPollniveachStep, drunkenAli), unspecifiedCoins));
+		allSteps.add(new PanelDetails("Find the beef between the two factions", Arrays.asList(talkToThug, talkToBandit, talkToCamelman, talkToBanditReturnedCamel, talkToMenaphiteReturnedCamel), unspecifiedCoins));
+		allSteps.add(new PanelDetails("Second job", Arrays.asList(talkToAliToGetSecondJob, hideBehindCactus, openTheDoor, goUpStairs, crackTheSafe, giveTheJewelsToAli), desertDisguise, gloves));
+		allSteps.add(new PanelDetails("Rising up", Arrays.asList(talkMenaphiteToFindTraitor, tellAliYouFoundTraitor, talkToAliTheBarman, talkToAliTheHag, giveCoinToSnakeCharmer, catchSnake, givePoisonToAliTheHag, talkToAliTheKebabSalesman, getDung, givenDungToHag, tellAliOperatorPoisoned), unspecifiedCoins));
+		allSteps.add(new PanelDetails("Finishing off", Arrays.asList(talkToMenaphiteLeader, talkToAVillager, talkToBanditLeader, talkToAVillagerToSpawnMayor, talkToMayor, finishQuest), combatGear));
 
-		PanelDetails startingPanel = new PanelDetails("Starting out",
-			Collections.singletonList(startQuest),
-			unspecifiedCoins);
-		steps.add(startingPanel);
-
-		PanelDetails pollniveachPanel = new PanelDetails("Pollnivneach",
-			Arrays.asList(buyDisguiseGear, createDisguise, goToPollniveachStep, drunkenAli),
-			unspecifiedCoins);
-		steps.add(pollniveachPanel);
-
-		PanelDetails findTheBeefJobPanel = new PanelDetails("Find the beef",
-			Arrays.asList(talkToThug, talkToBandit, talkToCamelman, talkToBanditReturnedCamel, talkToMenaphiteReturnedCamel),
-			unspecifiedCoins);
-		steps.add(findTheBeefJobPanel);
-
-		PanelDetails firstJobPanel = new PanelDetails("First job",
-			Arrays.asList(talkToAliTheOperator, pickpocketVillager, pickPocketVillagerWithUrchin,
-				getBlackjackFromAli, blackJackVillager),
-			unspecifiedCoins);
-		steps.add(firstJobPanel);
-
-		PanelDetails secondJobPanel = new PanelDetails("Second job",
-			Arrays.asList(talkToAliToGetSecondJob, hideBehindCactus, openTheDoor, goUpStairs,
-				crackTheSafe, giveTheJewelsToAli),
-			desertDisguise, gloves);
-		steps.add(secondJobPanel);
-
-		PanelDetails thirdJobPanel = new PanelDetails("Third job",
-			Arrays.asList(talkMenaphiteToFindTraitor, tellAliYouFoundTraitor, talkToAliTheBarman,
-				talkToAliTheHag, giveCoinToSnakeCharmer, catchSnake, givePoisonToAliTheHag, talkToAliTheKebabSalesman, getDung,
-				givenDungToHag, tellAliOperatorPoisoned), unspecifiedCoins);
-		steps.add(thirdJobPanel);
-
-		PanelDetails finishingUpPanel = new PanelDetails("Finishing up",
-			Arrays.asList(talkToMenaphiteLeader, talkToAVillager, talkToBanditLeader,
-				talkToAVillagerToSpawnMayor, talkToMayor, finishQuest), combatGear
-		);
-		steps.add(finishingUpPanel);
-
-		return steps;
+		return allSteps;
 	}
 }

--- a/src/main/java/com/questhelper/quests/thefeud/TheFeud.java
+++ b/src/main/java/com/questhelper/quests/thefeud/TheFeud.java
@@ -43,6 +43,10 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.RequirementBuilder;
+import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
@@ -511,6 +515,39 @@ public class TheFeud extends BasicQuestHelper
 	public List<String> getCombatRequirements()
 	{
 		return Arrays.asList("Bandit Champion (level 70) - Safespottable", "Tough Guy (level 75) - Safespottable");
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(1);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Collections.singletonList(new ExperienceReward(Skill.THIEVING, 15000));
+	}
+
+	@Override
+	public List<ItemReward> getItemRewards()
+	{
+		return Arrays.asList(
+				new ItemReward("500 Coins", ItemID.COINS_995, 500),
+				new ItemReward("Oak Blackjack", ItemID.OAK_BLACKJACK, 1),
+				new ItemReward("Desert Disguise", ItemID.DESERT_DISGUISE, 1),
+				new ItemReward("Willow Blackjack", ItemID.WILLOW_BLACKJACK, 1),
+				new ItemReward("An Adamant Scimitar", ItemID.ADAMANT_SCIMITAR, 1)
+		);
+	}
+
+	@Override
+	public List<UnlockReward> getUnlockRewards()
+	{
+		return Arrays.asList(
+				new UnlockReward("Ability to blackjack."),
+				new UnlockReward("Access to the Rogue Trader minigame")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theforsakentower/TheForsakenTower.java
+++ b/src/main/java/com/questhelper/quests/theforsakentower/TheForsakenTower.java
@@ -225,6 +225,12 @@ public class TheForsakenTower extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "500 Mining Experience", "500 Smithing Experience", "</br>", "6,000 Coins", "Lovakengj favour certificate.", "A page for Kharedst's memoirs.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikexiles/TheFremennikExiles.java
@@ -498,6 +498,12 @@ public class TheFremennikExiles extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "15,000 Slayer Experience", "15,000 Crafting Experience", "5,000 Runecrafting Experience", "</br>", "V's Shield", "</br>", "Access to the Isle of Stone.", "Ability to kill Basilisk Knights as a slayer task.", "Ability to craft and equip the Neitiznot faceguard.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -576,6 +576,12 @@ public class TheFremennikIsles extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Construction Experience", "5,000 Crafting Experience", "10,000 Woodcutting Experience", "2 x 10,000 Experience Lamps (Combat)", "A Helm of Neitiznot", "A Jester Outfit");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thefremenniktrials/TheFremennikTrials.java
+++ b/src/main/java/com/questhelper/quests/thefremenniktrials/TheFremennikTrials.java
@@ -923,6 +923,12 @@ public class TheFremennikTrials extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "2,812 Agility Experience", "2,812 Attack Experience", "2,812 Crafting Experience", "2,812 Defence Experience", "2,812 Fishing Experience", "2,812 Fletching Experience", "2,812 Hitpoints Experience", "2,812 Strength Experience", "2,812 Thieving Experience", "2,812 Woodcutting Experience", "</br>", "Access to Miscellania, Etceteria, Neitiznot, Jatizso and the facilities of Rellekka.", "Ability to wear the Fremennik helms", "Free travel to Waterbirth Island.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thegeneralsshadow/TheGeneralsShadow.java
+++ b/src/main/java/com/questhelper/quests/thegeneralsshadow/TheGeneralsShadow.java
@@ -246,6 +246,12 @@ public class TheGeneralsShadow extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2,000 Slayer Experience", "</br>", "The Shadow Sword.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thegiantdwarf/TheGiantDwarf.java
+++ b/src/main/java/com/questhelper/quests/thegiantdwarf/TheGiantDwarf.java
@@ -462,6 +462,12 @@ public class TheGiantDwarf extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2,500 Mining Experience", "2,500 Smithing Experience", "2,500 Crafting Experience", "1,500 Magic Experience", "1,500 Thieving Experience", "1,500 Firemaking Experience");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thegolem/TheGolem.java
+++ b/src/main/java/com/questhelper/quests/thegolem/TheGolem.java
@@ -343,6 +343,12 @@ public class TheGolem extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Points", "</br>", "1,000 Thieving Experience", "1,000 Crafting Experience", "</br>", "2 x Rubies", "2 x Emeralds", "2x Sapphires", "</br>", "Ability to take the Carpet ride from Shanty Pass to Uzer.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thegrandtree/TheGrandTree.java
+++ b/src/main/java/com/questhelper/quests/thegrandtree/TheGrandTree.java
@@ -432,6 +432,12 @@ public class TheGrandTree extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("5 Quest Points", "</br>", "18,400 Attack Experience", "7,900 Agility Experience", "2,150 Magic Experience", "</br>", "Access to the Gnomer Glider transportation system.", "Ability to use the Spirit Tree in the Stronghold.");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -557,6 +557,12 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "6,000 Prayer Experience", "3,000 Crafting Experience", "2,000 Construction Experience", "5,000 Experience Lamp (Any Skill above level 30)", "</br>", "Barrelchest Anchor", "Prayer Book");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thehandinthesand/TheHandInTheSand.java
+++ b/src/main/java/com/questhelper/quests/thehandinthesand/TheHandInTheSand.java
@@ -285,6 +285,12 @@ public class TheHandInTheSand extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Points", "</br>", "1,000 Thieving Experience", "9,000 Crafting Experience", "</br>", "Daily sand from Bert in Yanille", "Access to the Wizards Guild rune store.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
+++ b/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
@@ -207,6 +207,12 @@ public class TheKnightsSword extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "12,725 Smithing Experience", "</br>", "The ability to smelt Blurite ore.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thelosttribe/TheLostTribe.java
+++ b/src/main/java/com/questhelper/quests/thelosttribe/TheLostTribe.java
@@ -370,6 +370,12 @@ public class TheLostTribe extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "3,000 Mining Experience", "</br>", "A ring of life", "Access to Dorgesh-Kann mine", "Access to Nardok's Bone Weapon Store", "2 new goblin emotes.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/themagearenai/TheMageArenaI.java
+++ b/src/main/java/com/questhelper/quests/themagearenai/TheMageArenaI.java
@@ -179,6 +179,12 @@ public class TheMageArenaI extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("A God Staff of your choosing", "A God Cloak of your choosing", "Ability to unlock the 3 God Spells");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/themagearenaii/TheMageArenaII.java
+++ b/src/main/java/com/questhelper/quests/themagearenaii/TheMageArenaII.java
@@ -255,6 +255,12 @@ public class TheMageArenaII extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("An upgraded God Cloak");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thequeenofthieves/TheQueenOfThieves.java
+++ b/src/main/java/com/questhelper/quests/thequeenofthieves/TheQueenOfThieves.java
@@ -222,6 +222,12 @@ public class TheQueenOfThieves extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,000 Thieving Experience", "</br>", "2,000 Coins", "A Favour Certificate", "Access to the Warrens", "A Page for Kharedst's Memoirs");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/therestlessghost/TheRestlessGhost.java
+++ b/src/main/java/com/questhelper/quests/therestlessghost/TheRestlessGhost.java
@@ -171,6 +171,12 @@ public class TheRestlessGhost extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "1,125 Prayer Experience", "</br>", "Ghostspeak Amulet");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
@@ -419,6 +419,12 @@ public class TheSlugMenace extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "3,500 Crafting Experience", "3,500 Runecrafting Experience", "3,500 Thieving Experience", "Ability to purchase and equip Proselyte equipment.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/thetouristtrap/TheTouristTrap.java
+++ b/src/main/java/com/questhelper/quests/thetouristtrap/TheTouristTrap.java
@@ -413,6 +413,12 @@ public class TheTouristTrap extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "2 x 4,650 Experience Lamps (Agility, Fletching, Smithing, or Thieving)", "</br>", "Ability to smith darts");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/throneofmiscellania/ThroneOfMiscellania.java
+++ b/src/main/java/com/questhelper/quests/throneofmiscellania/ThroneOfMiscellania.java
@@ -508,6 +508,12 @@ public class ThroneOfMiscellania extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "Ability to Manage Miscellania", "Ability to teleport to Miscellania using a Ring of Wealth");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/toweroflife/TowerOfLife.java
+++ b/src/main/java/com/questhelper/quests/toweroflife/TowerOfLife.java
@@ -461,6 +461,12 @@ public class TowerOfLife extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "1,000 Construction Experience", "500 Crafting Experience", "500 Thieving Experience", "</br>", "Access to Creature Creation", "Builders Costume");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/treegnomevillage/TreeGnomeVillage.java
+++ b/src/main/java/com/questhelper/quests/treegnomevillage/TreeGnomeVillage.java
@@ -323,6 +323,12 @@ public class TreeGnomeVillage extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "11,450 Attack Experience", "</br>", "Use of Spirit Tree transportation method");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> steps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/tribaltotem/TribalTotem.java
+++ b/src/main/java/com/questhelper/quests/tribaltotem/TribalTotem.java
@@ -175,6 +175,12 @@ public class TribalTotem extends BasicQuestHelper
 	}
 
     @Override
+    public List<String> getQuestRewards()
+    {
+        return Arrays.asList("1 Quest Point", "</br>", "1,775 Thieving Experience", "</br>", "5 Swordfish");
+    }
+
+    @Override
     public List<PanelDetails> getPanels()
     {
         List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/trollromance/TrollRomance.java
+++ b/src/main/java/com/questhelper/quests/trollromance/TrollRomance.java
@@ -285,6 +285,12 @@ public class TrollRomance extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("2 Quest Points", "</br>", "8,000 Agility Experience", "4,000 Strength Experience", "</br>", "1 x Diamond", "2 x Rubies", "4 x Emeralds", "A sled", "</br>", "Sledding route from Trollweiss Mountain");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/trollstronghold/TrollStronghold.java
+++ b/src/main/java/com/questhelper/quests/trollstronghold/TrollStronghold.java
@@ -290,6 +290,12 @@ public class TrollStronghold extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "Law talisman", "</br>", "Ability to make law runes", "Access to Trollheim and Troll Stronghold", "Access to God Wars Dungeon");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/undergroundpass/UndergroundPass.java
+++ b/src/main/java/com/questhelper/quests/undergroundpass/UndergroundPass.java
@@ -798,6 +798,12 @@ public class UndergroundPass extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("5 Quest Points", "</br>", "3,000 Agility Experience", "3,000 Attack Experience", "</br>", "Iban's Staff and use of Ibans Blast spell.");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/vampyreslayer/VampyreSlayer.java
+++ b/src/main/java/com/questhelper/quests/vampyreslayer/VampyreSlayer.java
@@ -177,6 +177,12 @@ public class VampyreSlayer extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("3 Quest Points", "</br>", "4,825 Attack Experience");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/wanted/Wanted.java
+++ b/src/main/java/com/questhelper/quests/wanted/Wanted.java
@@ -541,6 +541,12 @@ public class Wanted extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "5,000 Slayer Experience", "</br>", "Access to the White Knights Armory");
+	}
+
+	@Override
 	public ArrayList<PanelDetails> getPanels()
 	{
 		ArrayList<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/watchtower/Watchtower.java
+++ b/src/main/java/com/questhelper/quests/watchtower/Watchtower.java
@@ -640,6 +640,12 @@ public class Watchtower extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Points", "</br>", "15,250 Magic Experience", "</br>", "5,000 Coins", "</br>", "Ability to use the Watchtower Teleport", "Access to the Ogre City, and Ogre Enclave");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/waterfallquest/WaterfallQuest.java
+++ b/src/main/java/com/questhelper/quests/waterfallquest/WaterfallQuest.java
@@ -284,6 +284,12 @@ public class WaterfallQuest extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "13,750 Strength Experience", "13,750 Attack Experience", "</br>", "2 x Diamonds", "2 x Gold Bars", "40 x Mithril Seeds");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/whatliesbelow/WhatLiesBelow.java
+++ b/src/main/java/com/questhelper/quests/whatliesbelow/WhatLiesBelow.java
@@ -259,6 +259,12 @@ public class WhatLiesBelow extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "8,000 Runecraft Experience", "2,000 Defence Experience", "</br>", "The Beacon Ring", "</br>", "Access to a shortcut to the Chaos Altar");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/witchshouse/WitchsHouse.java
+++ b/src/main/java/com/questhelper/quests/witchshouse/WitchsHouse.java
@@ -237,6 +237,12 @@ public class WitchsHouse extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("4 Quest Points", "</br>", "6,325 Hitpoints Experience");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/witchspotion/WitchsPotion.java
+++ b/src/main/java/com/questhelper/quests/witchspotion/WitchsPotion.java
@@ -120,6 +120,12 @@ public class WitchsPotion extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "325 Magic Experience");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/quests/xmarksthespot/XMarksTheSpot.java
+++ b/src/main/java/com/questhelper/quests/xmarksthespot/XMarksTheSpot.java
@@ -130,6 +130,11 @@ public class XMarksTheSpot extends BasicQuestHelper
 		return reqs;
 	}
 
+	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "300 Experience Lamp (Any Skill)", "</br>", "200 Coins", "A Beginner Clue Scroll");
+	}
 
 	@Override
 	public List<PanelDetails> getPanels()

--- a/src/main/java/com/questhelper/quests/zogreflesheaters/ZogreFleshEaters.java
+++ b/src/main/java/com/questhelper/quests/zogreflesheaters/ZogreFleshEaters.java
@@ -377,6 +377,12 @@ public class ZogreFleshEaters extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getQuestRewards()
+	{
+		return Arrays.asList("1 Quest Point", "</br>", "2,000 Fletching Experience", "2,000 Ranged Experience", "2,000 Herblore Experience", "</br>", "3 Ourg Bones", "2 Zogre Bones", "</br>", "Ability to make Relicym's balm", "Ability to fletch Comp ogre bows and Brutal Arrows", "Ability to wear Inoculation bracelets");
+	}
+
+	@Override
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();

--- a/src/main/java/com/questhelper/rewards/ExperienceReward.java
+++ b/src/main/java/com/questhelper/rewards/ExperienceReward.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.rewards;
+
+import javax.annotation.Nonnull;
+import net.runelite.api.Skill;
+
+public class ExperienceReward implements Reward
+{
+	private final Skill skill;
+	private final int experience;
+
+	public ExperienceReward(Skill skill, int experience)
+	{
+		this.skill = skill;
+		this.experience = experience;
+	}
+
+	@Nonnull
+	@Override
+	public RewardType rewardType()
+	{
+		return RewardType.EXPERIENCE;
+	}
+
+	@Nonnull
+	@Override
+	public String getDisplayText()
+	{
+		return experience + " " + skill.name() + " Experience";
+	}
+}

--- a/src/main/java/com/questhelper/rewards/ItemReward.java
+++ b/src/main/java/com/questhelper/rewards/ItemReward.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Kerpackie
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.rewards;
+
+import javax.annotation.Nonnull;
+
+import net.runelite.api.ItemID;
+import net.runelite.api.Skill;
+
+public class ItemReward implements Reward {
+    private final String name;
+    private final ItemID itemID;
+    private final int quantity;
+
+    public ItemReward(String name, ItemID itemID, int quantity) {
+        this.name = name;
+        this.itemID = itemID;
+        this.quantity = quantity;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Nonnull
+    @Override
+    public RewardType rewardType() {
+        return RewardType.ITEM;
+    }
+
+    @Nonnull
+    @Override
+    public String getDisplayText()
+    {
+        return getName();
+    }
+}

--- a/src/main/java/com/questhelper/rewards/ItemReward.java
+++ b/src/main/java/com/questhelper/rewards/ItemReward.java
@@ -31,7 +31,7 @@ import net.runelite.api.Skill;
 
 public class ItemReward implements Reward {
     private final String name;
-    private final ItemID itemID;
+    private final int itemID;
     private final int quantity;
 
     public ItemReward(String name, int itemID, int quantity) {

--- a/src/main/java/com/questhelper/rewards/ItemReward.java
+++ b/src/main/java/com/questhelper/rewards/ItemReward.java
@@ -34,7 +34,7 @@ public class ItemReward implements Reward {
     private final ItemID itemID;
     private final int quantity;
 
-    public ItemReward(String name, ItemID itemID, int quantity) {
+    public ItemReward(String name, int itemID, int quantity) {
         this.name = name;
         this.itemID = itemID;
         this.quantity = quantity;

--- a/src/main/java/com/questhelper/rewards/QuestPointReward.java
+++ b/src/main/java/com/questhelper/rewards/QuestPointReward.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.rewards;
+
+import javax.annotation.Nonnull;
+
+public class QuestPointReward implements Reward
+{
+	private final int points;
+
+	public QuestPointReward(int points)
+	{
+		this.points = points;
+	}
+
+	@Nonnull
+	@Override
+	public RewardType rewardType()
+	{
+		return RewardType.QUEST_POINT;
+	}
+
+	@Nonnull
+	@Override
+	public String getDisplayText()
+	{
+		return points + " Quest Points";
+	}
+}

--- a/src/main/java/com/questhelper/rewards/Reward.java
+++ b/src/main/java/com/questhelper/rewards/Reward.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.rewards;
+
+import javax.annotation.Nonnull;
+
+public interface Reward
+{
+	@Nonnull
+	RewardType rewardType();
+
+	@Nonnull
+	String getDisplayText();
+}

--- a/src/main/java/com/questhelper/rewards/RewardType.java
+++ b/src/main/java/com/questhelper/rewards/RewardType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.rewards;
+
+public enum RewardType
+{
+	EXPERIENCE,
+	UNLOCK,
+	QUEST_POINT
+}

--- a/src/main/java/com/questhelper/rewards/RewardType.java
+++ b/src/main/java/com/questhelper/rewards/RewardType.java
@@ -28,5 +28,6 @@ public enum RewardType
 {
 	EXPERIENCE,
 	UNLOCK,
+	ITEM,
 	QUEST_POINT
 }

--- a/src/main/java/com/questhelper/rewards/UnlockReward.java
+++ b/src/main/java/com/questhelper/rewards/UnlockReward.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Zoinkwiz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.rewards;
+
+import javax.annotation.Nonnull;
+
+public class UnlockReward implements Reward
+{
+	private final String unlock;
+
+	public UnlockReward(String unlock)
+	{
+		this.unlock = unlock;
+	}
+
+	@Nonnull
+	@Override
+	public RewardType rewardType()
+	{
+		return RewardType.UNLOCK;
+	}
+
+	@Nonnull
+	@Override
+	public String getDisplayText()
+	{
+		return unlock;
+	}
+}


### PR DESCRIPTION
Added all quest rewards to the side-panel, as has been requested a few times.

Functions the same as other recommended and required side-panels.

Panels are set to always show, as each quest should have a reward by default. (May need to be changed if Custom quests are added in the future). This is done so that a report can easily be made if a quest is missing its rewards.