### PR TITLE
Update LumbridgeHard.java

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -71,8 +71,8 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 {
 	// Items required
 	ItemRequirement bones, earthRune4, earthRune10, earthRune14, waterRune, natureRune, fairyAccess, axe, goldBar,
-		cutDiamond, amuletMould, ballOfWool, cosmicRune, diamondAmuletU, diamondAmulet, miningHelm, tinderbox, coins, ess,
-		cosmicAccessOrAbyss, bellaSeed, seedDib, spade, rake, gloves, earthRune;
+		cutDiamond, amuletMould, ballOfWool, cosmicRune, diamondAmuletU, diamondAmulet, miningHelm, tinderbox, coins,
+		essence, cosmicAccessOrAbyss, bellaSeed, seedDib, spade, rake, gloves, earthRune;
 
 	// Items recommended
 	ItemRequirement ringOfDueling, gamesNeck, dorgSphere, lightsource;
@@ -174,7 +174,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		coins = new ItemRequirement("Coins", ItemCollections.getCoins()).showConditioned(notBarrowsGloves);
 		gamesNeck = new ItemRequirement("Games Necklace", ItemCollections.getGamesNecklaces()).showConditioned(notHundredTears);
 		dorgSphere = new ItemRequirement("Dorgesh-kann Sphere", ItemID.DORGESHKAAN_SPHERE).showConditioned(notTrainToKeld);
-		ess = new ItemRequirement("Pure or daeyalt essence", ItemCollections.getEssenceHigh()).showConditioned(notCosmics);
+		essence = new ItemRequirement("Pure or daeyalt essence", ItemCollections.getEssenceHigh(), 28).showConditioned(notCosmics);
 		cosmicAccessOrAbyss = new ItemRequirement("Access to cosmic altar, or travel through abyss. Tiara recommended unless using essence pouches",
 			ItemCollections.getCosmicAltar()).showConditioned(notCosmics);
 		bellaSeed = new ItemRequirement("Belladonna seed", ItemID.BELLADONNA_SEED).showConditioned(notBelladonna);
@@ -291,7 +291,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 			"Enter the cosmic altar.", cosmicAccessOrAbyss.highlighted());
 		moveToCosmic.addIcon(ItemID.COSMIC_TALISMAN);
 		cosmics = new ObjectStep(this, ObjectID.ALTAR_34766, new WorldPoint(2142, 4833, 0),
-			"Craft 56 cosmic runes.", ess.quantity(28));
+			"Craft 56 cosmic runes.", essence);
 		belladonna = new ObjectStep(this, 7572, new WorldPoint(3087, 3355, 0),
 			"Grow and pick some belladonna from the Draynor Manor farming patch.", bellaSeed, rake, spade, gloves, seedDib);
 
@@ -303,7 +303,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune.quantity(4), ess.quantity(28),
+		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune.quantity(4), essence,
 			fairyAccess, axe, goldBar, cutDiamond, amuletMould, ballOfWool, cosmicRune, miningHelm, tinderbox,
 			coins.quantity(130000), bellaSeed, seedDib, spade, rake, gloves);
 	}
@@ -411,7 +411,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		allSteps.add(juttingWallSteps);
 
 		PanelDetails cosmicsSteps = new PanelDetails("56 Cosmic Runes", Arrays.asList(moveToZanarisForCosmics, moveToCosmic,
-			cosmics), new SkillRequirement(Skill.RUNECRAFT, 59, true), lostCity, ess.quantity(28),
+			cosmics), new SkillRequirement(Skill.RUNECRAFT, 59, true), lostCity, essence,
 			cosmicAccessOrAbyss, fairyAccess);
 		cosmicsSteps.setDisplayCondition(notCosmics);
 		allSteps.add(cosmicsSteps);

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -303,7 +303,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune, essence,
+		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune, natureRune, essence,
 			fairyAccess, axe, goldBar, cutDiamond, amuletMould, ballOfWool, cosmicRune, miningHelm, tinderbox,
 			coins.quantity(130000), bellaSeed, seedDib, spade, rake, gloves);
 	}

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -246,7 +246,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		smeltAmmy.addIcon(ItemID.GOLD_BAR);
 		stringAmmy = new ItemStep(this, "String the diamond amulet.", ballOfWool.highlighted(), diamondAmuletU.highlighted());
 		powerAmmy = new ItemStep(this, "Enchant the strung diamond amulet.", diamondAmulet, cosmicRune.quantity(1),
-			earthRune.quantity(10));
+			earthRune10);
 		moveToLumby = new TileStep(this, new WorldPoint(3228, 3238, 0),
 			"Move to the Lumbridge smithy.", ballOfWool, cutDiamond, goldBar);
 
