### PR TITLE
Add woodcutting requirement for ironman

### DIFF
--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -584,6 +584,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 		req.add(new QuestRequirement(QuestHelperQuest.THE_FREMENNIK_TRIALS, QuestState.FINISHED));
 		req.add(new SkillRequirement(Skill.AGILITY, 40, true));
 		req.add(new SkillRequirement(Skill.CONSTRUCTION, 20, true));
+		req.add(new SkillRequirement(Skill.WOODCUTTING, 56, true));
 		return req;
 	}
 


### PR DESCRIPTION
Add the 56 woodcutting requirement (splitting artic logs) for ironman players.