### PR TITLE
"Snail" to "blamish" shell in easy Morytania diary

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaEasy.java
@@ -129,7 +129,7 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		notRestorePrayer = new VarplayerRequirement(1180, false, 11);
 
 		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).showConditioned(notCraftSnelm);
-		snailShell = new ItemRequirement("Snail shell", ItemCollections.getSnailShells()).showConditioned(notCraftSnelm);
+		snailShell = new ItemRequirement("Blamish shell", ItemCollections.getSnailShells()).showConditioned(notCraftSnelm);
 		thinSnail = new ItemRequirement("Thin snail", ItemID.THIN_SNAIL).showConditioned(notCookSnail);
 		tannableHide = new ItemRequirement("Tannable hide", ItemCollections.getTannableHide()).showConditioned(notSbottTan);
 		coins = new ItemRequirement("Coins", ItemCollections.getCoins()).showConditioned(notSbottTan);


### PR DESCRIPTION
The snail shell is a drop in Temple Trekking. I may or may not have just done Temple Trekking until I got a snail shell, only to find it is not required and cannot be used for the task diary.