### PR TITLE
HauntedMine -food added to rec items

### DIFF
--- a/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
+++ b/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
@@ -378,6 +378,11 @@ public class HauntedMine extends BasicQuestHelper
 		return reqs;
 	}
 
+	@Override
+	public List<ItemRequirement> getItemRecommended()
+	{
+		return QuestUtil.toArrayList(food);
+	}
 
 	@Override
 	public List<String> getCombatRequirements()


### PR DESCRIPTION
Food added to recommended items. Food is currently not mentioned in either of the req items or rec items, this fix better reflects the wiki guide and lets the user know, before starting the quest, that food is recommended. Requested by a Discord user.