### PR TITLE
Add missing Falador Medium diary item requirements for Scarecrow

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorMedium.java
@@ -340,8 +340,8 @@ public class FaladorMedium extends ComplexStateQuestHelper
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return Arrays.asList(bullseyeLantern, tinderbox, airRune4, airRune3, airRune1, lawRune2, lawRune1, waterRune1,
-			crystalKey, rake, fishingExplosive, mithGrapple, anyCrossbow, initiateHelm, initiateChest, initiateLegs,
-			pickaxe, axe, brownApron, willowBranch6);
+			crystalKey, emptySack, bronzeSpear, watermelon, rake, fishingExplosive, mithGrapple, anyCrossbow, initiateHelm,
+			initiateChest, initiateLegs, pickaxe, axe, brownApron, willowBranch6);
 	}
 
 	@Override


### PR DESCRIPTION
Items required to build a Scarecrow for the step labelled "Brain not included" added to the helper's item requirements.

Item requirements were listed on the step's specific panel, but not the overall diary's item requirements.

Would resolve #829 