### PR TITLE
Mourning's End P1 - Fix not progressing when filling apple barrel.

### DIFF
--- a/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
+++ b/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
@@ -167,7 +167,7 @@ public class MourningsEndPartI extends BasicQuestHelper
 		takeAppleToElena.addStep(new Conditions(receivedSieve, naphthaAppleMix), useSieveOnBarrel);
 		takeAppleToElena.addStep(new Conditions(receivedSieve, appleBarrel.alsoCheckBank(questBank), naphtha), useNaphthaOnBarrel);
 		takeAppleToElena.addStep(new Conditions(receivedSieve, appleBarrel.alsoCheckBank(questBank)), getNaphtha);
-		takeAppleToElena.addStep(new Conditions(receivedSieve, rottenApple), useApplesOnPress);
+		takeAppleToElena.addStep(new Conditions(receivedSieve, barrelOfRottenApples), useApplesOnPress);
 		takeAppleToElena.addStep(new Conditions(receivedSieve, emptyBarrel), useBarrelOnPile);
 		takeAppleToElena.addStep(receivedSieve, pickUpBarrel);
 		takeAppleToElena.addStep(givenRottenApple, talkToElenaNoApple);


### PR DESCRIPTION
Accidentally forgot to make a new branch since it's just a very minor fix so I'm making a pull request from main.

The Requirement `barrelOfRottenApples` was already there, it was just not used in the right spot. This way, you are not asked to endlessly fill barrels with rotten apples and quest helper knows when you got the filled barrel in your inventory to use on the press.