@@ -381,7 +381,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		PanelDetails powerAmuletSteps = new PanelDetails("Power Amulet", Arrays.asList(moveToLumby, smeltAmmy,
 			stringAmmy, powerAmmy), new SkillRequirement(Skill.CRAFTING, 70, true),
 			new SkillRequirement(Skill.MAGIC, 57), goldBar, cutDiamond, amuletMould, ballOfWool,
-			cosmicRune.quantity(1), earthRune.quantity(10));
+			cosmicRune.quantity(1), earthRune10);
 		powerAmuletSteps.setDisplayCondition(notPowerAmmy);
 		allSteps.add(powerAmuletSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -157,8 +157,8 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		earthRune14 = new ItemRequirement("Earth runes", ItemID.EARTH_RUNE, 14)
 			.showConditioned(bothEarth);
 		earthRune = new ItemRequirement("Earth runes", ItemID.EARTH_RUNE);
-		waterRune = new ItemRequirement("Water rune", ItemID.WATER_RUNE).showConditioned(notBonesToPeachesPalace);
-		natureRune = new ItemRequirement("Nature rune", ItemID.NATURE_RUNE).showConditioned(notBonesToPeachesPalace);
+		waterRune = new ItemRequirement("Water rune", ItemID.WATER_RUNE, 4).showConditioned(notBonesToPeachesPalace);
+		natureRune = new ItemRequirement("Nature rune", ItemID.NATURE_RUNE, 2).showConditioned(notBonesToPeachesPalace);
 		fairyAccess = new ItemRequirement("Lunar or Dramen staff", ItemCollections.getFairyStaff())
 			.showConditioned(new Conditions(LogicType.OR, notCosmics, notJuttingWall));
 		axe = new ItemRequirement("Any axe", ItemCollections.getAxes()).showConditioned(notWakaToEdge);
@@ -234,8 +234,8 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 
 		moveToPalace = new DetailedQuestStep(this, new WorldPoint(3293, 3164, 0),
 			"Enter the Al Kharid palace.");
-		bonesToPeachesPalace = new DetailedQuestStep(this, "Cast bones to peaches.", bones, earthRune.quantity(4),
-			waterRune.quantity(4), natureRune.quantity(2));
+		bonesToPeachesPalace = new DetailedQuestStep(this, "Cast bones to peaches.", bones, earthRune4,
+			waterRune, natureRune);
 		unlockBonesToPeaches = new DetailedQuestStep(this, "Unlock bones to peaches from the Mage Training Arena.");
 
 		wakaToEdge = new ObjectStep(this, 12163, new WorldPoint(3242, 3237, 0),
@@ -303,7 +303,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune.quantity(4), essence,
+		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune, essence,
 			fairyAccess, axe, goldBar, cutDiamond, amuletMould, ballOfWool, cosmicRune, miningHelm, tinderbox,
 			coins.quantity(130000), bellaSeed, seedDib, spade, rake, gloves);
 	}
@@ -368,8 +368,8 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 
 		PanelDetails peachesPalaceSteps = new PanelDetails("Bones to Peaches Palace",
 			Arrays.asList(unlockBonesToPeaches, moveToPalace, bonesToPeachesPalace),
-			new SkillRequirement(Skill.MAGIC, 60), bonesToPeaches, bones, earthRune.quantity(4),
-			waterRune.quantity(4), natureRune.quantity(2));
+			new SkillRequirement(Skill.MAGIC, 60), bonesToPeaches, bones, earthRune4,
+			waterRune, natureRune);
 		peachesPalaceSteps.setDisplayCondition(notBonesToPeachesPalace);
 		allSteps.add(peachesPalaceSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -230,7 +230,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	public void setupSteps()
 	{
 		smiteAltar = new ObjectStep(this, ObjectID.ALTAR, new WorldPoint(3377, 3285, 0),
-			"Pray at the altar at the duel arena with smite active.", smiteActive);
+			"Pray at the altar at the Duel Arena with smite active.", smiteActive);
 
 		moveToPalace = new DetailedQuestStep(this, new WorldPoint(3293, 3164, 0),
 			"Enter the Al Kharid palace.");

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -303,9 +303,9 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune, natureRune, essence,
+		return Arrays.asList(coins, bones, earthRune4, earthRune10, earthRune14, waterRune, natureRune, essence,
 			fairyAccess, axe, goldBar, cutDiamond, amuletMould, ballOfWool, cosmicRune, miningHelm, tinderbox,
-			coins, bellaSeed, seedDib, spade, rake, gloves);
+			bellaSeed, seedDib, spade, rake, gloves);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -174,7 +174,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		coins = new ItemRequirement("Coins", ItemCollections.getCoins()).showConditioned(notBarrowsGloves);
 		gamesNeck = new ItemRequirement("Games Necklace", ItemCollections.getGamesNecklaces()).showConditioned(notHundredTears);
 		dorgSphere = new ItemRequirement("Dorgesh-kann Sphere", ItemID.DORGESHKAAN_SPHERE).showConditioned(notTrainToKeld);
