### PR TITLE
Update Morytania Hard Diary Req's

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaHard.java
@@ -273,7 +273,7 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return Arrays.asList(combatGear, coins.quantity(100000), limestoneBrick.quantity(2), hammer, saw,
-			teakPlank.quantity(3), lawRune.quantity(200), bloodRune.quantity(100), seedDibber, spade, rake, axe,
+			teakPlank.quantity(3), lawRune.quantity(200), bloodRune.quantity(100), watermelonSeeds.quantity(3), seedDibber, spade, rake, axe,
 			tinderbox, witchwoodIcon, lightSource, mushroomSpore, pickaxe, crystalMineKey);
 	}
 


### PR DESCRIPTION
Watermelon seeds is not visible in the broader item req's, but is visible in the individual task. Just adding to broader item req's.