### PR TITLE
Fix Troll Stronghold coin requirement

### DIFF
--- a/src/main/java/com/questhelper/quests/trollstronghold/TrollStronghold.java
+++ b/src/main/java/com/questhelper/quests/trollstronghold/TrollStronghold.java
@@ -33,6 +33,7 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.player.SkillRequirement;
@@ -135,9 +136,9 @@ public class TrollStronghold extends BasicQuestHelper
 	{
 		climbingBoots = new ItemRequirement("Climbing boots", ItemID.CLIMBING_BOOTS);
 		climbingBootsEquipped = new ItemRequirement("Climbing boots", ItemID.CLIMBING_BOOTS, 1, true);
-		climbingBootsOr12Coins = new ItemRequirement("Climbing boots or 12 coins", ItemID.CLIMBING_BOOTS);
-		gamesNecklace = new ItemRequirement("Games necklace", ItemCollections.getGamesNecklaces());
 		coins12 = new ItemRequirement("Coins", ItemCollections.getCoins(), 12);
+		climbingBootsOr12Coins = new ItemRequirements(LogicType.OR, "Climbing boots or 12 coins", climbingBoots, coins12);
+		gamesNecklace = new ItemRequirement("Games necklace", ItemCollections.getGamesNecklaces());
 		mageRangedGear = new ItemRequirement("Mage or ranged gear for safe spotting", -1, -1);
 		mageRangedGear.setDisplayItemId(BankSlotIcons.getMagicCombatGear());
 		foodAndPotions = new ItemRequirement("Food + prayer potions", ItemCollections.getGoodEatingFood(), -1);


### PR DESCRIPTION
Probably a copy-paste mistake, the `climbingBootsOr12Coins` requirement was the same as `climbingBoots`, so even if 12 coins were held in the inventory the requirement was shown as unsatisfied.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/11244353/166273183-2c5702f4-2e52-4582-83f3-0becc1810b89.png">
