### PR TITLE
Update TheSlugMenace.java Quest Step Description

### DIFF
--- a/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
@@ -354,7 +354,7 @@ public class TheSlugMenace extends BasicQuestHelper
 
 		solvePuzzle = new PuzzleStep(this);
 
-		useEmptyRunes = new DetailedQuestStep(this, "Right-click each page to turn rune/pure essence into empty runes. Take each empty rune and use it on its respective Runecrafting Altar.", page1, page2, page3, essence, chisel);
+		useEmptyRunes = new DetailedQuestStep(this, "Right-click each page to turn rune/pure essence into empty runes. Take each empty rune and use it on its respective Runecrafting Altar. Bring extra essence (~10 extra) as it is possible to accidentally destroy the essence upon creation.", page1, page2, page3, essence, chisel);
 
 		enterDungeonAgain = new ObjectStep(this, ObjectID.OLD_RUIN_ENTRANCE, new WorldPoint(2696, 3283, 0), "Prepare to fight the Slug Prince (level 62). Only melee can hurt it. Then, enter the old ruin entrance west of Witchaven.", meleeGear, airRune, waterRune, earthRune, fireRune, mindRune);
 		enterDungeonAgainUsedRunes = new ObjectStep(this, ObjectID.OLD_RUIN_ENTRANCE, new WorldPoint(2696, 3283, 0), "Prepare to fight the Slug Prince (level 62). Only melee can hurt it. Then, enter the old ruin entrance west of Witchaven.", meleeGear);


### PR DESCRIPTION
Update quest step description when crafting runes to include the following line: 
"Bring extra essence (~10 extra) as it is possible to accidentally destroy the essence upon creation.". 

The "10 extra" suggestion comes from the original item requirement section, where 5 runes are required, but it is recommended to bring 15 to be safe. The "15 to be safe" may be forgotten by the time that step is reached, so a reminder is helpful. 

Old:
"Right-click each page to turn rune/pure essence into empty runes. Take each empty rune and use it on its respective Runecrafting Altar."

New: 
"Right-click each page to turn rune/pure essence into empty runes. Take each empty rune and use it on its respective Runecrafting Altar. **Bring extra essence (~10 extra) as it is possible to accidentally destroy the essence upon creation.**"