### PR TITLE
Resolving Wanted! essence issue #478

### DIFF
--- a/src/main/java/com/questhelper/quests/wanted/Wanted.java
+++ b/src/main/java/com/questhelper/quests/wanted/Wanted.java
@@ -69,8 +69,8 @@ public class Wanted extends BasicQuestHelper
 	private static final String TEXT_ASK_ABOUT_WANTED_QUEST = "Ask about the Wanted! Quest";
 
 	ItemRequirement commorbComponents, tenThousandGp, commorbComponentsOrTenThousandGp, lightSource, spinyHelmet, rope,
-		combatGear, commorb, highlightedCommorb, essence, amuletOfGlory, faladorTeleport, varrockTeleport,
-		canifisTeleport;
+		combatGear, commorb, highlightedCommorb, runeEssence, pureEssence, essence, amuletOfGlory, faladorTeleport,
+		varrockTeleport, canifisTeleport;
 
 	Zone whiteKnightsCastleF1, whiteKnightsCastleF2, taverleyDungeonP1, taverleyDungeonP2, blackKnightsBase, nearCanifis,
 		canifis, championsGuild, essenceMine, dorgeshKaan, lumbridgeCellar, musaPoint, draynorMarket, goblinVillage,


### PR DESCRIPTION
Issue #478 explains that the guide states the user has all required items if they have some combination of rune/pure essence that are unnoted and amount to something >= 20. The quest needs all 20 essence to be the same (either all rune or all pure essence), so I split the logic into an OR, much like the commorb vs 10k requirement.