### PR TITLE
Rename short form variables in some Diaries

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertElite.java
@@ -67,7 +67,7 @@ import com.questhelper.steps.QuestStep;
 public class DesertElite extends ComplexStateQuestHelper
 {
 	// Items required
-	ItemRequirement combatGear, rawPie, waterRune, bloodRune, deathRune, dragonDartTip, feather, mahoPlank,
+	ItemRequirement combatGear, rawPie, waterRune, bloodRune, deathRune, dragonDartTip, feather, mahoganyPlank,
 		goldLeaves, coins, saw, hammer, kqHead;
 
 	// Items recommended
@@ -127,7 +127,7 @@ public class DesertElite extends ComplexStateQuestHelper
 		deathRune = new ItemRequirement("Death rune", ItemID.DEATH_RUNE).showConditioned(notIceBarrage);
 		dragonDartTip = new ItemRequirement("Dragon dart tip", ItemID.DRAGON_DART_TIP).showConditioned(notDragonDarts);
 		feather = new ItemRequirement("Feather", ItemID.FEATHER).showConditioned(notDragonDarts);
-		mahoPlank = new ItemRequirement("Mahogany plank", ItemID.MAHOGANY_PLANK).showConditioned(notTalkKQHead);
+		mahoganyPlank = new ItemRequirement("Mahogany plank", ItemID.MAHOGANY_PLANK).showConditioned(notTalkKQHead);
 		goldLeaves = new ItemRequirement("Gold leaf", ItemID.GOLD_LEAF_8784).showConditioned(notTalkKQHead);
 		saw = new ItemRequirement("Saw", ItemID.SAW).showConditioned(notTalkKQHead);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notTalkKQHead);
@@ -204,7 +204,7 @@ public class DesertElite extends ComplexStateQuestHelper
 
 		talkKQHead = new DetailedQuestStep(this, "Mount and then talk to a Kalphite Queen head in your POH. The 50k " +
 			"is necessary to stuff the KQ head at the taxidermist in Canifis.",
-			kqHead, mahoPlank.quantity(2), goldLeaves.quantity(2), saw, hammer, coins.quantity(50000));
+			kqHead, mahoganyPlank.quantity(2), goldLeaves.quantity(2), saw, hammer, coins.quantity(50000));
 
 		claimReward = new NpcStep(this, NpcID.JARR, new WorldPoint(3303, 3124, 0),
 			"Talk to Jarr at the Shantay pass to claim your reward!");
@@ -215,7 +215,7 @@ public class DesertElite extends ComplexStateQuestHelper
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return Arrays.asList(rawPie, waterRune.quantity(6), bloodRune.quantity(2), deathRune.quantity(4),
-			dragonDartTip, feather, kqHead, mahoPlank.quantity(2), goldLeaves.quantity(2), coins.quantity(50000), saw,
+			dragonDartTip, feather, kqHead, mahoganyPlank.quantity(2), goldLeaves.quantity(2), coins.quantity(50000), saw,
 			hammer, kqHead);
 	}
 
