### PR TITLE
Fix bridge requirements

### DIFF
--- a/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
+++ b/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
@@ -67,7 +67,7 @@ import net.runelite.api.coords.WorldPoint;
 public class HorrorFromTheDeep extends BasicQuestHelper
 {
 	ItemRequirement fireRune, airRune, waterRune, earthRune, sword, arrow, moltenGlass, tinderbox, hammer,
-	steelNails60, plank2, plank, swampTar1, combatRunes;
+	steelNails30, steelNails60, plank2, plank, swampTar1, combatRunes;
 
 	ItemRequirement magicCombat, food, prayerPotions, gamesNecklace;
 
@@ -156,6 +156,7 @@ public class HorrorFromTheDeep extends BasicQuestHelper
 		moltenGlass = new ItemRequirement("Molten glass", ItemID.MOLTEN_GLASS);
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX);
 		hammer = new ItemRequirement("Hammer", ItemCollections.getHammer());
+		steelNails30 = new ItemRequirement("Steel nails", ItemID.STEEL_NAILS, 30);
 		steelNails60 = new ItemRequirement("Steel nails", ItemID.STEEL_NAILS, 60);
 		plank2 = new ItemRequirement("Plank", ItemID.PLANK, 2);
 		plank = new ItemRequirement("Plank", ItemID.PLANK);
@@ -226,11 +227,11 @@ public class HorrorFromTheDeep extends BasicQuestHelper
 		talkToLarrissa.addDialogSteps("With what?", "But how can I help?", "Okay, I'll help!");
 
 		usePlankOnBridge = new ObjectStep(this, ObjectID.BROKEN_BRIDGE, new WorldPoint(2596, 3608, 0), "Use a plank " +
-			"on the bridge east of the Lighthouse.", plank.highlighted(), steelNails60, hammer);
+			"on the bridge east of the Lighthouse.", plank.highlighted(), steelNails30, hammer);
 		usePlankOnBridge.addIcon(ItemID.PLANK);
 
 		useSecondPlank = new ObjectStep(this, ObjectID.BROKEN_BRIDGE_4616, new WorldPoint(2598, 3608, 0),
-			"Use a plank on the other side of the bridge east of the Lighthouse.", plank.highlighted(), steelNails60,
+			"Use a plank on the other side of the bridge east of the Lighthouse.", plank.highlighted(), steelNails30,
 			hammer);
 		useSecondPlank.addIcon(ItemID.PLANK);
 


### PR DESCRIPTION
Each side of the bridge only requires 30 steel nails each.

Was confusing to me after repairing the first side, and the panel told me I required 60 steel nails for the second, even though it showed only 1 plank required. I ended up running to the bank and making another 30 steel nails before coming back.

This pull request makes that consistent with showing just 1 plank, and just 30 steel nails per side of the bridge.