### PR TITLE
SeaSlug -note added mentioning Ardougne Task

### DIFF
--- a/src/main/java/com/questhelper/quests/seaslug/SeaSlug.java
+++ b/src/main/java/com/questhelper/quests/seaslug/SeaSlug.java
@@ -261,4 +261,10 @@ public class SeaSlug extends BasicQuestHelper
 
 		return allSteps;
 	}
+
+	@Override
+	public List<String> getNotes()
+	{
+		return Collections.singletonList("You can complete an Ardougne Medium Diary task by fishing from the fishing platform using a fishing rod or small fishing net (these can be bought from the fishing shop near quest start in Witchaven).");
+	}
 }


### PR DESCRIPTION
Note added which states that an Ardougne Medium task can be completed during the quest. This note is mentioned in the wiki but not in the Quest Helper. 
Brought to attention by a user in the Discord.