### PR TITLE
Fix Below Ice Mountain & Fremennik Isles typos

### DIFF
--- a/src/main/java/com/questhelper/quests/belowicemountain/BelowIceMountain.java
+++ b/src/main/java/com/questhelper/quests/belowicemountain/BelowIceMountain.java
@@ -280,7 +280,7 @@ public class BelowIceMountain extends BasicQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-				new UnlockReward("Acess to the Ruins of Camdozaal."),
+				new UnlockReward("Access to the Ruins of Camdozaal."),
 				new UnlockReward("Flex Emote"));
 	}
 

--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -343,24 +343,24 @@ public class TheFremennikIsles extends BasicQuestHelper
 			{
 				splitLogs8.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 				splitLogs4.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
+				roundShield.setTooltip("Buy from the GE, or get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
 			}
 			else
 			{
 				splitLogs8.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
 				splitLogs4.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
+				roundShield.setTooltip("Buy from the GE, or get level 56 Woodcutting");
 			}
 
 			if (client.getRealSkillLevel(Skill.CRAFTING) >= 46)
 			{
 				yakTop.setTooltip("Buy from the GE, or kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
 				yakBottom.setTooltip("Buy from the GE, or kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
-				roundShield.setTooltip("Buy from the GE, or get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
 			}
 			else
 			{
 				yakBottom.setTooltip("Buy from the GE, or get 46 crafting");
 				yakTop.setTooltip("Buy from the GE, or get 46 crafting");
-				roundShield.setTooltip("Buy from the GE, or get 46 crafting");
 			}
 		}
 		knife = new ItemRequirement("Knife", ItemID.KNIFE);


### PR DESCRIPTION
- "Acess" -> "Access" in Below Ice Mountain
- Fixed Neitiznot shield requirement from 46 Crafting
  to 56 Woodcutting in Fremennik Isles

Fixes #529
Fixes #524