@@ -305,7 +305,7 @@ public class DesertElite extends ComplexStateQuestHelper
 
 		PanelDetails kqHeadSteps = new PanelDetails("Kalphite Queen Head", Collections.singletonList(talkKQHead),
 			new SkillRequirement(Skill.CONSTRUCTION, 78), priestInPeril, kqHead, coins.quantity(50000),
-			mahoPlank.quantity(2), goldLeaves.quantity(2), saw, hammer);
+			mahoganyPlank.quantity(2), goldLeaves.quantity(2), saw, hammer);
 		kqHeadSteps.setDisplayCondition(notTalkKQHead);
 		allSteps.add(kqHeadSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikElite.java
@@ -59,7 +59,7 @@ import com.questhelper.panel.PanelDetails;
 public class FremennikElite extends ComplexStateQuestHelper
 {
 	// Items required
-	ItemRequirement pureEss, dragonstone, goldBar, amuletMould, combatGear, thrownaxe, climbingBoots, rope, petRock,
+	ItemRequirement pureEssence, dragonstone, goldBar, amuletMould, combatGear, thrownaxe, climbingBoots, rope, petRock,
 		crossbow, hammer, mithGrap;
 
 	// Recommended
@@ -160,7 +160,7 @@ public class FremennikElite extends ComplexStateQuestHelper
 		protectMagic = new PrayerRequirement("Protect from Magic", Prayer.PROTECT_FROM_MAGIC);
 
 		petRock = new ItemRequirement("Pet Rock", ItemID.PET_ROCK).showConditioned(notDagKings);
-		pureEss = new ItemRequirement("Pure essence", ItemID.PURE_ESSENCE).showConditioned(notAstralRunes);
+		pureEssence = new ItemRequirement("Pure essence", ItemID.PURE_ESSENCE).showConditioned(notAstralRunes);
 		dragonstone = new ItemRequirement("Cut dragonstone", ItemID.DRAGONSTONE).showConditioned(notDragonAmulet);
 		goldBar = new ItemRequirement("Gold bar", ItemID.GOLD_BAR).showConditioned(notDragonAmulet);
 		amuletMould = new ItemRequirement("Amulet mould", ItemID.AMULET_MOULD).showConditioned(notDragonAmulet);
@@ -348,7 +348,7 @@ public class FremennikElite extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(pureEss.quantity(28), dragonstone, goldBar, amuletMould, combatGear, rope.quantity(3), climbingBoots, petRock, crossbow, mithGrap, hammer);
+		return Arrays.asList(pureEssence.quantity(28), dragonstone, goldBar, amuletMould, combatGear, rope.quantity(3), climbingBoots, petRock, crossbow, mithGrap, hammer);
 	}
 
 	@Override
@@ -417,7 +417,7 @@ public class FremennikElite extends ComplexStateQuestHelper
 
 		PanelDetails astralRunesSteps = new PanelDetails("Astral Runes", Arrays.asList(moveToPirates, moveToCaptain,
 			moveToCaptain2, moveToLunarIsle, moveToAltar1, moveToAltar2), lunarDiplomacy,
-			new SkillRequirement(Skill.RUNECRAFT, 82), pureEss.quantity(28));
+			new SkillRequirement(Skill.RUNECRAFT, 82), pureEssence.quantity(28));
 		astralRunesSteps.setDisplayCondition(notAstralRunes);
 		allSteps.add(astralRunesSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -65,7 +65,7 @@ import com.questhelper.steps.QuestStep;
 public class LumbridgeElite extends ComplexStateQuestHelper
 {
 	// Items required
-	ItemRequirement lockpick, crossbow, mithgrap, lightsource, axe, addyBar, hammer, ess, waterAccessOrAbyss, qcCape;
+	ItemRequirement lockpick, crossbow, mithgrap, lightsource, axe, addyBar, hammer, essence, waterAccessOrAbyss, qcCape;
 
 	// Items recommended
 	ItemRequirement ringOfDueling, dorgSphere;
@@ -133,7 +133,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		axe = new ItemRequirement("Any axe", ItemCollections.getAxes()).showConditioned(notChopMagic);
 		addyBar = new ItemRequirement("Adamantite bar", ItemID.ADAMANTITE_BAR).showConditioned(notAddyPlatebody);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notAddyPlatebody);
-		ess = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(notWaterRunes);
+		essence = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(notWaterRunes);
 		waterAccessOrAbyss = new ItemRequirement("Access to water altar, or travel through abyss",
 			ItemCollections.getWaterAltar()).showConditioned(notWaterRunes);
 		qcCape = new ItemRequirement("Quest cape", ItemCollections.getQuestCape()).showConditioned(notQCEmote);
@@ -179,9 +179,9 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 			"Perform the skill cape emote with the quest cape equipped.", qcCape.equipped());
 
 		moveToWater = new ObjectStep(this, 34815, new WorldPoint(3185, 3165, 0),
-			"Enter the water altar.", waterAccessOrAbyss.highlighted(), ess.quantity(28));
+			"Enter the water altar.", waterAccessOrAbyss.highlighted(), essence.quantity(28));
 		waterRunes = new ObjectStep(this, ObjectID.ALTAR_34762, new WorldPoint(2716, 4836, 0),
-			"Craft water runes.", ess.quantity(28));
+			"Craft water runes.", essence.quantity(28));
 
 		moveToUndergroundMovario = new ObjectStep(this, ObjectID.TRAPDOOR_14880, new WorldPoint(3209, 3216, 0),
 			"Climb down the trapdoor in the Lumbridge Castle.", mithgrap, crossbow, lightsource);
