### PR TITLE
Couple fixes

### DIFF
--- a/src/main/java/com/questhelper/ItemCollections.java
+++ b/src/main/java/com/questhelper/ItemCollections.java
@@ -2056,9 +2056,9 @@ public class ItemCollections
 	private static final List<Integer> fishingRod = ImmutableList.of(
 		ItemID.PEARL_FISHING_ROD,
 		ItemID.FISHING_ROD
-  );
+	);
 
-  @Getter
+	@Getter
 	private static final List<Integer> OgreBrutalArrows = ImmutableList.of(
 		ItemID.RUNE_BRUTAL,
 		ItemID.ADAMANT_BRUTAL,
@@ -2185,10 +2185,10 @@ public class ItemCollections
 	private static final List<Integer> voidRobe = ImmutableList.of(
 		ItemID.ELITE_VOID_ROBE,
 		ItemID.VOID_KNIGHT_ROBE
-  );
-	
-  @Getter
-  private static final List<Integer> guthixBalanceUnf = ImmutableList.of(
+	);
+
+	@Getter
+	private static final List<Integer> guthixBalanceUnf = ImmutableList.of(
 		ItemID.GUTHIX_BALANCE_UNF,
 		ItemID.GUTHIX_BALANCE_UNF_7654,
 		ItemID.GUTHIX_BALANCE_UNF_7656,

--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -59,8 +59,8 @@ public interface QuestHelperConfig extends Config
 		/** Sort quest by their release date (https://oldschool.runescape.wiki/w/Quests/Release_dates) */
 		RELEASE_DATE(QuestOrders.sortByRelease(), QuestFilter.QUEST, QuestFilter.MINIQUEST),
 
-		QUEST_POINTS_ASCENDING(QuestOrders.sortByQuestPointRewardAscending(), QuestFilter.QUEST),
-		QUEST_POINTS_DESCENDING(QuestOrders.sortByQuestPointRewardDescending(), QuestFilter.QUEST)
+		QUEST_POINTS_ASC(QuestOrders.sortByQuestPointRewardAscending(), QuestFilter.QUEST),
+		QUEST_POINTS_DESC(QuestOrders.sortByQuestPointRewardDescending(), QuestFilter.QUEST)
 		;
 
 		private final Comparator<QuestHelper> comparator;

--- a/src/main/java/com/questhelper/achievementdiaries/ardougne/ArdougneElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/ardougne/ArdougneElite.java
@@ -296,6 +296,7 @@ public class ArdougneElite extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.MAGIC, 94));
 		reqs.add(new SkillRequirement(Skill.SMITHING, 91, true));
 		reqs.add(new SkillRequirement(Skill.THIEVING, 82, true));
+
 		reqs.add(ancientBook);
 		reqs.add(desertTreasure);
 		reqs.add(hauntedMine);

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertHard.java
@@ -259,7 +259,6 @@ public class DesertHard extends ComplexStateQuestHelper
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new SkillRequirement(Skill.AGILITY, 70));
 		reqs.add(new SkillRequirement(Skill.ATTACK, 50));
-		reqs.add(new SkillRequirement(Skill.CRAFTING, 55));
 		reqs.add(new SkillRequirement(Skill.DEFENCE, 10));
 		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60));
 		reqs.add(new SkillRequirement(Skill.MAGIC, 68));

--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorEasy.java
@@ -267,8 +267,8 @@ public class FaladorEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.CONSTRUCTION, 16));
 		req.add(new SkillRequirement(Skill.AGILITY, 5, true));
+		req.add(new SkillRequirement(Skill.CONSTRUCTION, 16));
 		req.add(new SkillRequirement(Skill.MINING, 10, true));
 		req.add(new SkillRequirement(Skill.SMITHING, 13, true));
 

--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorElite.java
@@ -235,10 +235,10 @@ public class FaladorElite extends ComplexStateQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 
 		req.add(new SkillRequirement(Skill.AGILITY, 80, true));
-		req.add(new SkillRequirement(Skill.RUNECRAFT, 88, true));
 		req.add(new SkillRequirement(Skill.FARMING, 91, true));
-		req.add(new SkillRequirement(Skill.WOODCUTTING, 75, true));
 		req.add(new SkillRequirement(Skill.HERBLORE, 81, true));
