### PR TITLE
Garden of Tranquility: added tooltip to compost requirement.

### DIFF
--- a/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
+++ b/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
@@ -237,14 +237,14 @@ public class GardenOfTranquillity extends BasicQuestHelper
 		plantPot = new ItemRequirement("Filled plant pot", ItemID.FILLED_PLANT_POT);
 		compost2 = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST, 2);
 		compost2.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);
-		compost2.setTooltip("Bottomless bucket will not work for these two required composts.");
+		compost2.setTooltip("Bottomless bucket will not work for this compost.");
 		compost = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST);
 		compost.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);
 		compost.setTooltip("Bottomless bucket will not work for these two required composts.");
 
 		compost5 = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST, 5);
 		compost5.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);
-		compost5.setTooltip("Bottomless bucket will not work for these two required composts.");
+		compost5.setTooltip("Bottomless bucket will not work for these five required composts.");
 		fishingRod = new ItemRequirement("Fishing rod", ItemID.FISHING_ROD);
 		fishingRod.addAlternates(ItemID.FLY_FISHING_ROD);
 		varrockTeleport = new ItemRequirement("Varrock teleport", ItemID.VARROCK_TELEPORT);

--- a/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
+++ b/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
@@ -237,8 +237,10 @@ public class GardenOfTranquillity extends BasicQuestHelper
 		plantPot = new ItemRequirement("Filled plant pot", ItemID.FILLED_PLANT_POT);
 		compost2 = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST, 2);
 		compost2.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);
+		compost2.setTooltip("Bottomless bucket will not work for these two required composts.");
 		compost = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST);
 		compost.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);
+		compost.setTooltip("Bottomless bucket will not work for these two required composts.");
 
 		compost5 = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST, 5);
 		compost5.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);

--- a/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
+++ b/src/main/java/com/questhelper/quests/gardenoftranquility/GardenOfTranquillity.java
@@ -244,6 +244,7 @@ public class GardenOfTranquillity extends BasicQuestHelper
 
 		compost5 = new ItemRequirement("Normal/Super/Ultra compost", ItemID.COMPOST, 5);
 		compost5.addAlternates(ItemID.SUPERCOMPOST, ItemID.ULTRACOMPOST);
+		compost5.setTooltip("Bottomless bucket will not work for these two required composts.");
 		fishingRod = new ItemRequirement("Fishing rod", ItemID.FISHING_ROD);
 		fishingRod.addAlternates(ItemID.FLY_FISHING_ROD);
 		varrockTeleport = new ItemRequirement("Varrock teleport", ItemID.VARROCK_TELEPORT);


### PR DESCRIPTION
I've noticed that you cannot use the Bottomless Bucket for the compost requirement during the Garden of Tranquility, though it isn't mentioned within the plugin. I've added a simple tooltip to make it known that you cannot use a bottomless bucket.