### PR TITLE
Update General requirements in Fremennik Hard Diary

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
@@ -249,8 +249,7 @@ public class FremennikHard extends ComplexStateQuestHelper
 		req.add(new SkillRequirement(Skill.THIEVING, 75, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 56, true));
 		req.add(new ComplexRequirement("Normal and Lunar spellbooks",
-			new SpellbookRequirement(Spellbook.NORMAL),
-			new SpellbookRequirement(Spellbook.LUNAR))
+			new QuestRequirement(QuestHelperQuest.LUNAR_DIPLOMACY, QuestState.FINISHED))
 		);
 		return req;
 	}

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
@@ -248,9 +248,7 @@ public class FremennikHard extends ComplexStateQuestHelper
 		req.add(new SkillRequirement(Skill.SMITHING, 60, false));
 		req.add(new SkillRequirement(Skill.THIEVING, 75, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 56, true));
-		req.add(new ComplexRequirement("Normal and Lunar spellbooks",
-			new QuestRequirement(QuestHelperQuest.LUNAR_DIPLOMACY, QuestState.FINISHED))
-		);
+		req.add(new ItemRequirement("Normal and Lunar spellbooks", -1, -1));
 		return req;
 	}
 

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
@@ -148,7 +148,7 @@ public class FremennikHard extends ComplexStateQuestHelper
 		giantDwarf = new QuestRequirement(QuestHelperQuest.THE_GIANT_DWARF, QuestState.FINISHED);
 		fremIsles = new QuestRequirement(QuestHelperQuest.THE_FREMENNIK_ISLES, QuestState.FINISHED);
 		throneOfMisc = new QuestRequirement(QuestHelperQuest.THRONE_OF_MISCELLANIA, QuestState.FINISHED);
-		eadgarsRuse = new QuestRequirement(QuestHelperQuest.EADGARS_RUSE, QuestState.FINISHED);
+		eadgarsRuse = new QuestRequirement(QuestHelperQuest.EADGARS_RUSE, QuestState.IN_PROGRESS);
 		lunarDiplomacy = new QuestRequirement(QuestHelperQuest.LUNAR_DIPLOMACY, QuestState.FINISHED);
 
 		inMisc = new ZoneRequirement(misc);

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
@@ -145,10 +145,10 @@ public class FremennikHard extends ComplexStateQuestHelper
 		normalBook = new SpellbookRequirement(Spellbook.NORMAL);
 		lunarBook = new SpellbookRequirement(Spellbook.LUNAR);
 
-		giantDwarf = new QuestRequirement(QuestHelperQuest.THE_GIANT_DWARF, QuestState.FINISHED);
+		giantDwarf = new QuestRequirement(QuestHelperQuest.THE_GIANT_DWARF, QuestState.IN_PROGRESS);
 		fremIsles = new QuestRequirement(QuestHelperQuest.THE_FREMENNIK_ISLES, QuestState.FINISHED);
 		throneOfMisc = new QuestRequirement(QuestHelperQuest.THRONE_OF_MISCELLANIA, QuestState.FINISHED);
-		eadgarsRuse = new QuestRequirement(QuestHelperQuest.EADGARS_RUSE, QuestState.IN_PROGRESS);
+		eadgarsRuse = new QuestRequirement(QuestHelperQuest.EADGARS_RUSE, QuestState.FINISHED);
 		lunarDiplomacy = new QuestRequirement(QuestHelperQuest.LUNAR_DIPLOMACY, QuestState.FINISHED);
 
 		inMisc = new ZoneRequirement(misc);

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikHard.java
@@ -249,6 +249,14 @@ public class FremennikHard extends ComplexStateQuestHelper
 		req.add(new SkillRequirement(Skill.THIEVING, 75, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 56, true));
 		req.add(new ItemRequirement("Normal and Lunar spellbooks", -1, -1));
+
+
+		req.add(eadgarsRuse);
+		req.add(lunarDiplomacy);
+		req.add(giantDwarf);
+		req.add(fremIsles);
+		req.add(throneOfMisc);
+
 		return req;
 	}
 


### PR DESCRIPTION
edit: This PR now does the following:

- Gray's out the Spellbook requirement as being in 2 different spellbooks is not possible, and adding the quest requirement is redundant.
- Adds missing quests from `General Requirements` section
- Sets Giant Dwarf status from `COMPLETED` to `IN_PROGRESS` as per the wiki



It's not possible to be in 2 different spellbooks at the same time (not including Spellbook Swap), so the current check will always fail
(I should note this "fail" is only visual, it worked as intended when showing the diary when searching `Show Meet Reqs`)

~~I've taken the approach to checking for only `LUNAR_DIPLOMACY, QuestState.FINISHED`, as the Normal spellbook is always unlocked
Unsure if there's a better approach~~

Before
![image](https://user-images.githubusercontent.com/41973452/144274182-92cf019c-1911-4fc4-b5c7-0e6ff27e4e43.png)

After
![image](https://user-images.githubusercontent.com/41973452/144274207-9ae4c81d-7882-4a42-bbce-f54ed6bb1782.png)
