### PR TITLE
Small fix for step text

### DIFF
--- a/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
+++ b/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
@@ -284,8 +284,7 @@ public class BigChompyBirdHunting extends BasicQuestHelper
 
 		killChompy = new NpcStep(this, NpcID.CHOMPY_BIRD, new WorldPoint(2635, 2966, 0), "Kill the chompy. You can only hurt it with an ogre bow + ogre arrows.", ogreBow, ogreArrows);
 		pluckCarcass = new NpcStep(this, NpcID.CHOMPY_BIRD_1476, new WorldPoint(2635, 2966, 0), "Pluck the chompy.");
-		talkToRantzWithChompy = new NpcStep(this, NpcID.RANTZ, new WorldPoint(2631, 2982, 0), "Pick up the chompy and use it on Rantz in the east of Feldip Hills.", chompyHighlighted);
-		talkToRantzWithChompy.addIcon(ItemID.RAW_CHOMPY);
+		talkToRantzWithChompy = new NpcStep(this, NpcID.RANTZ, new WorldPoint(2631, 2982, 0), "Talk to Rantz in the east of Feldip Hills.", chompy);
 
 		enterCaveAgain = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_3379, new WorldPoint(2630, 2999, 0), "Enter Rantz's cave.");
 		talkToFycie = new NpcStep(this, NpcID.FYCIE, new WorldPoint(2649, 9391, 0), "Talk to Fycie.");

--- a/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
@@ -371,6 +371,7 @@ public class ForgettableTale extends BasicQuestHelper
 		beer = new ItemRequirement("Beer", ItemID.BEER);
 		beer.setTooltip("You can buy these from either of the bars in Keldagrim for 2 coins");
 		dwarvenStout = new ItemRequirement("Dwarven stout", ItemID.DWARVEN_STOUT);
+		dwarvenStout.setTooltop("You can pick up one of these next to the NPC you need to give it to.");
 		beerGlass = new ItemRequirement("Beer glass", ItemID.BEER_GLASS);
 		randomItem = new ItemRequirement("A random item per player", -1, -1);
 		pot = new ItemRequirement("Pot", ItemID.POT);

--- a/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/quests/forgettabletale/ForgettableTale.java
@@ -371,7 +371,7 @@ public class ForgettableTale extends BasicQuestHelper
 		beer = new ItemRequirement("Beer", ItemID.BEER);
 		beer.setTooltip("You can buy these from either of the bars in Keldagrim for 2 coins");
 		dwarvenStout = new ItemRequirement("Dwarven stout", ItemID.DWARVEN_STOUT);
-		dwarvenStout.setTooltop("You can pick up one of these next to the NPC you need to give it to.");
+		dwarvenStout.setTooltip("You can pick up one of these next to the NPC you need to give it to.");
 		beerGlass = new ItemRequirement("Beer glass", ItemID.BEER_GLASS);
 		randomItem = new ItemRequirement("A random item per player", -1, -1);
 		pot = new ItemRequirement("Pot", ItemID.POT);


### PR DESCRIPTION
Previously the text would have the user use the raw chompy on the NPC, but this would not progress the plugin to the next step correctly. Simply talking to the NPC works great, so I've changed the relevant step to instruct the user to do just that.