### PR TITLE
Added quest requirement to 'Client of Kourend'

### DIFF
--- a/src/main/java/com/questhelper/quests/clientofkourend/ClientOfKourend.java
+++ b/src/main/java/com/questhelper/quests/clientofkourend/ClientOfKourend.java
@@ -163,6 +163,14 @@ public class ClientOfKourend extends BasicQuestHelper
 		reqs.add(feather);
 		return reqs;
 	}
+	
+	@Override
+	public List<Requirement> getGeneralRequirements()
+	{
+		List<Requirement> reqs = new ArrayList<>();
+		reqs.add(new QuestRequirement(QuestHelperQuest.X_MARKS_THE_SPOT, QuestState.FINISHED));
+		return reqs;
+	}
 
 	@Override
 	public List<PanelDetails> getPanels()


### PR DESCRIPTION
Quest 'Client of Kourend' requires completion of 'X Marks the Spot'.
Source: https://oldschool.runescape.wiki/w/Client_of_Kourend (also confirmed in-game)