### PR TITLE
Forgettable Tale: add missing pot to array

### DIFF
--- a/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
@@ -935,7 +935,7 @@ public class ForgettableTale extends BasicQuestHelper
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return Arrays.asList(coins500, barleyMalt2, bucketOfWater2, spade, dibber, rake, kebab, beer.quantity(3),
-			dwarvenStout, beerGlass, randomItem);
+			dwarvenStout, beerGlass, pot, randomItem);
 	}
 
 	@Override


### PR DESCRIPTION
A pot is already listed in the requirements section, setup and mentioned
elsewhere but not added to the getItemRequirements array.

https://github.com/Zoinkwiz/quest-helper/blob/658d86a3329cdcf65d8ea8c7100930848e7c920b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java#L72-L74

https://github.com/Zoinkwiz/quest-helper/blob/658d86a3329cdcf65d8ea8c7100930848e7c920b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java#L371-L372

closes #516

based on the tooltip, this may have been intentionally left out in which case this is fine to be closed :cat: 
