### PR TITLE
Karamja Medium Diary: Added the two cut a tree diary steps to the axe item requirement display conditions

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
@@ -178,7 +178,7 @@ public class KaramjaMedium extends BasicQuestHelper
 		knife = new ItemRequirement("Knife", ItemID.KNIFE).showConditioned(notTrappedGraahk);
 		logs = new ItemRequirement("Logs", ItemID.LOGS).showConditioned(notTrappedGraahk);
 		axe = new ItemRequirement("Any axe", ItemCollections.getAxes()).showConditioned(new Conditions(LogicType.OR,
-			notTrappedGraahk, notCrossedLava, notClimbedStairs, notCutVine));
+			notTrappedGraahk, notCrossedLava, notClimbedStairs, notCutVine, notCutTeak, notCutMahog));
 		tradingSticks = new ItemRequirement("Trading sticks", ItemID.TRADING_STICKS).showConditioned(notExchangedGems);
 		tradingSticks.setTooltip("You can get these from villagers when doing Tai Bwo Wannai Cleanup");
 		opal = new ItemRequirement("Opal", ItemID.OPAL).showConditioned(notExchangedGems);


### PR DESCRIPTION
I was doing the Karamja Medium Diary and the axe item requirement disappeared before I completed the two cut a tree requirements.

Added "Cut a Teak Tree" and "Cut a Mahogany Tree" diary steps to Axe item requirement display condition.