### PR TITLE
Replace "Chaos Altar" step with "Chaos Temple"

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
@@ -76,7 +76,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		notKilledMogre, notVisitRatPits, notGrappleNorthWall, notPickpocketGuard, notPrayAtAltar,
 		notMineGold, notDwarfShortcut, notChopBurnWillowTav, notBasketFalLoom, notTeleportFalador;
 
-	QuestStep claimReward, goToChemist, lightLantern, goToChaosAltar, telegrabWine, unlockCrystalChest,
+	QuestStep claimReward, goToChemist, lightLantern, goToChaosTemple, telegrabWine, unlockCrystalChest,
 		getHaysack, useSackOnSpear, useWatermelonOnSack, placeScarecrow, killMogre, visitRatPits,
 		grappleNorthWallStart, grappleNorthWallEnd, prayAtAltar, getInitiateSet, goToCraftingGuild,
 		mineGold, enterDwarvenMines, dwarfShortcut, goToTav, chopWillowLog, burnWillowLog,
@@ -122,7 +122,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		doMed.addStep(notTeleportFalador, teleportToFalador);
 		doMed.addStep(notPickpocketGuard, pickpocketGuard);
 		doMed.addStep(new Conditions(notTelegrabbedWine, inChaosAltar), telegrabWine);
-		doMed.addStep(notTelegrabbedWine, goToChaosAltar);
+		doMed.addStep(notTelegrabbedWine, goToChaosTemple);
 
 		return doMed;
 	}
@@ -219,9 +219,9 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		lightLantern = new DetailedQuestStep(this,
 			"Use the tinderbox on the bullseye lantern.", bullseyeLanternHighLight, tinderboxHighlight);
 
-		//Telegrab - Chaos Altar
-		goToChaosAltar = new DetailedQuestStep(this, new WorldPoint(2934, 3516, 0),
-			"Go to the Chaos Altar near the Goblin Village north of Falador.");
+		//Telegrab - Chaos Temple
+		goToChaosTemple = new DetailedQuestStep(this, new WorldPoint(2934, 3516, 0),
+			"Go to the Chaos Temple near the Goblin Village north of Falador.");
 		telegrabWine = new DetailedQuestStep(this,
 			"Use the Telekinetic Grab Spell on the Wine of Zamorak.");
 		telegrabWine.addIcon(ItemID.TELEKINETIC_GRAB);
@@ -429,7 +429,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		pickGuardSteps.setDisplayCondition(notPickpocketGuard);
 		allSteps.add(pickGuardSteps);
 
-		PanelDetails teleGrabSteps = new PanelDetails("Yoink!", Arrays.asList(goToChaosAltar, telegrabWine),
+		PanelDetails teleGrabSteps = new PanelDetails("Yoink!", Arrays.asList(goToChaosTemple, telegrabWine),
 			new SkillRequirement(Skill.MAGIC, 33, true), telegrab);
 		teleGrabSteps.setDisplayCondition(notTelegrabbedWine);
 		allSteps.add(teleGrabSteps);

--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
@@ -86,9 +86,9 @@ public class FaladorMedium extends ComplexStateQuestHelper
 
 	ObjectStep spawnMogre;
 
-	Zone chemist, chaosAltar, craftingGuild, dwarvenMine, tav, falNorthWall;
+	Zone chemist, chaosTemple, craftingGuild, dwarvenMine, tav, falNorthWall;
 
-	ZoneRequirement inChemist, inChaosAltar, inCraftingGuild, inDwarvenMine, inTav, inFalNorthWall;
+	ZoneRequirement inChemist, inChaosTemple, inCraftingGuild, inDwarvenMine, inTav, inFalNorthWall;
 
 	@Override
 	public QuestStep loadStep()
@@ -121,7 +121,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		doMed.addStep(notDwarfShortcut, enterDwarvenMines);
 		doMed.addStep(notTeleportFalador, teleportToFalador);
 		doMed.addStep(notPickpocketGuard, pickpocketGuard);
-		doMed.addStep(new Conditions(notTelegrabbedWine, inChaosAltar), telegrabWine);
+		doMed.addStep(new Conditions(notTelegrabbedWine, inChaosTemple), telegrabWine);
 		doMed.addStep(notTelegrabbedWine, goToChaosTemple);
 
 		return doMed;
@@ -193,7 +193,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		combatBracelet.addAlternates(ItemCollections.getGamesNecklaces());
 
 		inChemist = new ZoneRequirement(chemist);
-		inChaosAltar = new ZoneRequirement(chaosAltar);
+		inChaosTemple = new ZoneRequirement(chaosTemple);
 		inCraftingGuild = new ZoneRequirement(craftingGuild);
 		inDwarvenMine = new ZoneRequirement(dwarvenMine);
 		inTav = new ZoneRequirement(tav);
@@ -204,7 +204,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 	public void loadZones()
 	{
 		chemist = new Zone(new WorldPoint(2929, 3213, 0), new WorldPoint(2936, 3207, 0));
-		chaosAltar = new Zone(new WorldPoint(2935, 3513, 0), new WorldPoint(2929, 3518, 0));
+		chaosTemple = new Zone(new WorldPoint(2935, 3513, 0), new WorldPoint(2929, 3518, 0));
 		craftingGuild = new Zone(new WorldPoint(2929, 3288, 0), new WorldPoint(2943, 3276, 0));
 		dwarvenMine = new Zone(new WorldPoint(2979, 9855, 0), new WorldPoint(3069, 9698, 0));
 		tav = new Zone(new WorldPoint(2939, 3398, 0), new WorldPoint(2878, 3489, 0));


### PR DESCRIPTION
The name of the building containing the Wine of Zamorak is called the "[Chaos Temple](https://oldschool.runescape.wiki/w/Chaos_Temple_(Asgarnia))". Having the step refer to the "Chaos Altar" implies the [Chaos Altar](https://oldschool.runescape.wiki/w/Chaos_altar) in level 9 wilderness. This change brings the name in line with what is used on the OSRS Wiki for this [diary task](https://oldschool.runescape.wiki/w/Falador_Diary#Medium) (Falador medium - step 2).