@@ -217,7 +217,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return Arrays.asList(qcCape, lockpick, mithgrap, hammer, waterAccessOrAbyss, axe, addyBar.quantity(5),
-			ess.quantity(28), crossbow);
+			essence.quantity(28), crossbow);
 	}
 
 	@Override
@@ -283,7 +283,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		allSteps.add(questCapeEmoteSteps);
 
 		PanelDetails waterRunesSteps = new PanelDetails("140 Water Runes", Arrays.asList(moveToWater, waterRunes),
-			new SkillRequirement(Skill.RUNECRAFT, 76), ess.quantity(28), waterAccessOrAbyss);
+			new SkillRequirement(Skill.RUNECRAFT, 76), essence.quantity(28), waterAccessOrAbyss);
 		waterRunesSteps.setDisplayCondition(notWaterRunes);
 		allSteps.add(waterRunesSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
@@ -71,7 +71,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 	// Items required
 	ItemRequirement crossbow, mithGrap, steelArrows, avasAttractor, coins, fairyAccess, earthRune,
 		airRune, lawRune, earthTali, fireAccess, flyFishingRod, feathers, leather, needle, thread, axe, butterflyNet,
-		implingJar, ess, bindingNeck;
+		implingJar, essence, bindingNeck;
 
 	ItemRequirements avasAccumulator;
 	// magic imbue
@@ -141,7 +141,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		fireAccess = new ItemRequirement("Access to fire altar", ItemCollections.getFireAltar()).showConditioned(notCraftLava);
 		earthRune = new ItemRequirement("Earth rune", ItemID.EARTH_RUNE)
 			.showConditioned(new Conditions(LogicType.OR, notCraftLava, notTPlumb));
-		ess = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(notCraftLava);
+		essence = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(notCraftLava);
 		bindingNeck = new ItemRequirement("Binding necklace", ItemID.BINDING_NECKLACE).showConditioned(notCraftLava);
 		feathers = new ItemRequirement("Feathers", ItemID.FEATHER).showConditioned(notCatchSalmon);
 		flyFishingRod = new ItemRequirement("Fly fishing rod", ItemID.FLY_FISHING_ROD).showConditioned(notCatchSalmon);
@@ -191,7 +191,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		moveToLavaAltar = new ObjectStep(this, 34817, new WorldPoint(3313, 3255, 0),
 			"Enter the fire altar north of Al Kharid.", fireAccess);
 		craftLava = new ObjectStep(this, ObjectID.ALTAR_34764, new WorldPoint(2585, 4838, 0),
-			"Use an earth talisman on the fire altar.", earthTali.highlighted(), ess, earthRune);
+			"Use an earth talisman on the fire altar.", earthTali.highlighted(), essence, earthRune);
 		craftLava.addIcon(ItemID.EARTH_TALISMAN);
 
 		catchSalmon = new NpcStep(this, NpcID.ROD_FISHING_SPOT_1527, new WorldPoint(3241, 3248, 0),
@@ -240,7 +240,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(crossbow, mithGrap, earthTali, fireAccess, earthRune.quantity(2), ess, feathers.quantity(10), flyFishingRod, needle,
+		return Arrays.asList(crossbow, mithGrap, earthTali, fireAccess, earthRune.quantity(2), essence, feathers.quantity(10), flyFishingRod, needle,
 			thread, leather, lawRune.quantity(1), airRune.quantity(3), steelArrows.quantity(75), avasAccumulator, axe,
 			fairyAccess, butterflyNet, implingJar);
 	}
@@ -355,7 +355,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		allSteps.add(grappleRiverLumSteps);
 
 		PanelDetails lavaRunesSteps = new PanelDetails("Craft Lava Runes", Arrays.asList(moveToLavaAltar, craftLava),
-			new SkillRequirement(Skill.RUNECRAFT, 23), fireAccess, earthTali, earthRune, ess);
+			new SkillRequirement(Skill.RUNECRAFT, 23), fireAccess, earthTali, earthRune, essence);
 		lavaRunesSteps.setDisplayCondition(notCraftLava);
 		allSteps.add(lavaRunesSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockEasy.java
@@ -65,7 +65,7 @@ import com.questhelper.steps.QuestStep;
 public class VarrockEasy extends ComplexStateQuestHelper
 {
 	// Items required
-	ItemRequirement coins, pickaxe, log, axe, bone, softClay, earthTali, ess, flyRod, feathers;
+	ItemRequirement coins, pickaxe, log, axe, bone, softClay, earthTali, essence, flyRod, feathers;
 
 	ItemRequirement unfiredBowl;
 
@@ -142,7 +142,7 @@ public class VarrockEasy extends ComplexStateQuestHelper
 		bone = new ItemRequirement("Bones", ItemCollections.getBones()).showConditioned(notDogBone);
 		softClay = new ItemRequirement("Soft clay", ItemID.SOFT_CLAY).showConditioned(notBowl);
 		earthTali = new ItemRequirement("Access to Earth altar, or travel through abyss", ItemCollections.getEarthAltar()).showConditioned(notEarthRune);
-		ess = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(notEarthRune);
+		essence = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(notEarthRune);
 		flyRod = new ItemRequirement("Fly fishing rod", ItemID.FLY_FISHING_ROD).showConditioned(notTrout);
 		feathers = new ItemRequirement("Feather", ItemID.FEATHER).showConditioned(notTrout);
 		unfiredBowl = new ItemRequirement("Unfired bowl", ItemID.UNFIRED_BOWL);
@@ -211,7 +211,7 @@ public class VarrockEasy extends ComplexStateQuestHelper
 			"Travel to the earth altar or go through the abyss.", earthTali);
 		moveToEarthRune.addIcon(ItemID.EARTH_TALISMAN);
 		earthRune = new ObjectStep(this, 34763, new WorldPoint(2658, 4841, 0),
-			"Craft an earth rune.", ess);
+			"Craft an earth rune.", essence);
 		trout = new NpcStep(this, NpcID.ROD_FISHING_SPOT_1526, new WorldPoint(3106, 3428, 0),
 			"Fish a trout in the River Lum.", flyRod, feathers);
 		teaStall = new ObjectStep(this, ObjectID.TEA_STALL, new WorldPoint(3270, 3411, 0),
@@ -225,7 +225,7 @@ public class VarrockEasy extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(coins.quantity(150), pickaxe, log, axe, bone, softClay, earthTali, ess, flyRod, feathers);
+		return Arrays.asList(coins.quantity(150), pickaxe, log, axe, bone, softClay, earthTali, essence, flyRod, feathers);
 	}
 
 	@Override
