### PR TITLE
Fix backwards requirements in MorytaniaElite.java

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaElite.java
@@ -109,8 +109,8 @@ public class MorytaniaElite extends ComplexStateQuestHelper
 
 	public void setupRequirements()
 	{
-		notBareHandShark = new VarplayerRequirement(1181, true, 3);
-		notCremateShade = new VarplayerRequirement(1181, true, 4);
+		notBareHandShark = new VarplayerRequirement(1181, false, 3);
+		notCremateShade = new VarplayerRequirement(1181, false, 4);
 		notFertilizeHerb = new VarplayerRequirement(1181, false, 5);
 		notCraftBlackDhideBody = new VarplayerRequirement(1181, false, 6);
 		notAbyssalDemon = new VarplayerRequirement(1181, false, 7);


### PR DESCRIPTION
before:
![java_2022-02-21_14-55-28](https://user-images.githubusercontent.com/41973452/155019340-d60256ba-3c53-4634-9e41-4d215d1f6933.png)
after:
![java_2022-02-21_14-57-42](https://user-images.githubusercontent.com/41973452/155019344-6a1c24f7-112b-412b-8290-b62c507e5966.png)


Fixes #721