### PR TITLE
Fix Amelia location in DS2

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorHard.java
@@ -274,6 +274,7 @@ public class FaladorHard extends ComplexStateQuestHelper {
         req.add(new SkillRequirement(Skill.RUNECRAFT, 56, true));
         req.add(new SkillRequirement(Skill.THIEVING, 50, true));
         req.add(new SkillRequirement(Skill.DEFENCE, 50, true));
+        req.add(new SkillRequirement(Skill.SLAYER, 72, true));
         req.add(new SkillRequirement(Skill.ATTACK, 65, false, "130 Total combined Attack and Strength"));
         req.add(new SkillRequirement(Skill.STRENGTH, 65, false, "or 99 in either Attack or Strength."));
 

--- a/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
@@ -813,7 +813,7 @@ public class DragonSlayerII extends BasicQuestHelper
 		talkToBobAfterRobertFight = new NpcStep(this, NpcID.BOB_8111, new WorldPoint(2074, 3912, 0), "Talk to Bob next to the brazier.");
 
 		// Kourend key piece
-		talkToAmelia = new NpcStep(this, NpcID.AMELIA, new WorldPoint(1496, 3596, 0), "Talk to Amelia south west of the Shayzien bank.");
+		talkToAmelia = new NpcStep(this, NpcID.AMELIA, new WorldPoint(1540, 3545, 0), "Talk to Amelia south west of the Shayzien Archery Store.");
 		enterCrypt = new ObjectStep(this, ObjectID.CRYPT_ENTRANCE, new WorldPoint(1483, 3548, 0), "Enter the Crypt south of Amelia.");
 		goDownInCryptF2ToF1 = new ObjectStep(this, ObjectID.LADDER_32397, new WorldPoint(1524, 9967, 3), "Climb down to the bottom of the crypts.");
 		goDownInCryptF1ToF0 = new ObjectStep(this, ObjectID.STAIRCASE_32394, new WorldPoint(1511, 9979, 2), "Climb down to the bottom of the crypts.");


### PR DESCRIPTION
Fixes Amelias location in DS2, this should stop players wondering about, and getting lost. (Reported at least 2x daily)

Added Slayer Req for Fally Hard.