+		req.add(new SkillRequirement(Skill.RUNECRAFT, 88, true));
+		req.add(new SkillRequirement(Skill.WOODCUTTING, 75, true));
 
 		req.add(wanted);
 

--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorHard.java
@@ -302,12 +302,12 @@ public class FaladorHard extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.AGILITY, 59, true));
+		req.add(new SkillRequirement(Skill.AGILITY, 50));
 		req.add(new SkillRequirement(Skill.DEFENCE, 50));
-		req.add(new SkillRequirement(Skill.SLAYER, 72, true));
 		req.add(new SkillRequirement(Skill.MINING, 60, true));
 		req.add(new SkillRequirement(Skill.PRAYER, 70));
 		req.add(new SkillRequirement(Skill.RUNECRAFT, 56, true));
+		req.add(new SkillRequirement(Skill.SLAYER, 72, true));
 		req.add(new SkillRequirement(Skill.THIEVING, 50, true));
 		req.add(new WarriorsGuildAccessRequirement());
 

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikMedium.java
@@ -391,13 +391,10 @@ public class FremennikMedium extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.AGILITY, 35, true));
 		req.add(new SkillRequirement(Skill.CONSTRUCTION, 37, true));
-		req.add(new SkillRequirement(Skill.DEFENCE, 30));
 		req.add(new SkillRequirement(Skill.HUNTER, 35, true));
 		req.add(new SkillRequirement(Skill.MINING, 40));
 		req.add(new SkillRequirement(Skill.SLAYER, 47, true));
-		req.add(new SkillRequirement(Skill.SMITHING, 50, true));
 		req.add(new SkillRequirement(Skill.THIEVING, 42, true));
 		req.add(new SkillRequirement(Skill.PRAYER, 43, false,
 			"43 Prayer for protection prayers"));

--- a/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaEasy.java
@@ -129,9 +129,6 @@ public class KaramjaEasy extends ComplexStateQuestHelper
 		food = new ItemRequirement("Food", ItemCollections.getGoodEatingFood(), -1);
 		antipoison = new ItemRequirement("Antipoison", ItemCollections.getAntipoisons(), -1);
 
-		// 3578 = 2, completed final task
-		// varplayer 2943 0->1>2>3 when done final task
-
 		inCave = new ZoneRequirement(cave);
 		inTzhaar = new ZoneRequirement(tzhaar);
 		inPothole = new ZoneRequirement(pothole);

--- a/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaHard.java
@@ -308,15 +308,13 @@ public class KaramjaHard extends ComplexStateQuestHelper
 		reqs.add(new CombatLevelRequirement(100));
 		reqs.add(new SkillRequirement(Skill.AGILITY, 53));
 		reqs.add(new SkillRequirement(Skill.COOKING, 30));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 59));
 		reqs.add(new SkillRequirement(Skill.MINING, 52));
 		reqs.add(new SkillRequirement(Skill.RANGED, 42));
 		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 44));
 		reqs.add(new SkillRequirement(Skill.SLAYER, 50));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 40));
 		reqs.add(new SkillRequirement(Skill.STRENGTH, 50));
 		reqs.add(new SkillRequirement(Skill.THIEVING, 50));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 34));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 15));
 
 		reqs.add(new QuestRequirement(QuestHelperQuest.TAI_BWO_WANNAI_TRIO, QuestState.FINISHED));
 		reqs.add(new VarplayerRequirement(QuestVarPlayer.QUEST_LEGENDS_QUEST.getId(), 1,

--- a/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/karamja/KaramjaMedium.java
@@ -216,11 +216,6 @@ public class KaramjaMedium extends BasicQuestHelper
 		shiloVillage = new QuestRequirement(QuestHelperQuest.SHILO_VILLAGE, QuestState.FINISHED);
 		junglePotion = new QuestRequirement(QuestHelperQuest.JUNGLE_POTION, QuestState.FINISHED);
 
-		// 3578 = 2, completed final task
-		// varplayer 2943 0->1>2>3 when done final task
-
-		// Used skewer on spider, 2943 3->4 (VARPLAYER)
-
 		inCave = new ZoneRequirement(cave);
 		inAgilityArena = new ZoneRequirement(agilityArena);
 		inBrimhavenDungeon = new ZoneRequirement(brimhavenDungeon);

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendEasy.java
@@ -35,6 +35,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.player.Favour;
+import com.questhelper.requirements.player.FavourRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.Operation;
@@ -161,8 +163,7 @@ public class KourendEasy extends ComplexStateQuestHelper
 		hasMedpack = medpack.alsoCheckBank(questBank);
 
 		houseInKourend = new VarbitRequirement(2187, 8);
-		hosidiusFavour = new VarbitRequirement(4895, Operation.GREATER_EQUAL, 150,
-			"15% Hosidius Favour");
+		hosidiusFavour = new FavourRequirement(Favour.HOSIDIUS, 15);
 	}
 
 	public void loadZones()

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendElite.java
@@ -36,6 +36,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.player.Favour;
+import com.questhelper.requirements.player.FavourRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.player.SpellbookRequirement;
 import com.questhelper.requirements.util.LogicType;
@@ -183,14 +185,10 @@ public class KourendElite extends ComplexStateQuestHelper
 		potatoCactus = new ItemRequirement("Potato cactus", ItemID.POTATO_CACTUS, 8);
 		ultraCompost = new ItemRequirement("Compost", ItemCollections.getCompost());
 
-		arceuusFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_ARCEUUS, Operation.GREATER_EQUAL, 1000,
-			"100% Arceuus favour");
-		hosidiusFavour60 = new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 600,
-			"60% Hosidius favour");
-		hosidiusFavour75 = new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 750,
-			"75% Hosidius favour");
-		piscariliusFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_PISCARILIUS, Operation.GREATER_EQUAL, 1000,
-			"100% Piscarilius favour");
+		arceuusFavour = new FavourRequirement(Favour.ARCEUUS, 100);
+		hosidiusFavour60 = new FavourRequirement(Favour.HOSIDIUS, 60);
+		hosidiusFavour75 = new FavourRequirement(Favour.HOSIDIUS, 75);
+		piscariliusFavour = new FavourRequirement(Favour.PISCARILIUS, 100);
 
 		// Zone requirements
 		inRedwoodTree = new ZoneRequirement(redwoodTree);
