### PR TITLE
Update Enter the Abyss to align with new quest version

### DIFF
--- a/src/main/java/com/questhelper/quests/entertheabyss/EnterTheAbyss.java
+++ b/src/main/java/com/questhelper/quests/entertheabyss/EnterTheAbyss.java
@@ -134,23 +134,25 @@ public class EnterTheAbyss extends BasicQuestHelper
 
 		talkToMageInVarrock = new NpcStep(this, NpcID.MAGE_OF_ZAMORAK_2582, new WorldPoint(3259, 3383, 0),
 			"Talk to the Mage of Zamorak in south east Varrock.");
-		talkToMageInVarrock.addDialogSteps("Where do you get your runes from?", "Yes");
+		talkToMageInVarrock.addDialogSteps("Where do you get your runes from?", "Maybe I could make it worth your while?", "Yes, but I can still help you as well.",
+			"I did it so that I could then steal their secrets.", "Deal.",
+			"But I'm a loyal servant of Zamorak as well!", "Okay, fine. I don't really serve Zamorak.", "Because I can still help you.");
 
-		talkToAubury = new NpcStep(this, NpcID.AUBURY, new WorldPoint(3253, 3401, 0),
+		talkToAubury = new NpcStep(this, NpcID.AUBURY_11435, new WorldPoint(3253, 3401, 0),
 			"Teleport to the essence mine with Aubury in south east Varrock.", scryingOrb);
-		talkToAubury.addDialogStep("Can you teleport me to the Rune Essence?");
+		talkToAubury.addDialogStep("Can you teleport me to the Rune Essence Mine?");
 
 		goDownInWizardsTower = new ObjectStep(this, ObjectID.LADDER_2147, new WorldPoint(3104, 3162, 0),
 			"Teleport to the essence mine with Sedridor in the Wizard Tower's basement.", scryingOrb);
 		goDownInWizardsTower.addDialogStep("Wizard's Tower");
 		talkToSedridor = new NpcStep(this, NpcID.ARCHMAGE_SEDRIDOR, new WorldPoint(3104, 9571, 0),
 			"Teleport to the essence mine with Sedridor in the Wizard Tower's basement.", scryingOrb);
-		talkToSedridor.addDialogStep("Can you teleport me to the Rune Essence?");
+		talkToSedridor.addDialogStep("Can you teleport me to the Rune Essence Mine?");
 		talkToSedridor.addSubSteps(goDownInWizardsTower);
 
 		talkToCromperty = new NpcStep(this, NpcID.WIZARD_CROMPERTY, new WorldPoint(2684, 3323, 0),
 			"Teleport to the essence mine with Wizard Cromperty in East Ardougne.", scryingOrb);
-		talkToCromperty.addDialogStep("Can you teleport me to the Rune Essence?");
+		talkToCromperty.addDialogStep("Can you teleport me to the Rune Essence Mine?");
 
 		talkToMageAfterTeleports = new NpcStep(this, NpcID.MAGE_OF_ZAMORAK_2582, new WorldPoint(3259, 3383, 0),
 			"Talk to the Mage of Zamorak in south east Varrock.", scryingOrbCharged);


### PR DESCRIPTION
As with #834, the Enter the Abyss miniquest dialogue was changed with the 23/03/2022 Guardians of the Rift update.

This PR fixes some broken dialogue highlighting, as well as updating the talkToAubury step to correctly highlight Aubury.

Regarding the talkToMageInVarrock dialogue steps, all possible dialogue options that will eventually lead the player to progressing the quest to the next step are highlighted. If you would prefer the shortest route to progress the step to be highlighted, then the dialogue steps in lines 138 and 139 can just be deleted.