@@ -308,7 +308,7 @@ public class VarrockEasy extends ComplexStateQuestHelper
 		allSteps.add(dyingTreeSteps);
 
 		PanelDetails earthRuneSteps = new PanelDetails("Craft an Earth Rune", Arrays.asList(moveToEarthRune,
-			earthRune), new SkillRequirement(Skill.RUNECRAFT, 9), ess, earthTali);
+			earthRune), new SkillRequirement(Skill.RUNECRAFT, 9), essence, earthTali);
 		earthRuneSteps.setDisplayCondition(notEarthRune);
 		allSteps.add(earthRuneSteps);
 

--- a/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockElite.java
@@ -72,8 +72,8 @@ import com.questhelper.steps.QuestStep;
 public class VarrockElite extends ComplexStateQuestHelper
 {
 	// Items required
-	ItemRequirement sAtk4, sStr4, sDef4, torstol, natRune, astRune, earthRune, coins, mahoLog, cookingGuild, rawPie,
-		runeBar, feather, hammer, ess, earthTali, runeDartTip;
+	ItemRequirement sAtk4, sStr4, sDef4, torstol, natureRune, astralRune, earthRune, coins, mahoganyLog, cookingGuild, rawPie,
+		runeBar, feather, hammer, essence, earthTali, runeDartTip;
 
 	// Quests required
 	Requirement dreamMentor, runeMyster, touristTrap;
@@ -122,11 +122,11 @@ public class VarrockElite extends ComplexStateQuestHelper
 		sStr4 = new ItemRequirement("Super strength(4)", ItemID.SUPER_STRENGTH4).showConditioned(notSuperCombat);
 		sDef4 = new ItemRequirement("Super defense(4)", ItemID.SUPER_DEFENCE4).showConditioned(notSuperCombat);
 		torstol = new ItemRequirement("Torstol", ItemID.TORSTOL).showConditioned(notSuperCombat);
-		natRune = new ItemRequirement("Nature rune", ItemID.NATURE_RUNE).showConditioned(notPlankMake);
-		astRune = new ItemRequirement("Astral rune", ItemID.ASTRAL_RUNE).showConditioned(notPlankMake);
+		natureRune = new ItemRequirement("Nature rune", ItemID.NATURE_RUNE).showConditioned(notPlankMake);
+		astralRune = new ItemRequirement("Astral rune", ItemID.ASTRAL_RUNE).showConditioned(notPlankMake);
 		earthRune = new ItemRequirement("Earth rune", ItemID.EARTH_RUNE).showConditioned(notPlankMake);
 		coins = new ItemRequirement("Coins", ItemCollections.getCoins()).showConditioned(notPlankMake);
-		mahoLog = new ItemRequirement("Mahogany logs", ItemID.MAHOGANY_LOGS).showConditioned(notPlankMake);
+		mahoganyLog = new ItemRequirement("Mahogany logs", ItemID.MAHOGANY_LOGS).showConditioned(notPlankMake);
 		cookingGuild = new ItemRequirement("Access to cooking guild", ItemCollections.getCookingGuild()).showConditioned(notSummerPie);
 		cookingGuild.setTooltip("A chef's hat, Varrock Armour 3, or Cooking Cape");
 		rawPie = new ItemRequirement("Raw summer pie", ItemID.RAW_SUMMER_PIE).showConditioned(notSummerPie);
@@ -134,7 +134,7 @@ public class VarrockElite extends ComplexStateQuestHelper
 		feather = new ItemRequirement("Feather", ItemID.FEATHER).showConditioned(notRuneDart);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notRuneDart);
 		runeDartTip = new ItemRequirement("Rune dart tip", ItemID.RUNE_DART_TIP);