@@ -351,13 +349,9 @@ public class KourendElite extends ComplexStateQuestHelper
 		req.add(new SkillRequirement(Skill.SLAYER, 95, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 90, true));
 
-		// Overall required favours
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_ARCEUUS, Operation.GREATER_EQUAL, 1000,
-			"100% Arceuus favour"));
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 750,
-			"75% Hosidius favour"));
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_PISCARILIUS, Operation.GREATER_EQUAL, 1000,
-			"100% Piscarilius favour"));
+		req.add(arceuusFavour);
+		req.add(hosidiusFavour75);
+		req.add(piscariliusFavour);
 
 		return req;
 	}

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
@@ -36,6 +36,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.player.CombatLevelRequirement;
+import com.questhelper.requirements.player.Favour;
+import com.questhelper.requirements.player.FavourRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.player.SpellbookRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
@@ -182,16 +184,11 @@ public class KourendHard extends ComplexStateQuestHelper
 		dreamMentor = new QuestRequirement(QuestHelperQuest.DREAM_MENTOR, QuestState.FINISHED);
 		theForsakenTower = new QuestRequirement(QuestHelperQuest.THE_FORSAKEN_TOWER, QuestState.FINISHED);
 
-		shayzienFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_SHAYZIEN, Operation.GREATER_EQUAL, 1000,
-			"100% Shayzien favour");
-		hosidiusFavour75 = new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 750,
-			"75% Hosidius favour");
-		hosidiusFavour100 = new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 1000,
-			"100% Hosidius favour");
-		lovakengjFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_LOVAKENGJ, Operation.GREATER_EQUAL, 300,
-			"30% Lovakengj favour");
-		piscariliusFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_PISCARILIUS, Operation.GREATER_EQUAL, 750,
-			"75% Piscarilius favour");
+		shayzienFavour = new FavourRequirement(Favour.SHAYZIEN, 100);
+		hosidiusFavour75 = new FavourRequirement(Favour.HOSIDIUS, 100);
+		hosidiusFavour100 = new FavourRequirement(Favour.HOSIDIUS, 100);
+		lovakengjFavour = new FavourRequirement(Favour.LOVAKENGJ,30);
+		piscariliusFavour = new FavourRequirement(Favour.PISCARILIUS, 75);
 
 		// Zone requirements
 		inForsakenTower = new ZoneRequirement(forsakenTower);
