### PR TITLE
Biohazard - order correction

### DIFF
--- a/src/main/java/com/questhelper/quests/biohazard/Biohazard.java
+++ b/src/main/java/com/questhelper/quests/biohazard/Biohazard.java
@@ -344,7 +344,7 @@ public class Biohazard extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Getting back into West Ardougne",
 			Arrays.asList(talkToJerico, getBirdFeed, getPigeonCage, investigateWatchtower, clickPigeonCage, talkToOmartAgain)));
 		allSteps.add(new PanelDetails("Getting the Distillator",
-			pickupRottenApple, enterBackyardOfHeadquarters,  useRottenAppleOnCauldron, searchSarahsCupboard,
+			enterBackyardOfHeadquarters, pickupRottenApple, useRottenAppleOnCauldron, searchSarahsCupboard,
 			enterMournerHeadquarters, goUpstairsInMournerBuilding, searchCrateForDistillator, talkToElenaWithDistillator));
 
 		List<QuestStep> testingSteps = QuestUtil.toArrayList(talkToTheChemist);


### PR DESCRIPTION
'pickupRottenApple' should occur after 'enterBackyardOfHeadquarters'. Change reflects this.

fixes #895