### PR TITLE
Kourend Med diary Any Axe req fix

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendMedium.java
@@ -38,6 +38,7 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
@@ -153,7 +154,8 @@ public class KourendMedium extends ComplexStateQuestHelper
 		kingWorm = new ItemRequirement("King worm or fish chunks", ItemID.KING_WORM).showConditioned(notCatchBluegill);
 		kingWorm.addAlternates(ItemID.FISH_CHUNKS);
 		kingWorm.setTooltip("Obtainable on Molch Island");
-		axe = new ItemRequirement("Any axe", ItemCollections.getAxes()).showConditioned(notSubdueWintertodt);
+		axe = new ItemRequirement("Any axe", ItemCollections.getAxes()).showConditioned(new Conditions(LogicType.OR,
+				notSubdueWintertodt, notChopMahoganyTree));
 		tinderbox = new ItemRequirement("Tinderbox", Arrays.asList(ItemID.BRUMA_TORCH, ItemID.TINDERBOX))
 			.showConditioned(notSubdueWintertodt);
 		boxTrap = new ItemRequirement("Box trap", ItemID.BOX_TRAP).showConditioned(notCatchChinchompa);


### PR DESCRIPTION
![Screenshot from 2022-03-30 00-24-41](https://user-images.githubusercontent.com/32951356/160634206-ea8e7fee-1ebf-496a-b957-2550294f41c3.png)

Bug is shown above, the axe item requirement was only added for defeating wintertodt, its also needed for chopping mahogany tree

added OR conditional to the item requirement to solve the problem.

the fix:
![Screenshot from 2022-03-30 00-28-56](https://user-images.githubusercontent.com/32951356/160635305-9493d87b-1624-4c01-a1e0-5bf2c5923473.png)