@@ -326,17 +323,10 @@ public class KourendHard extends ComplexStateQuestHelper
 		req.add(new SkillRequirement(Skill.THIEVING, 49));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 60));
 
-		// Overall required favours
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_ARCEUUS, Operation.GREATER_EQUAL, 1000,
-			"100% Arceuus favour"));
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 1000,
-			"100% Hosidius favour"));
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_LOVAKENGJ, Operation.GREATER_EQUAL, 1000,
-			"100% Lovakengj favour"));
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_PISCARILIUS, Operation.GREATER_EQUAL, 1000,
-			"100% Piscarilius favour"));
-		req.add(new VarbitRequirement(Varbits.KOUREND_FAVOR_SHAYZIEN, Operation.GREATER_EQUAL, 1000,
-			"100% Shayzien favour"));
+		req.add(shayzienFavour);
+		req.add(hosidiusFavour100);
+		req.add(lovakengjFavour);
+		req.add(piscariliusFavour);
 
 		req.add(architecturalAlliance);
 		req.add(dreamMentor);

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
@@ -137,7 +137,7 @@ public class KourendHard extends ComplexStateQuestHelper
 
 		// Items required
 		adamantiteOre = new ItemRequirement("Adamantite ore", ItemID.ADAMANTITE_ORE).showConditioned(notSmeltAddyBar);
-		coal = new ItemRequirement("6 Coal", ItemID.COAL).showConditioned(notSmeltAddyBar);
+		coal = new ItemRequirement("Coal", ItemID.COAL).showConditioned(notSmeltAddyBar);
 		bootsOfStone = new ItemRequirement("Boots of stone", ItemCollections.getStoneBoots()).showConditioned(notKillWyrm);
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.getPickaxes()).showConditioned(notMineLovakite);
 		lightSource = new ItemRequirement("Light source", ItemCollections.getLightSources())

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendMedium.java
@@ -36,6 +36,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.player.Favour;
+import com.questhelper.requirements.player.FavourRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.LogicType;
@@ -155,7 +157,7 @@ public class KourendMedium extends ComplexStateQuestHelper
 		kingWorm.addAlternates(ItemID.FISH_CHUNKS);
 		kingWorm.setTooltip("Obtainable on Molch Island");
 		axe = new ItemRequirement("Any axe", ItemCollections.getAxes()).showConditioned(new Conditions(LogicType.OR,
-				notSubdueWintertodt, notChopMahoganyTree));
+			notSubdueWintertodt, notChopMahoganyTree));
 		tinderbox = new ItemRequirement("Tinderbox", Arrays.asList(ItemID.BRUMA_TORCH, ItemID.TINDERBOX))
 			.showConditioned(notSubdueWintertodt);
 		boxTrap = new ItemRequirement("Box trap", ItemID.BOX_TRAP).showConditioned(notCatchChinchompa);
@@ -182,12 +184,9 @@ public class KourendMedium extends ComplexStateQuestHelper
 		ascentOfArceuus = new QuestRequirement(QuestHelperQuest.THE_ASCENT_OF_ARCEUUS, QuestState.FINISHED);
 		eaglesPeak = new QuestRequirement(QuestHelperQuest.EAGLES_PEAK, QuestState.FINISHED);
 
-		arceuusFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_ARCEUUS, Operation.GREATER_EQUAL, 600,
-			"60% Arceuus favour");
-		hosidiusFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_HOSIDIUS, Operation.GREATER_EQUAL, 600,
-			"60% Hosidius favour");
-		shayzienFavour = new VarbitRequirement(Varbits.KOUREND_FAVOR_SHAYZIEN, Operation.GREATER_EQUAL, 400,
-			"40% Shayzien favour");
+		arceuusFavour = new FavourRequirement(Favour.ARCEUUS, 60);
+		hosidiusFavour = new FavourRequirement(Favour.HOSIDIUS, 60);
+		shayzienFavour = new FavourRequirement(Favour.SHAYZIEN, 40);
 
 		// Zone requirements
 		inMolchIsland = new ZoneRequirement(molchIsland);
@@ -335,10 +334,9 @@ public class KourendMedium extends ComplexStateQuestHelper
 
 		req.add(new SkillRequirement(Skill.AGILITY, 49, true));
 		req.add(new SkillRequirement(Skill.CRAFTING, 30));
