### PR TITLE
Telekinetic Grab requires one air rune

### DIFF
--- a/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
+++ b/src/main/java/com/questhelper/quests/kingsransom/KingsRansom.java
@@ -222,7 +222,7 @@ public class KingsRansom extends BasicQuestHelper
 		lockpick = new ItemRequirement("Lockpick", ItemID.LOCKPICK);
 
 		telegrab = new ItemRequirements("Telegrab runes", new ItemRequirement("Law rune", ItemID.LAW_RUNE),
-			new ItemRequirements(LogicType.OR, "Air runes or staff", new ItemRequirement("Air runes", ItemCollections.getAirRune(), 5), new ItemRequirement("Air staff", ItemCollections.getAirStaff())));
+			new ItemRequirements(LogicType.OR, "Air runes or staff", new ItemRequirement("Air runes", ItemCollections.getAirRune()), new ItemRequirement("Air staff", ItemCollections.getAirStaff())));
 
 		grabOrLockpick = new ItemRequirements(LogicType.OR, "Runes for telekinetic grab or a lockpick", new ItemRequirement("Lockpick", ItemID.LOCKPICK), telegrab);
 


### PR DESCRIPTION
During King's Ransom a cast of telekinetic grab (or a lockpick) is required. This correctly indicates you have the necessary runes to cast telekinetic grab, when you do.