### PR TITLE
Added Smiths Gloves(i) as alt to Ice Gloves

### DIFF
--- a/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
@@ -149,7 +149,7 @@ public class ClockTower extends BasicQuestHelper
 
 	public void setupItemRequirements()
 	{
-		bucketOfWater = new ItemRequirement("Bucket of Water or a pair of ice gloves or smith gloves(i)", ItemID.BUCKET_OF_WATER);
+		bucketOfWater = new ItemRequirement("Bucket of Water or a pair of ice gloves or smiths gloves(i)", ItemID.BUCKET_OF_WATER);
 		bucketOfWater.addAlternates(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
 		bucketOfWater.setTooltip("There is a bucket spawn next to the well east of the Clocktower. You can fill it on" +
 			" the well");

--- a/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
@@ -149,8 +149,8 @@ public class ClockTower extends BasicQuestHelper
 
 	public void setupItemRequirements()
 	{
-		bucketOfWater = new ItemRequirement("Bucket of Water or a pair of ice gloves", ItemID.BUCKET_OF_WATER);
-		bucketOfWater.addAlternates(ItemID.ICE_GLOVES);
+		bucketOfWater = new ItemRequirement("Bucket of Water or a pair of ice gloves or smith gloves(i)", ItemID.BUCKET_OF_WATER);
+		bucketOfWater.addAlternates(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
 		bucketOfWater.setTooltip("There is a bucket spawn next to the well east of the Clocktower. You can fill it on" +
 			" the well");
 		noteAboutWater = new ItemRequirement("There's a bucket and a well and just next to brother cedric for the black cog", -1, -1);
@@ -241,7 +241,7 @@ public class ClockTower extends BasicQuestHelper
 		blueCogOnBlueSpindle.addIcon(ItemID.BLUE_COG);
 
 		pickupBlackCog = new DetailedQuestStep(this, new WorldPoint(2613, 9639, 0), "Enter the north east door, and " +
-			"pick up the black cog with either a bucket of water or ice gloves equipped.", bucketOfWater, blackCog);
+			"pick up the black cog with a bucket of water, alternatively you can equip ice gloves or smith gloves(i).", bucketOfWater, blackCog);
 		blackCogOnBlackSpindle = new ObjectStep(this, ObjectID.CLOCK_SPINDLE_30, new WorldPoint(2570, 9642, 0),
 			"", blackCog.highlighted());
 		blackCogOnBlackSpindle.addIcon(ItemID.BLACK_COG);

--- a/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
+++ b/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
@@ -264,7 +264,7 @@ public class DesertTreasure extends BasicQuestHelper
 		bloodDiamondHighlighted = new ItemRequirement("Blood diamond", ItemID.BLOOD_DIAMOND);
 		bloodDiamondHighlighted.setTooltip("You can get another from Malak in Canifis");
 
-		iceGloves = new ItemRequirement("Ice gloves or smith gloves(i)", ItemID.ICE_GLOVES, 1, true);
+		iceGloves = new ItemRequirement("Ice gloves or smiths gloves(i)", ItemID.ICE_GLOVES, 1, true);
 		iceGloves.setTooltip("You can kill the Ice Queen under White Wolf Mountain for ice gloves");
 		iceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
 

--- a/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
+++ b/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
@@ -264,8 +264,9 @@ public class DesertTreasure extends BasicQuestHelper
 		bloodDiamondHighlighted = new ItemRequirement("Blood diamond", ItemID.BLOOD_DIAMOND);
 		bloodDiamondHighlighted.setTooltip("You can get another from Malak in Canifis");
 
-		iceGloves = new ItemRequirement("Ice gloves", ItemID.ICE_GLOVES, 1, true);
-		iceGloves.setTooltip("You can kill the Ice Queen under White Wolf Mountain for these");
+		iceGloves = new ItemRequirement("Ice gloves or smith gloves(i)", ItemID.ICE_GLOVES, 1, true);
+		iceGloves.setTooltip("You can kill the Ice Queen under White Wolf Mountain for ice gloves");
+		iceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
 
 		waterSpellOrMelee = new ItemRequirement("Water spells or melee gear", -1, -1);
 		waterSpellOrMelee.setDisplayItemId(ItemID.WATER_RUNE);

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
@@ -129,8 +129,8 @@ public class RFDDwarf extends BasicQuestHelper
 		bowlOfWater.setTooltip("You can find a bowl in Lumbridge Castle's Basement and fill it in the nearby sink");
 		asgarniaAle4 = new ItemRequirement("Asgarnian ale", ItemID.ASGARNIAN_ALE, 4);
 		asgarniaAle4.setTooltip("You can buy them for 3 coins each from Kaylee during the quest");
-		iceGloves = new ItemRequirement("Ice gloves/normal gloves/telekinetic grab", ItemID.ICE_GLOVES);
-		iceGloves.addAlternates(ItemID.LEATHER_GLOVES);
+		iceGloves = new ItemRequirement("Ice gloves/smiths gloves(i)/normal gloves/telekinetic grab", ItemID.ICE_GLOVES);
+		iceGloves.addAlternates(ItemID.LEATHER_GLOVES, ItemID.SMITHS_GLOVES_I);
 		iceGloves.setTooltip("You can use normal gloves/telekenetic grab instead, but you'll then need to kill an Ice " +
 			"Fiend");
 		rockCake = new ItemRequirement("Dwarven rock cake", ItemID.DWARVEN_ROCK_CAKE_7510);

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
@@ -105,7 +105,8 @@ public class RFDFinal extends BasicQuestHelper
 
 	public void setupRequirements()
 	{
-		iceGloves = new ItemRequirement("Ice gloves", ItemID.ICE_GLOVES);
+		iceGloves = new ItemRequirement("Ice gloves or smiths gloves(i)", ItemID.ICE_GLOVES);
+		iceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
 		restorePotions = new ItemRequirement("Restore potions for Karamel", ItemCollections.getRestorePotions());
 		combatGear = new ItemRequirement("Combat gear, food and potions", -1, -1);
 		combatGear.setDisplayItemId(BankSlotIcons.getCombatGear());

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
@@ -172,7 +172,8 @@ public class RFDSirAmikVarze extends BasicQuestHelper
 		pestleAndMortarHighlighted = new ItemRequirement("Pestle and mortar", ItemID.PESTLE_AND_MORTAR);
 		pestleAndMortarHighlighted.setHighlightInInventory(true);
 
-		iceGloves = new ItemRequirement("Ice gloves", ItemID.ICE_GLOVES, 1, true);
+		iceGloves = new ItemRequirement("Ice gloves or smiths gloves(i)", ItemID.ICE_GLOVES, 1, true);
+		iceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
 		iceGloves.setTooltip("Although optional, you'll take a lot of damage if you're not wearing them");
 		rawChicken = new ItemRequirement("Raw chicken", ItemID.RAW_CHICKEN);
 		rawChicken.setHighlightInInventory(true);

--- a/src/main/java/com/questhelper/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikexiles/TheFremennikExiles.java
@@ -238,8 +238,9 @@ public class TheFremennikExiles extends BasicQuestHelper
 		fishingOrFlyFishingRod.addAlternates(ItemID.FLY_FISHING_ROD);
 		fremennikShield = new ItemRequirement("Fremennik shield", ItemID.FREMENNIK_SHIELD);
 		fremennikShield.setTooltip("Obtainable during the quest for 150k, or free with a Ring of Charos(a)");
-		iceGloves = new ItemRequirement("Ice gloves", ItemID.ICE_GLOVES);
-		iceGloves.setTooltip("You can get another pair by killing the Ice Queen under White Wolf Mountain");
+		iceGloves = new ItemRequirement("Ice gloves or smiths gloves(i)", ItemID.ICE_GLOVES);
+		iceGloves.setTooltip("You can get another pair of ice gloves by killing the Ice Queen under White Wolf Mountain");
+		iceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
 		hammer = new ItemRequirement("Hammer", ItemCollections.getHammer());
 		glassblowingPipe = new ItemRequirement("Glassblowing pipe", ItemID.GLASSBLOWING_PIPE);
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.getPickaxes());


### PR DESCRIPTION
Various quests have an Ice Gloves requirement, this fix adds Smiths Gloves(i) as an alternate to Ice gloves. 

This alternate item added to these quests:
-Fremennik Exiles
-Clock Tower
-Desert Treasure
-RFD: Sir Amik Varze
-RFD: Dwarf
-RFD: Final

fixes #863  and beyond