-		req.add(new SkillRequirement(Skill.FARMING, 45));
 		req.add(new SkillRequirement(Skill.FIREMAKING, 50));
 		req.add(new SkillRequirement(Skill.FISHING, 43));
-		req.add(new SkillRequirement(Skill.HUNTER, 53));
+		req.add(new SkillRequirement(Skill.HUNTER, 35));
 		req.add(new SkillRequirement(Skill.MINING, 42));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 50, true));
 

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -118,7 +118,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		notChopMagic = new VarplayerRequirement(1195, false, 6);
 		notAddyPlatebody = new VarplayerRequirement(1195, false, 7);
 		notWaterRunes = new VarplayerRequirement(1195, false, 8);
-		notQCEmote = new VarplayerRequirement(1195, true, 9);
+		notQCEmote = new VarplayerRequirement(1195, false, 9);
 
 		// todo find better way to check for all quests completed
 		allQuests = new QuestPointRequirement(286, Operation.EQUAL);

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
@@ -265,7 +265,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 23));
 		reqs.add(new SkillRequirement(Skill.STRENGTH, 19));
 		reqs.add(new SkillRequirement(Skill.THIEVING, 38));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 36));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 30));
 
 		reqs.add(fairyTaleII);
 		reqs.add(animalMagnetism);

--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaMedium.java
@@ -155,7 +155,7 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 		ammoMould = new ItemRequirement("Ammo mould", ItemID.AMMO_MOULD).showConditioned(notCannonBall);
 		slayerGloves = new ItemRequirement("Slayer gloves", ItemID.SLAYER_GLOVES).showConditioned(notFeverSpider);
 		ectophial = new ItemRequirement("Ectophial", ItemID.ECTOPHIAL).showConditioned(notEctophialTP);
-		restorePot = new ItemRequirement("Restore potion (4)", ItemCollections.getRestorePotions()).showConditioned(notGuthBalance);
+		restorePot = new ItemRequirement("Restore potion (4)", ItemID.RESTORE_POTION4).showConditioned(notGuthBalance);
 		garlic = new ItemRequirement("Garlic", ItemID.GARLIC).showConditioned(notGuthBalance);
 		silverDust = new ItemRequirement("Silver dust", ItemID.SILVER_DUST).showConditioned(notGuthBalance);
 		silverDust.setTooltip("Created by grinding a silver bar in the ectofuntus bone grinder.");

--- a/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockHard.java
@@ -358,8 +358,6 @@ public class VarrockHard extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.HUNTER, 66));
 		reqs.add(new SkillRequirement(Skill.MAGIC, 54));
 		reqs.add(new SkillRequirement(Skill.PRAYER, 52));
-		reqs.add(new SkillRequirement(Skill.RANGED, 40));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 53));
 		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 60));
 		reqs.add(ancientBook);
 		reqs.add(desertTreasure);

--- a/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockMedium.java
@@ -290,12 +290,9 @@ public class VarrockMedium extends ComplexStateQuestHelper
 		reqs.add(new CombatLevelRequirement(40));
 		reqs.add(qp);
 		reqs.add(new SkillRequirement(Skill.AGILITY, 30));
-		reqs.add(new SkillRequirement(Skill.CRAFTING, 36));
 		reqs.add(new SkillRequirement(Skill.FARMING, 30));
 		reqs.add(new SkillRequirement(Skill.FIREMAKING, 40));
-		reqs.add(new SkillRequirement(Skill.HERBLORE, 10));
 		reqs.add(new SkillRequirement(Skill.MAGIC, 25));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 25));
 		reqs.add(normalBook);
 
 		reqs.add(gardenOfTranq);

--- a/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternEasy.java
@@ -232,7 +232,6 @@ public class WesternEasy extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.FLETCHING, 20));
 		reqs.add(new SkillRequirement(Skill.HUNTER, 9));
 		reqs.add(new SkillRequirement(Skill.MINING, 15));
-		reqs.add(new SkillRequirement(Skill.RANGED, 30));
 
 		reqs.add(bigChompy);
 		reqs.add(runeMysteries);

--- a/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternMedium.java
@@ -325,10 +325,8 @@ public class WesternMedium extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.COOKING, 42));
 		reqs.add(new SkillRequirement(Skill.FIREMAKING, 35));
 		reqs.add(new SkillRequirement(Skill.FISHING, 46));
