### PR TITLE
MountainDaughter -pole/staff clarity

### DIFF
--- a/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
+++ b/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
@@ -187,7 +187,7 @@ public class InSearchOfKnowledge extends BasicQuestHelper
 			protectFromMagic);
 
 		searchBookcasesForSun = new ObjectStep(this, ObjectID.MUSTY_BOOKSHELF, new WorldPoint(1805, 9935, 0),
-			"Search  the musty bookshelves to the west of Aimeri for the tomes of moon, sun, and temple.",
+			"Search the musty bookshelves to the west of Aimeri for the tomes of moon, sun, and temple.",
 			protectFromMagic);
 
 		searchBookcasesForMoon = new ObjectStep(this, ObjectID.MUSTY_BOOKSHELF_34848, new WorldPoint(1804, 9943, 0),

--- a/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
+++ b/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
@@ -184,7 +184,11 @@ public class MountainDaughter extends BasicQuestHelper
 		plank = new ItemRequirement("Any plank", ItemID.PLANK);
 		plank.addAlternates(ItemID.OAK_PLANK, ItemID.TEAK_PLANK, ItemID.MAHOGANY_PLANK);
 		pole = new ItemRequirement("A staff or a pole", ItemID.POLE);
-		pole.addAlternates(ItemID.LUNAR_STAFF, ItemID.STAFF, ItemID.STAFF_OF_AIR, ItemID.STAFF_OF_EARTH, ItemID.STAFF_OF_FIRE, ItemID.STAFF_OF_WATER);
+		pole.addAlternates(ItemID.LUNAR_STAFF, ItemID.STAFF, ItemID.BATTLESTAFF);
+		pole.addAlternates(ItemCollections.getAirStaff());
+		pole.addAlternates(ItemCollections.getWaterStaff());
+		pole.addAlternates(ItemCollections.getEarthStaff());
+		pole.addAlternates(ItemCollections.getFireStaff());
 		pole.setTooltip("A Dramen Staff will NOT work. A pole can be obtained from the goat pen north of Hamal's house.");
 		gloves = new ItemRequirement("Almost any gloves", ItemID.LEATHER_GLOVES);
 		gloves.addAlternates(ItemID.BARROWS_GLOVES, ItemID.DRAGON_GLOVES, ItemID.RUNE_GLOVES, ItemID.ADAMANT_GLOVES, ItemID.MITHRIL_GLOVES,

--- a/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
+++ b/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
@@ -184,8 +184,8 @@ public class MountainDaughter extends BasicQuestHelper
 		plank = new ItemRequirement("Any plank", ItemID.PLANK);
 		plank.addAlternates(ItemID.OAK_PLANK, ItemID.TEAK_PLANK, ItemID.MAHOGANY_PLANK);
 		pole = new ItemRequirement("A staff or a pole", ItemID.POLE);
-		pole.addAlternates(ItemID.LUNAR_STAFF);
-		pole.setTooltip("You can find one in the north part of the Mountain Camp.");
+		pole.addAlternates(ItemID.LUNAR_STAFF, ItemID.STAFF, ItemID.STAFF_OF_AIR, ItemID.STAFF_OF_EARTH, ItemID.STAFF_OF_FIRE, ItemID.STAFF_OF_WATER);
+		pole.setTooltip("A Dramen Staff will NOT work. A pole can be obtained from the goat pen north of Hamal's house.");
 		gloves = new ItemRequirement("Almost any gloves", ItemID.LEATHER_GLOVES);
 		gloves.addAlternates(ItemID.BARROWS_GLOVES, ItemID.DRAGON_GLOVES, ItemID.RUNE_GLOVES, ItemID.ADAMANT_GLOVES, ItemID.MITHRIL_GLOVES,
 			ItemID.BLACK_GLOVES, ItemID.STEEL_GLOVES, ItemID.IRON_GLOVES, ItemID.BRONZE_GLOVES, ItemID.HARDLEATHER_GLOVES,
@@ -256,7 +256,7 @@ public class MountainDaughter extends BasicQuestHelper
 		talkToHamal.addDialogStep("I will search for her!");
 
 		digUpMud = new ObjectStep(this, ObjectID.ROOTS_5885, new WorldPoint(2805, 3661, 0),
-			"Dig some mud from the mud pond south of Hamal's house.");
+			"If you did not bring a staff grab a pole from the goat pen north of Hamal's house. Head south of Hamal's house and dig some mud from the mud pond.");
 
 		rubMudIntoTree = new ObjectStep(this, ObjectID.TALL_TREE, new WorldPoint(2772, 3681, 0),
 			"Use mud on the Tall Tree on the lake north of the camp, and then climb it.",
@@ -394,6 +394,7 @@ public class MountainDaughter extends BasicQuestHelper
 		reqs.add(axe);
 		reqs.add(plank);
 		reqs.add(gloves);
+		reqs.add(pole);
 		return reqs;
 	}
 


### PR DESCRIPTION
Fix makes the staff/pole requirement visible. Tool-tip for staff/pole has been expanded upon. Lastly, information on obtaining the pole has been included in the steps. This has been requested numerous times on the Discord.

Also removed an extra space typo from a quest.