### PR TITLE
Ordering Dropdown Overlap Fix

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -59,8 +59,8 @@ public interface QuestHelperConfig extends Config
 		/** Sort quest by their release date (https://oldschool.runescape.wiki/w/Quests/Release_dates) */
 		RELEASE_DATE(QuestOrders.sortByRelease(), QuestFilter.QUEST, QuestFilter.MINIQUEST),
 
-		QUEST_POINTS_ASCENDING(QuestOrders.sortByQuestPointRewardAscending(), QuestFilter.QUEST),
-		QUEST_POINTS_DESCENDING(QuestOrders.sortByQuestPointRewardDescending(), QuestFilter.QUEST)
+		QUEST_POINTS_ASC(QuestOrders.sortByQuestPointRewardAscending(), QuestFilter.QUEST),
+		QUEST_POINTS_DESC(QuestOrders.sortByQuestPointRewardDescending(), QuestFilter.QUEST)
 		;
 
 		private final Comparator<QuestHelper> comparator;


### PR DESCRIPTION
Noticed a problem with overlapping dropdown on the panel because of #755. The problem stems from the padding at the end of each option in the dropdown, so there might be a more suitable fix to this.

Before:
![image](https://user-images.githubusercontent.com/13607196/164707826-5d390f22-d2aa-4be2-872c-2fb38b935dd2.png)


After:
![image](https://user-images.githubusercontent.com/13607196/164707698-85f80555-3fe1-4210-8d02-063adf30852c.png)
