### PR TITLE
Fix karamja medium diary quest requirement

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
@@ -208,7 +208,7 @@ public class KaramjaMedium extends BasicQuestHelper
 			"completion of Tai Bwo Wannai Trio to fish karambwan");
 		dragonSlayerI = new QuestRequirement(QuestHelperQuest.DRAGON_SLAYER_I, QuestState.FINISHED, "Partial " +
 			"completion of Dragon Slayer I for access to Crandor");
-		shiloVillage = new QuestRequirement(QuestHelperQuest.THE_GRAND_TREE, QuestState.FINISHED);
+		shiloVillage = new QuestRequirement(QuestHelperQuest.SHILO_VILLAGE, QuestState.FINISHED);
 
 
 		// 3578 = 2, completed final task

--- a/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
@@ -314,7 +314,7 @@ public class KaramjaMedium extends BasicQuestHelper
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
-		allSteps.add(new PanelDetails("Easy Diary", Arrays.asList(enterVolcano, returnThroughWall, enterAgilityArena,
+		allSteps.add(new PanelDetails("Medium Diary", Arrays.asList(enterVolcano, returnThroughWall, enterAgilityArena,
 			tag2Pillars, useCart, mineRedTopaz, travelToKhazard, flyToKaramja, catchKarambwan, charterFromShipyard,
 			trapGraahk, doCleanup, makeSpiderStick, cookSpider, cutTeak, cutMahogany, getMachete,
 			enterBrimhavenDungeon, chopVines, crossLava, climbBrimhavenStaircase, growFruitTree, claimReward),


### PR DESCRIPTION
In the Karamja Medium Diary, one of the requirements is intended to be the Shilo Village quest, but ended up being a duplicate line of The Grand Tree, probably due to a copy-paste error. This PR fixes these.