### PR TITLE
clarify item rewards quest: Forgettable Tale

### DIFF
--- a/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
@@ -980,7 +980,7 @@ public class ForgettableTale extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("Dwarven Stout (m)", ItemID.DWARVEN_STOUTM, 1));
+		return Collections.singletonList(new ItemReward("2x Dwarven Stout (m)", ItemID.DWARVEN_STOUTM, 1));
 	}
 
 	@Override


### PR DESCRIPTION
To clarify the item rewards after you've done the quest: Forgettable Tale.
It sort of says that you will get '1 Drawven Stout (m)'. Wikipedia of osrs says it's 2.

link to source: [https://oldschool.runescape.wiki/w/Forgettable_Tale...](https://oldschool.runescape.wiki/w/Forgettable_Tale...)