-		essence = new ItemRequirement("Pure or daeyalt essence", ItemCollections.getEssenceHigh(), 28).showConditioned(notCosmics);
+		essence = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.getEssenceHigh(), 28).showConditioned(notCosmics);
 		cosmicAccessOrAbyss = new ItemRequirement("Access to cosmic altar, or travel through abyss. Tiara recommended unless using essence pouches",
 			ItemCollections.getCosmicAltar()).showConditioned(notCosmics);
 		bellaSeed = new ItemRequirement("Belladonna seed", ItemID.BELLADONNA_SEED).showConditioned(notBelladonna);

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -171,7 +171,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		diamondAmulet = new ItemRequirement("Diamond amulet", ItemID.DIAMOND_AMULET).showConditioned(notPowerAmmy);
 		miningHelm = new ItemRequirement("Mining helmet", ItemCollections.getMiningHelm()).showConditioned(notLightMiningHelm);
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX).showConditioned(notLightMiningHelm);
-		coins = new ItemRequirement("Coins", ItemCollections.getCoins()).showConditioned(notBarrowsGloves);
+		coins = new ItemRequirement("Coins", ItemCollections.getCoins(), 130000).showConditioned(notBarrowsGloves);
 		gamesNeck = new ItemRequirement("Games Necklace", ItemCollections.getGamesNecklaces()).showConditioned(notHundredTears);
 		dorgSphere = new ItemRequirement("Dorgesh-kann Sphere", ItemID.DORGESHKAAN_SPHERE).showConditioned(notTrainToKeld);
 		essence = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.getEssenceHigh(), 28).showConditioned(notCosmics);
@@ -255,10 +255,10 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		lightMiningHelm = new ItemStep(this, "Light your mining helmet.", miningHelm.highlighted(), tinderbox.highlighted());
 
 		moveToBasementForGloves = new ObjectStep(this, ObjectID.TRAPDOOR_14880, new WorldPoint(3209, 3216, 0),
-			"Climb down the trapdoor in the Lumbridge Castle.", coins.quantity(130000));
+			"Climb down the trapdoor in the Lumbridge Castle.", coins);
 		barrowsGloves = new ObjectStep(this, 12308, new WorldPoint(3219, 9623, 0),
 			"Purchase the barrows gloves from the bank chest. Right click and select 'Buy-items'.",
-			coins.quantity(130000));
+			coins);
 		// 12308 is mine and I only have FULL access, and the ELITE version wouldn't make sense here
 
 		moveToBasementForTears = new ObjectStep(this, ObjectID.TRAPDOOR_14880, new WorldPoint(3209, 3216, 0),
@@ -305,7 +305,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	{
 		return Arrays.asList(bones, earthRune4, earthRune10, earthRune14, waterRune, natureRune, essence,
 			fairyAccess, axe, goldBar, cutDiamond, amuletMould, ballOfWool, cosmicRune, miningHelm, tinderbox,
-			coins.quantity(130000), bellaSeed, seedDib, spade, rake, gloves);
+			coins, bellaSeed, seedDib, spade, rake, gloves);
 	}
 
 	@Override
@@ -391,7 +391,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		allSteps.add(miningHelmetSteps);
 
 		PanelDetails barrowsGlovesSteps = new PanelDetails("Barrows Gloves", Arrays.asList(moveToBasementForGloves,
-			barrowsGloves), recipeForDisaster, coins.quantity(130000));
+			barrowsGloves), recipeForDisaster, coins);
 		barrowsGlovesSteps.setDisplayCondition(notBarrowsGloves);
 		allSteps.add(barrowsGlovesSteps);
 


### PR DESCRIPTION
- Capitalized Duel Arena & Daeyalt essence
- Adding missing `natureRune` in ItemRequirements
- renamed `ess` variable to `essence` & declared the requirement of `28` once
- declared the rune requirements for `waterRune` & `natureRune` once
- moved earthRune requirements to existing `earthRune4` & `earthRune10` variables
- declared `coins` variable once for barrows glove purchase, also moved it to the top of the ItemRequirements (looksout of place in the middle)

Fixes #696

also please squash and merge this, I seperated the commits very specifically so I could keep track of the changes, but it will look terrible in git history without squash&merge