### PR TITLE
Ratcatchers -poison changes

### DIFF
--- a/src/main/java/com/questhelper/quests/ratcatchers/RatCatchers.java
+++ b/src/main/java/com/questhelper/quests/ratcatchers/RatCatchers.java
@@ -64,7 +64,7 @@ public class RatCatchers extends BasicQuestHelper
 {
 	// Required
 	ItemRequirement ratPoison, cheese, marrentill, unicornHornDust, bucketOfMilk, catspeakAmuletOrDS2,
-		potOfWeeds, tinderbox, coins101, snakeCharm, fish8, cat, coin;
+		potOfWeeds, tinderbox, coins101, snakeCharm, fish8, cat, coin, kwuarm, vial, redEggs;
 
 	Requirement catFollower;
 
@@ -214,7 +214,7 @@ public class RatCatchers extends BasicQuestHelper
 
 		catFollower = new FollowerRequirement("A non-overgrown cat following you", NpcCollections.getHuntingCats());
 		ratPoison = new ItemRequirement("Rat poison", ItemID.RAT_POISON);
-		ratPoison.setTooltip("You can get some from under the Clocktower south of Ardougne");
+		ratPoison.canBeObtainedDuringQuest();
 		cheese = new ItemRequirement("Cheese", ItemID.CHEESE);
 		cheese.addAlternates(ItemID.POISONED_CHEESE);
 		marrentill = new ItemRequirement("Marrentill", ItemID.MARRENTILL);
@@ -228,6 +228,9 @@ public class RatCatchers extends BasicQuestHelper
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX);
 		coins101 = new ItemRequirement("Coins", ItemCollections.getCoins(), 101);
 		coin = new ItemRequirement("Coins", ItemCollections.getCoins());
+		kwuarm = new ItemRequirement("Clean kwuarm", ItemID.KWUARM);
+		redEggs = new ItemRequirement("Red spiders' eggs", ItemID.RED_SPIDERS_EGGS);
+		vial = new ItemRequirement("Empty vial", ItemID.VIAL);
 		snakeCharm = new ItemRequirement("Snake charm", ItemID.SNAKE_CHARM);
 		snakeCharm.canBeObtainedDuringQuest();
 		fish8 = new ItemRequirement("Fish or more, raw or cooked", ItemCollections.getFishFood(), 8);
@@ -368,7 +371,8 @@ public class RatCatchers extends BasicQuestHelper
 			"Talk to Jimmy Dazzler again.", cat);
 
 		talkToJack = new NpcStep(this, NpcID.HOOKNOSED_JACK, new WorldPoint(3268, 3401, 0),
-			"Talk to Hooknosed Jack in south east Varrock.", cat);
+			"Talk to Hooknosed Jack in south east Varrock.  You can give Jack your vial, kwuarm, and red spiders' eggs" + 
+			" for the rat poison", cat, kwuarm, vial, redEggs);
 		climbJackLadder = new ObjectStep(this, ObjectID.LADDER_11794, new WorldPoint(3268, 3379, 0),
 			"Climb up the ladder south of Jack.", cheese.quantity(4), ratPoison);
 		useRatPoisonOnCheese = new DetailedQuestStep(this, "Add rat poison to your cheese.",
@@ -462,15 +466,15 @@ public class RatCatchers extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(cat, ratPoison, cheese.quantity(4), marrentill, unicornHornDust, bucketOfMilk,
-			catspeakAmuletOrDS2,
+		return Arrays.asList(cat, cheese.quantity(4), marrentill, unicornHornDust, bucketOfMilk,
+			catspeakAmuletOrDS2, vial, kwuarm, redEggs,
 			potOfWeeds, tinderbox, coins101, snakeCharm, fish8);
 	}
 
 	@Override
 	public List<ItemRequirement> getItemRecommended()
 	{
-		return Arrays.asList(varrockTeleport, sarimTeleport, pollnivneachTeleport, ardougneTeleport, keldagrimTeleport,
+		return Arrays.asList(ratPoison, varrockTeleport, sarimTeleport, pollnivneachTeleport, ardougneTeleport, keldagrimTeleport,
 			carpetCoins);
 	}
 
@@ -509,6 +513,13 @@ public class RatCatchers extends BasicQuestHelper
 				new UnlockReward("Access to the Rat Pits"),
 				new UnlockReward("Ability to train Overgrown Cats into Wiley and Lazy Cats"));
 	}
+	
+	@Override
+	public List<String> getNotes()
+	{
+		return Collections.singletonList("Alternatively, rat poison could be obtained in the basement of the Clocktower south of East" +
+				" Ardougne. If you already have the rat poison it follows that you would not need the vial, red spiders' eggs, or kwuarm.");
+	}
 
 	@Override
 	public List<PanelDetails> getPanels()
@@ -521,7 +532,7 @@ public class RatCatchers extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Helping Jack",
 			Arrays.asList(talkToJack, useRatPoisonOnCheese, climbJackLadder, useCheeseOnHole1, talkToJackAfterCheese,
 				talkToApoth, talkToJackAfterApoth, climbJackLadderAgain, useCatOnHole, feedCatAsItFights, talkToJackAfterFight),
-			cheese.quantity(4), ratPoison, bucketOfMilk, marrentill, unicornHornDust, cat, fish8));
+			cheese.quantity(4), bucketOfMilk, marrentill, unicornHornDust, cat, fish8, vial, kwuarm, redEggs, ratPoison)));
 		allSteps.add(new PanelDetails("Helping Joe", Arrays.asList(travelToKeldagrim, talkToSmokinJoe, usePotOnHole,
 			usePotOnHoleAgain, talkToJoeAgain), cat, catspeakAmuletOrDS2, potOfWeeds, tinderbox));
 


### PR DESCRIPTION
1. Adds 'kwuarm' , 'vial', 'red spiders' eggs' to required items 
   -giving these items to Jack gives you the rat poison, this may be more convenient to the player and less confusing
   -the current version would have someone running back to the Clocktower if they didn't have the poison without mentioning the much simpler alternate
    
2. Moves 'rat poison' to recommended item
    -tooltip states that the item can be obtained during the quest
    
3. Note added that tells you where rat poison could be obtained
    -the note informs the user that they could retrieve the rat poison before the quest if they so choose
    -tells the user that if they wish to do this the kwuarm, vial, and eggs will not be necessary
 
4. Added text to the step where you talk with Jack, telling the user to obtain the poison by giving the kwuarm, vial, and eggs to Jack
    -the steps themselves are not messed with, there is just a change to the items needed while expanding the text of the step
    
This provides more information to the player and clarifies the process. If this could be more concise or if there is a different method that should be used please let me know.