### PR TITLE
Add config to disable world line rendering

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -184,6 +184,16 @@ public interface QuestHelperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showWorldLines",
+			name = "Display navigation paths",
+			description = "Choose whether navigation paths are drawn to the next objective"
+	)
+	default boolean showWorldLines()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showOverlayPanel",
 		name = "Display overlay on screen",
 		description = "Chose whether the overlay should be displayed on screen"

--- a/src/main/java/com/questhelper/overlays/QuestHelperWorldLineOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperWorldLineOverlay.java
@@ -49,6 +49,11 @@ public class QuestHelperWorldLineOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!plugin.getConfig().showWorldLines())
+		{
+			return null;
+		}
+
 		QuestHelper quest = plugin.getSelectedQuest();
 
 		if (quest != null && quest.getCurrentStep() != null)


### PR DESCRIPTION
The same should be added for other overlay hints, such as inventory item highlighting. Unfortunately I do not have an OSRS account in a position to test this, so just world lines it is.