### PR TITLE
Fix spelling mistake in 'Jungle Potion' quest

### DIFF
--- a/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
+++ b/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
@@ -235,7 +235,7 @@ public class JunglePotion extends BasicQuestHelper
 	public List<String> getCombatRequirements()
 	{
 		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Surive against level 53 Jogres and level 46 Harpie Bug Swarms.");
+		reqs.add("Survive against level 53 Jogres and level 46 Harpie Bug Swarms.");
 		return reqs;
 	}
 


### PR DESCRIPTION
Changes `Surive` to `Survive`. This will resolve issue #322 