### PR TITLE
Cleanup Faladory Easy required item wording

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorEasy.java
@@ -128,10 +128,10 @@ public class FaladorEasy extends ComplexStateQuestHelper
 
 		//Required
 		coins2000 = new ItemRequirement("Coins", ItemID.COINS_995, 2000).showConditioned(notGotHaircut);
-		bucket = new ItemRequirement("A Bucket", ItemID.BUCKET).showConditioned(notFilledWater);
-		tiara = new ItemRequirement("A Silver Tiara", ItemID.TIARA).showConditioned(notMindTiara);
-		mindTalisman = new ItemRequirement("A Mind Talisman", ItemID.MIND_TALISMAN).showConditioned(notMindTiara);
-		hammer = new ItemRequirement("A Hammer", ItemID.HAMMER).showConditioned(new Conditions(LogicType.OR, notMotherloadMine, notBluriteLimbs));
+		bucket = new ItemRequirement("Bucket", ItemID.BUCKET).showConditioned(notFilledWater);
+		tiara = new ItemRequirement("Silver Tiara", ItemID.TIARA).showConditioned(notMindTiara);
+		mindTalisman = new ItemRequirement("Mind Talisman", ItemID.MIND_TALISMAN).showConditioned(notMindTiara);
+		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(new Conditions(LogicType.OR, notMotherloadMine, notBluriteLimbs));
 		pickaxe = new ItemRequirement("Any Pickaxe", ItemCollections.getPickaxes()).showConditioned(new Conditions(LogicType.OR, notMotherloadMine, notBluriteLimbs));
 		combatGear = new ItemRequirement("A range or mage attack to kill a Duck (Level 1)", -1, -1).showConditioned(notKilledDuck);
 		combatGear.setDisplayItemId(BankSlotIcons.getRangedCombatGear());


### PR DESCRIPTION
Removed unnecessary `A`'s - moves from `1x A Bucket` to `1x Bucket`
![image](https://user-images.githubusercontent.com/41973452/144494592-59dc6417-1429-4918-952b-d2e2407d675e.png)

Used the fairly constant precedent from other files
![image](https://user-images.githubusercontent.com/41973452/144494659-57898ca0-3d27-44d0-82b6-98f3682904b9.png)
![image](https://user-images.githubusercontent.com/41973452/144494674-afdd46bf-06bf-48c6-b500-d13406f235c1.png)


