### PR TITLE
Add WidgetPresenceRequirement

### DIFF
--- a/src/main/java/com/questhelper/requirements/WidgetModelRequirement.java
+++ b/src/main/java/com/questhelper/requirements/WidgetModelRequirement.java
@@ -36,7 +36,6 @@ public class WidgetModelRequirement extends WidgetPresenceRequirement
 	public WidgetModelRequirement(int groupId, int childId, int childChildId, int id)
 	{
 		super(groupId, childId, childChildId);
-		;
 		this.id = id;
 	}
 

--- a/src/main/java/com/questhelper/requirements/WidgetPresenceRequirement.java
+++ b/src/main/java/com/questhelper/requirements/WidgetPresenceRequirement.java
@@ -26,39 +26,66 @@
  */
 package com.questhelper.requirements;
 
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 
-public class WidgetModelRequirement extends WidgetPresenceRequirement
+public class WidgetPresenceRequirement extends SimpleRequirement
 {
-	private final int id;
+	@Setter
+	@Getter
+	protected boolean hasPassed;
+	protected boolean onlyNeedToPassOnce;
 
-	public WidgetModelRequirement(int groupId, int childId, int childChildId, int id)
+	@Getter
+	protected final int groupId;
+
+	protected final int childId;
+	protected int childChildId = -1;
+
+	public WidgetPresenceRequirement(int groupId, int childId, int childChildId)
 	{
-		super(groupId, childId, childChildId);
-		;
-		this.id = id;
+		this.groupId = groupId;
+		this.childId = childId;
+		this.childChildId = childChildId;
 	}
 
-	public WidgetModelRequirement(int groupId, int childId, int id)
+	public WidgetPresenceRequirement(int groupId, int childId)
 	{
-		super(groupId, childId);
-		this.id = id;
+		this.groupId = groupId;
+		this.childId = childId;
+	}
+
+	@Override
+	public boolean check(Client client)
+	{
+		if (onlyNeedToPassOnce && hasPassed)
+		{
+			return true;
+		}
+		return checkWidget(client);
+	}
+
+	@Nullable
+	protected Widget getWidget(Client client)
+	{
+		Widget widget = client.getWidget(groupId, childId);
+		if (widget == null)
+		{
+			return null;
+		}
+		if (childChildId != -1)
+		{
+			return widget.getChild(childChildId);
+		}
+		return widget;
 	}
 
 	public boolean checkWidget(Client client)
 	{
-		Widget widget = getWidget(client);
-		if (widget == null)
-		{
-			return false;
-		}
-		return widget.getModelId() == id;
-	}
-
-	public void checkWidgetText(Client client)
-	{
-		hasPassed = hasPassed || checkWidget(client);
+		return getWidget(client) != null;
 	}
 }
 


### PR DESCRIPTION
Yesterday, @LlemonDuck mentioned to me that I can conditionally check whether a Widget is there or not (`null` vs. `Widget` instance) to detect eg. puzzle 'interfaces' being open.

After looking into it this morning I also noticed that there's already a `WidgetModelRequirement`, which does exactly that _except_ that it also checks for a Model ID to be matching, which for the sake of detecting a widget's presence/visibility is likely not needed, so it made me wonder whether it would make sense to add a `WidgetPresenceRequirement`  and have the `WidgetModelRequirement` become a subclass of that.

While this obviously doesn't add groundbreaking new logic, it does provide an easy-to-find Requirement for people new to the project, which does exactly what they would expect it to do, so I figured it'd be a good QoL change to submit.