-		reqs.add(new SkillRequirement(Skill.FLETCHING, 5));
 		reqs.add(new SkillRequirement(Skill.HUNTER, 31));
 		reqs.add(new SkillRequirement(Skill.MINING, 40));
-		reqs.add(new SkillRequirement(Skill.RANGED, 30));
 		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 35));
 
 		reqs.add(bigChompy);

--- a/src/main/java/com/questhelper/quests/belowicemountain/BelowIceMountain.java
+++ b/src/main/java/com/questhelper/quests/belowicemountain/BelowIceMountain.java
@@ -297,14 +297,12 @@ public class BelowIceMountain extends BasicQuestHelper
 		allSteps.add(checkalPanel);
 
 		PanelDetails marleyPanel = new PanelDetails("Recruit Marley",
-			Arrays.asList(talkToMarley, talkToCook, getIngredients, makeSandwich, feedMarley),
-			cookedMeat, bread, knife);
+			Arrays.asList(talkToMarley, talkToCook, getIngredients, makeSandwich, feedMarley), cookedMeat, bread, knife);
 		marleyPanel.setLockingStep(getMarley);
 		allSteps.add(marleyPanel);
 
 		PanelDetails burntofPanel = new PanelDetails("Recruit Burntof",
-			Arrays.asList(talkToBurntof, buyBeer, giveBeer, playRPS),
-			coins);
+			Arrays.asList(talkToBurntof, buyBeer, giveBeer, playRPS), coins);
 		burntofPanel.setLockingStep(getBurntof);
 		allSteps.add(burntofPanel);
 

--- a/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
@@ -503,7 +503,7 @@ public class ColdWar extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.HUNTER, 10, true));
 		req.add(new SkillRequirement(Skill.AGILITY, 30));
 		req.add(new SkillRequirement(Skill.CRAFTING, 30));
-		req.add(new SkillRequirement(Skill.CONSTRUCTION, 34, true));
+		req.add(new SkillRequirement(Skill.CONSTRUCTION, 34));
 		req.add(new SkillRequirement(Skill.THIEVING, 15));
 		return req;
 	}

--- a/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
+++ b/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
@@ -205,7 +205,7 @@ public class PriestInPeril extends BasicQuestHelper
 		bucket = new ItemRequirement("Bucket", ItemID.BUCKET);
 		bucketHighlighted = new ItemRequirement("Bucket", ItemID.BUCKET);
 		bucketHighlighted.setHighlightInInventory(true);
-		runePouches = new ItemRequirements(LogicType.AND, "Rune pouches for carrying essence",
+		runePouches = new ItemRequirements(LogicType.AND, "Essence pouches for carrying essence",
 			new ItemRequirement("Small pouch", ItemID.SMALL_POUCH),
 			new ItemRequirement("Medium pouch", ItemID.MEDIUM_POUCH),
 			new ItemRequirement("Large pouch", ItemID.LARGE_POUCH),

--- a/src/main/java/com/questhelper/quests/whatliesbelow/WhatLiesBelow.java
+++ b/src/main/java/com/questhelper/quests/whatliesbelow/WhatLiesBelow.java
@@ -249,17 +249,11 @@ public class WhatLiesBelow extends BasicQuestHelper
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new QuestRequirement(QuestHelperQuest.RUNE_MYSTERIES, QuestState.FINISHED));
+		req.add(new SkillRequirement(Skill.MINING, 42, false));
 		req.add(new SkillRequirement(Skill.RUNECRAFT, 35));
 		return req;
 	}
 
-	@Override
-	public List<Requirement> getGeneralRecommended()
-	{
-		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.MINING, 42, false, "42 Mining to unlock a shortcut to the Chaos altar"));
-		return req;
-	}
 
 	@Override
 	public QuestPointReward getQuestPointReward()


### PR DESCRIPTION
Noticed a problem with overlapping dropdown on the panel from #755. The problem stems from the padding at the end of each option in the dropdown, so there might be a more suitable fix to this.

Before:
![image](https://user-images.githubusercontent.com/13607196/164707826-5d390f22-d2aa-4be2-872c-2fb38b935dd2.png)


After:
![image](https://user-images.githubusercontent.com/13607196/164707698-85f80555-3fe1-4210-8d02-063adf30852c.png)

Also a bunch of diary skill req adjustments. Previously they _sometimes_ included skill requirements for quests. Which didn't really make sense because in our quest guides they don't require the skills from leading quests. 