### PR TITLE
Add more planks to Item Requirements

### DIFF
--- a/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
+++ b/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
@@ -181,8 +181,9 @@ public class MountainDaughter extends BasicQuestHelper
 		pickaxe.addAlternates(ItemCollections.getPickaxes());
 
 		axe = new ItemRequirement("Any axe", ItemCollections.getAxes());
-		plank = new ItemRequirement("Plank", ItemID.PLANK);
-		pole = new ItemRequirement("A staff or a Pole", ItemID.POLE);
+		plank = new ItemRequirement("Any plank", ItemID.PLANK);
+		plank.addAlternates(ItemID.OAK_PLANK, ItemID.TEAK_PLANK, ItemID.MAHOGANY_PLANK);
+		pole = new ItemRequirement("A staff or a pole", ItemID.POLE);
 		pole.addAlternates(ItemID.LUNAR_STAFF);
 		pole.setTooltip("You can find one in the north part of the Mountain Camp.");
 		gloves = new ItemRequirement("Almost any gloves", ItemID.LEATHER_GLOVES);


### PR DESCRIPTION
Added Oak, Teak, and Mahogany planks as alternatives to satisfy item requirements.
Tested all planks in-game to make sure they were actually able to be used; checked both crossing into the island, and back to the mainland.