-		ess = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(not100Earth);
+		essence = new ItemRequirement("Essence", ItemCollections.getEssenceLow()).showConditioned(not100Earth);
 		earthTali = new ItemRequirement("Access to Earth altar, or travel through abyss",
 			ItemCollections.getEarthAltar()).showConditioned(not100Earth);
 
@@ -177,7 +177,7 @@ public class VarrockElite extends ComplexStateQuestHelper
 		moveToLumb = new ObjectStep(this, 2618, new WorldPoint(3308, 3492, 0),
 			"Climb the fence to enter the lumber yard.");
 		plankMake = new DetailedQuestStep(this, "Cast plank make until you've made 20 mahogany planks.",
-			natRune.quantity(20), astRune.quantity(40), earthRune.quantity(300), coins.quantity(21000), mahoLog.quantity(20));
+			natureRune.quantity(20), astralRune.quantity(40), earthRune.quantity(300), coins.quantity(21000), mahoganyLog.quantity(20));
 		moveToCookingGuild = new ObjectStep(this, ObjectID.DOOR_24958, new WorldPoint(3143, 3443, 0),
 			"Enter the cooking guild.", cookingGuild.equipped());
 		summerPie = new ObjectStep(this, ObjectID.RANGE_7183, new WorldPoint(3146, 3453, 0),
@@ -185,7 +185,7 @@ public class VarrockElite extends ComplexStateQuestHelper
 		moveToEarthRune = new ObjectStep(this, 34816, new WorldPoint(3306, 3474, 0),
 			"Travel to the earth altar or go through the abyss.", earthTali);
 		earthRune100 = new ObjectStep(this, 34763, new WorldPoint(2658, 4841, 0),
-			"Craft the earth runes.", ess.quantity(25));
+			"Craft the earth runes.", essence.quantity(25));
 		moveToAnvil = new TileStep(this, new WorldPoint(3188, 3426, 0),
 			"Go to the anvil beside the east Varrock bank.");
 		dartTip = new ObjectStep(this, ObjectID.ANVIL_2097, new WorldPoint(3188, 3426, 0),
@@ -201,9 +201,9 @@ public class VarrockElite extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(sAtk4, sStr4, sDef4, torstol, natRune.quantity(20), astRune.quantity(40),
-			earthRune.quantity(300), coins.quantity(21000), mahoLog.quantity(20), cookingGuild, rawPie, runeBar,
-			feather, hammer, ess.quantity(25), earthTali);
+		return Arrays.asList(sAtk4, sStr4, sDef4, torstol, natureRune.quantity(20), astralRune.quantity(40),
+			earthRune.quantity(300), coins.quantity(21000), mahoganyLog.quantity(20), cookingGuild, rawPie, runeBar,
+			feather, hammer, essence.quantity(25), earthTali);
 	}
 
 	@Override
