### PR TITLE
Fix missing item recommendation in Monkey Madness I

### DIFF
--- a/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -71,7 +71,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		enchantedBarHighlight, ballOfWoolHighlight, unstrungAmuletHighlight, amulet, banana5, amuletWorn, talisman, talismanHighlight, karamjanGreegree, monkeyBonesOrCorpseHighlight,
 		monkey, karamjanGreegreeEquipped, sigilEquipped, bananaReq;
 
-	//Items Recommendded
+	//Items Recommended
 	ItemRequirement combatGear, antipoison;
 
 	Requirement inStronghold, inFloor1, inFloor2, inFloor3, inKaramja, talkedToCaranock, reportedBackToNarnode, inHangar, startedPuzzle, solvedPuzzle,

--- a/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -69,7 +69,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 	//Items Required
 	ItemRequirement monkeyBonesOrCorpse, ballOfWool, goldBar, royalSeal, narnodesOrders, monkeyDentures, mould, monkeyDenturesHighlight, mouldHighlight, barHighlight, enchantedBar,
 		enchantedBarHighlight, ballOfWoolHighlight, unstrungAmuletHighlight, amulet, banana5, amuletWorn, talisman, talismanHighlight, karamjanGreegree, monkeyBonesOrCorpseHighlight,
-		monkey, karamjanGreegreeEquipped, sigilEquipped;
+		monkey, karamjanGreegreeEquipped, sigilEquipped, bananaReq;
 
 	//Items Recommendded
 	ItemRequirement combatGear, antipoison;
@@ -246,6 +246,8 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		ballOfWool = new ItemRequirement("Ball of wool", ItemID.BALL_OF_WOOL);
 		ballOfWoolHighlight = new ItemRequirement("Ball of wool", ItemID.BALL_OF_WOOL);
 		ballOfWoolHighlight.setHighlightInInventory(true);
+
+		bananaReq = new ItemRequirement("Banana (obtainable during quest)", ItemID.BANANA, 5);
 
 		monkeyBonesOrCorpse = new ItemRequirement("Monkey bones or corpse", ItemID.MONKEY_BONES);
 		monkeyBonesOrCorpse.addAlternates(ItemID.MONKEY_CORPSE);
@@ -703,7 +705,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(goldBar, ballOfWool, monkeyBonesOrCorpse);
+		return Arrays.asList(goldBar, ballOfWool, bananaReq, monkeyBonesOrCorpse);
 	}
 
 	@Override


### PR DESCRIPTION
References the needed banana's in `Item Requirements`

Used the precedent from `GoblinDiplomacy` and named the new var `bananaReq`

Also fixed a comment typo

Before
![image](https://user-images.githubusercontent.com/41973452/144160767-cde1d266-f375-4d49-ac51-042bda16b14f.png)

After
![image](https://user-images.githubusercontent.com/41973452/144161034-d949e60b-0b1c-48d8-b655-dc026699d87b.png)


Fixes #558