### PR TITLE
Fix wrong name in Clock tower quest

### DIFF
--- a/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
@@ -326,7 +326,7 @@ public class ClockTower extends BasicQuestHelper
 		goToSecondFloorWithWhiteCog.addSubSteps(climbWhiteLadder);
 
 		goFinishQuest = goToGroundFloor.copy();
-		goFinishQuest.setText("Talk to Koja for your reward.");
+		goFinishQuest.setText("Talk to Kojo for your reward.");
 		goFinishQuest.addStep(null, kojoReward);
 	}
 


### PR DESCRIPTION
This commit fixes the name of the monk at the end of the quest