### PR TITLE
Fix Mudskipper Point name in Falador Medium

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
@@ -244,7 +244,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 
 		//Mogre
 		spawnMogre = new ObjectStep(this, ObjectID.OMINOUS_FISHING_SPOT,
-			"Go to Mogre Point south of Port Sarim and use your fishing explosive to spawn a Mogre.", fishingExplosiveHighlight);
+			"Go to Mudskipper Point south of Port Sarim and use your fishing explosive to spawn a Mogre.", fishingExplosiveHighlight);
 		spawnMogre.addAlternateObjects(ObjectID.OMINOUS_FISHING_SPOT_10088, ObjectID.OMINOUS_FISHING_SPOT_10089);
 		spawnMogre.addIcon(ItemID.FISHING_EXPLOSIVE);
 		killMogre = new NpcStep(this, NpcID.MOGRE,


### PR DESCRIPTION
The name of the area should be Mudskipper Point rather than Mogre Point, I believe.