@@ -265,13 +265,13 @@ public class VarrockElite extends ComplexStateQuestHelper
 		allSteps.add(runeDartsSteps);
 
 		PanelDetails plankMakeSteps = new PanelDetails("Plank Make", Arrays.asList(moveToLumb, plankMake),
-			new SkillRequirement(Skill.MAGIC, 86), dreamMentor, natRune.quantity(20), astRune.quantity(40),
-			earthRune.quantity(300), coins.quantity(21000), mahoLog.quantity(20));
+			new SkillRequirement(Skill.MAGIC, 86), dreamMentor, natureRune.quantity(20), astralRune.quantity(40),
+			earthRune.quantity(300), coins.quantity(21000), mahoganyLog.quantity(20));
 		plankMakeSteps.setDisplayCondition(notPlankMake);
 		allSteps.add(plankMakeSteps);
 
 		PanelDetails earth100Steps = new PanelDetails("Craft 100 Earth runes", Arrays.asList(moveToEarthRune,
-			earthRune100), new SkillRequirement(Skill.RUNECRAFT, 78), ess.quantity(25), earthTali);
+			earthRune100), new SkillRequirement(Skill.RUNECRAFT, 78), essence.quantity(25), earthTali);
 		earth100Steps.setDisplayCondition(not100Earth);
 		allSteps.add(earth100Steps);
 


### PR DESCRIPTION
Renames some variables in Diaries that seem out of place compared to the same item(s) variables in other files.

Noticed these while doing `.quantity()` changes and figured they needed their own PR