### PR TITLE
Fix for a typo in Legends Quest

### DIFF
--- a/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
@@ -672,7 +672,7 @@ public class LegendsQuest extends BasicQuestHelper
 		sketchWest = new DetailedQuestStep(this, new WorldPoint(2791, 2917, 0), "Stand in the west of the Kharazi Jungle and right-click complete the Radimus note.", radimusNotesHighlight, papyrus, charcoal);
 		sketchWest.addDialogStep("Start Mapping Kharazi Jungle.");
 		useNotes = new NpcStep(this, NpcID.JUNGLE_FORESTER, new WorldPoint(2867, 2942, 0),
-				"Use the Radimus notes on a Jungle Forester outside the Kharazi Jungle. Whilst in the jungle, consider grabbing a Vanilla Pod from a Vanilla plant in the south east of the Kharazi", true, completeNotesHighlighted);
+				"Use the Radimus notes on a Jungle Forester outside the Kharazi Jungle. Whilst in the jungle, consider grabbing a Vanilla Pod from a Vanilla plant in the south west of the Kharazi.", true, completeNotesHighlighted);
 		useNotes.addAlternateNpcs(NpcID.JUNGLE_FORESTER_3955);
 		useNotes.addDialogStep("Yes, go ahead make a copy!");
 		enterJungleWithRoarer = new DetailedQuestStep(this, "Re-enter the Kharazi Jungle. You'll need to cut through some trees and bushes to enter.", completeNotes, bullRoarer, axe, machete, lockpick, pickaxe, soulRune, mindRune, earthRune, lawRune2, opal, jade, topaz, sapphire, emerald, ruby, diamond);


### PR DESCRIPTION
Correcting a step to specify that the Vanilla Pods are in the south *west* of the Kharazi Jungle, as shown in the image below:

![image](https://user-images.githubusercontent.com/18320375/153088932-3fed87e5-60d2-47c8-b1f8-545d4341e552.png)
![image](https://user-images.githubusercontent.com/18320375/153089085-5bc0d2ca-db2c-400b-a3c3-bd1796963f6f.png)

Also adding a full stop to the end of this step.

