### PR TITLE
add missing enemies to defeat during Zogre Flesh Eaters

### DIFF
--- a/src/main/java/com/questhelper/quests/zogreflesheaters/ZogreFleshEaters.java
+++ b/src/main/java/com/questhelper/quests/zogreflesheaters/ZogreFleshEaters.java
@@ -345,6 +345,7 @@ public class ZogreFleshEaters extends BasicQuestHelper
 	{
 		ArrayList<String> reqs = new ArrayList<>();
 		reqs.add("Slash Bash (level 111)");
+		reqs.add("Zombie (level 39)");
 		return reqs;
 	}
 


### PR DESCRIPTION
Currently the Zogre Flesh Eaters guide only mentions a single enemy to defeat (Slash Bash). However as the guide does state, you also have to kill a level 39 zombie.

The Wiki mentions both enemies - https://oldschool.runescape.wiki/w/Zogre_Flesh_Eaters.