### PR TITLE
Fix some wording & typos

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertMedium.java
@@ -225,7 +225,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 		talkToSimon = new NpcStep(this, NpcID.SIMON_TEMPLETON, new WorldPoint(3346, 2827, 0),
 			"Talk to Simon Templeton.");
 		moveToPyramid = new ObjectStep(this, ObjectID.CLIMBING_ROCKS_11948, new WorldPoint(3335, 2829, 0),
-			"Go the the Agility Pyramid.");
+			"Go to the Agility Pyramid.");
 		agiPyramid = new ObjectStep(this, ObjectID.STAIRS_10857, new WorldPoint(3355, 2832, 0),
 			"Climb the Agility Pyramid and collect the pyramid top. Be sure to click continue in the dialog.");
 

--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaHard.java
@@ -236,7 +236,7 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 			mushroomSpore);
 
 		moveToUpstairs = new ObjectStep(this, ObjectID.SPIKEY_CHAIN, new WorldPoint(3422, 3550, 0),
-			"Climb up the chain to get the the second floor of the slayer tower.");
+			"Climb up the chain to get to the second floor of the slayer tower.");
 		advancedSpikes = new ObjectStep(this, 16537, new WorldPoint(3447, 3576, 1),
 			"Climb the advanced spike chain.");
 

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -351,7 +351,7 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 		goBackToFirstFloor = new DetailedQuestStep(this, "Go back to the first floor of the castle and talk to Dr" +
 			".Fenkenstrain.");
 		talkToFenkenstrainAfterFixingRod = new NpcStep(this, NpcID.DR_FENKENSTRAIN, new WorldPoint(3551, 3548, 0),
-			"Go back to the the first floor of the castle and talk to Dr.Fenkenstrain.");
+			"Go back to the first floor of the castle and talk to Dr.Fenkenstrain.");
 
 		goToMonsterFloor1 = new ObjectStep(this, ObjectID.STAIRCASE_5206, new WorldPoint(3538, 3552, 0),
 			"Go up to the second floor to confront Fenkenstrain's monster.");

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -189,7 +189,7 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 		towerKey = new ItemRequirement("Tower Key", ItemID.TOWER_KEY);
 
 		fenkenstrainTeleports = new ItemRequirement("Fenkenstrain's Castle Teleport", ItemID.FENKENSTRAINS_CASTLE_TELEPORT, 2);
-		teleportToFurnace = new ItemRequirement("Teleport to any furnace such as glory for Edgeville teleport, ectophial to Port Phasmatys or a Falador teleport",
+		teleportToFurnace = new ItemRequirement("Teleport to any furnace such as glory for Edgeville teleport, Ectophial to Port Phasmatys or a Falador teleport",
 			ItemCollections.getAmuletOfGlories());
 		teleportToFurnace.addAlternates(ItemID.ECTOPHIAL, ItemID.FALADOR_TELEPORT);
 		staminaPotion = new ItemRequirement("Stamina potions", ItemCollections.getStaminaPotions(), -1);

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -73,7 +73,7 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 	ItemRequirement armor, hammer, ghostSpeakAmulet, silverBar, bronzeWire, needle, thread, spade, coins, telegrabOrCoins, pickledBrain,
 		obsidianAmulet, marbleAmulet, starAmulet, decapitatedHead, decapitatedHeadWithBrain, cavernKey, torso, legs, arms,
 		shedKey, brush, canes, extendedBrush3, conductorMould, lightningRod, towerKey,
-		fenkenstrainTeleports, teleportToFurnance, staminaPotion;
+		fenkenstrainTeleports, teleportToFurnace, staminaPotion;
 	Zone barZone, castleZoneFloor0, castleZoneFloor1, experimentCave, graveIsland, castleTower, monsterTower;
 	Requirement inCanifisBar, inCastleFloor0, inCastleFloor1, followingGardenerForHead, putStarOnGrave, inExperiementCave,
 		inGraveIsland, inCastleTower, usedTowerKey, inMonsterTower, keyNearby, hasDecapitatedHeadWithBrain, hasArm, hasLegs,
@@ -189,9 +189,9 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 		towerKey = new ItemRequirement("Tower Key", ItemID.TOWER_KEY);
 
 		fenkenstrainTeleports = new ItemRequirement("Fenkenstrain's Castle Teleport", ItemID.FENKENSTRAINS_CASTLE_TELEPORT, 2);
-		teleportToFurnance = new ItemRequirement("Teleport to any furnance such as glory for edgeville teleport, ectophial to Port Phasmatys or a Falador teleport",
+		teleportToFurnace = new ItemRequirement("Teleport to any furnance such as glory for edgeville teleport, ectophial to Port Phasmatys or a Falador teleport",
 			ItemCollections.getAmuletOfGlories());
-		teleportToFurnance.addAlternates(ItemID.ECTOPHIAL, ItemID.FALADOR_TELEPORT);
+		teleportToFurnace.addAlternates(ItemID.ECTOPHIAL, ItemID.FALADOR_TELEPORT);
 		staminaPotion = new ItemRequirement("Stamina potions", ItemCollections.getStaminaPotions(), -1);
 	}
 
@@ -377,7 +377,7 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 	{
 		ArrayList<ItemRequirement> reqs = new ArrayList<>();
 		reqs.add(fenkenstrainTeleports);
-		reqs.add(teleportToFurnance);
+		reqs.add(teleportToFurnace);
 		reqs.add(staminaPotion);
 
 		return reqs;

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -189,7 +189,7 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 		towerKey = new ItemRequirement("Tower Key", ItemID.TOWER_KEY);
 
 		fenkenstrainTeleports = new ItemRequirement("Fenkenstrain's Castle Teleport", ItemID.FENKENSTRAINS_CASTLE_TELEPORT, 2);
-		teleportToFurnace = new ItemRequirement("Teleport to any furnance such as glory for edgeville teleport, ectophial to Port Phasmatys or a Falador teleport",
+		teleportToFurnace = new ItemRequirement("Teleport to any furnace such as glory for Edgeville teleport, ectophial to Port Phasmatys or a Falador teleport",
 			ItemCollections.getAmuletOfGlories());
 		teleportToFurnace.addAlternates(ItemID.ECTOPHIAL, ItemID.FALADOR_TELEPORT);
 		staminaPotion = new ItemRequirement("Stamina potions", ItemCollections.getStaminaPotions(), -1);

--- a/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
@@ -827,7 +827,7 @@ public class LegendsQuest extends BasicQuestHelper
 		enterMossyRockForViyeldi.addDialogStep("Yes, I'll crawl through, I'm very athletic.");
 
 		useCrystalsOnFurnace = new ObjectStep(this, ObjectID.FURNACE_2966, new WorldPoint(2427, 4727, 0),
-			"Follow the path down, and kill each of the 3 skeletons for crystal pieces. Use them on the furnance in the north east of the area.",
+			"Follow the path down, and kill each of the 3 skeletons for crystal pieces. Use them on the furnace in the north east of the area.",
 			lumpCrystal, chunkCrystal, hunkCrystal);
 
 		useHeartOnRock = new ObjectStep(this, ObjectID.MOSSY_ROCK_2965, new WorldPoint(2411, 4716, 0),


### PR DESCRIPTION
Replaced incorrect usages of `the` with `to` in `CreatureOfFenkenstrain`, `MorytaniaHard`, & `DesertMedium`

Fixed typo in `CreatureofFenkenstrain` - `teleportToFurnance` variable & `furnance` text

Capitalized mention of `Edgeville` & `Ectophial` in `CreatureofFenkenstrain`