### PR TITLE
Bump quest point requirement for lumbridge elites=

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -121,7 +121,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		notQCEmote = new VarplayerRequirement(1195, false, 9);
 
 		// todo find better way to check for all quests completed
-		allQuests = new QuestPointRequirement(289, Operation.EQUAL);
+		allQuests = new QuestPointRequirement(290, Operation.EQUAL);
 
 		lockpick = new ItemRequirement("Lockpick", ItemID.LOCKPICK).showConditioned(notRichChest);
 		crossbow = new ItemRequirement("Crossbow", ItemCollections.getCrossbows()).showConditioned(notMovario);


### PR DESCRIPTION
With the release of sleeping giants, the requirement for quest cape is now 290 instead of 289