### PR TITLE
Fix: Mourning's End Part I Skill Requirement

### DIFF
--- a/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
+++ b/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
@@ -462,7 +462,7 @@ public class MourningsEndPartI extends BasicQuestHelper
 		req.add(new QuestRequirement(QuestHelperQuest.BIG_CHOMPY_BIRD_HUNTING, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.SHEEP_HERDER, QuestState.FINISHED));
 		req.add(new SkillRequirement(Skill.RANGED, 60));
-		req.add(new SkillRequirement(Skill.THIEVING, 50, true));
+		req.add(new SkillRequirement(Skill.THIEVING, 50));
 		return req;
 	}
 


### PR DESCRIPTION
The skill requirement for thieving on mourning's end part 1 is actually not boostable. 

I felt so sad that I was baited that I made this PR. 

please reference: https://oldschool.runescape.wiki/w/Mourning%27s_End_Part_I