### PR TITLE
DesertDiary -fix charges reward

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertEasy.java
@@ -269,7 +269,7 @@ public class DesertEasy extends ComplexStateQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-			new UnlockReward("Pharaoh's sceptre can hold up to 4 charges"),
+			new UnlockReward("Pharaoh's sceptre can hold up to 10 charges"),
 			new UnlockReward("Goats will always drop noted desert goat horn"),
 			new UnlockReward("Simon Templeton will now buy your noted artefacts too")
 		);

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertElite.java
@@ -244,7 +244,7 @@ public class DesertElite extends ComplexStateQuestHelper
 				"directly inside the Elidinis" +
 				" shrine"),
 			new UnlockReward("100% protection against desert heat when the desert amulet is worn"),
-			new UnlockReward("Pharaoh's sceptre can hold up to 8 charges"),
+			new UnlockReward("Pharaoh's sceptre can hold up to 100 charges"),
 			new UnlockReward("Free pass-through of the Shantay Pass"),
 			new UnlockReward("Access to a crevice shortcut, requiring 86 Agility, " +
 				"in the Kalphite Lair from the entrance to the antechamber before the " +

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertHard.java
@@ -294,7 +294,7 @@ public class DesertHard extends ComplexStateQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-			new UnlockReward("Pharaoh's sceptre can hold up to 6 charges"),
+			new UnlockReward("Pharaoh's sceptre can hold up to 50 charges"),
 			new UnlockReward("Access to the big window shortcut in Al Kharid Palace that takes you to the south of the palace, " +
 				"just north of the Shantay Pass, requiring 70 Agility"),
 			new UnlockReward("Unlocked the ability to toggle the Camulet teleport location between the inside and outside of Enakhra's Temple"),

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertMedium.java
@@ -297,7 +297,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-			new UnlockReward("Pharaoh's sceptre can hold up to 5 charges"),
+			new UnlockReward("Pharaoh's sceptre can hold up to 25 charges"),
 			new UnlockReward("One teleport to Nardah per day on desert amulet")
 		);
 	}


### PR DESCRIPTION
Pharaoh's Sceptre charge rewards needed updated as they did not correctly reflect the number of charges awarded after completing each diary. This is due to an update in late April 2022 which increased the number of max charges awarded for completing the diary. The fix reflects the updated rewarded charges.