### PR TITLE
DS2: Add period to end of sentence instructing what to pray against Robert the Strong

### DIFF
--- a/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
@@ -804,7 +804,7 @@ public class DragonSlayerII extends BasicQuestHelper
 		talkToBobInDream = new NpcStep(this, NpcID.BOB_8112, new WorldPoint(1824, 5209, 2), "Talk to Bob in the dream.");
 		talkToBobInDream.addSubSteps(talkToBobToEnterDreamAgain);
 		killRobertTheStrong = new NpcStep(this, NpcID.ROBERT_THE_STRONG_8057, new WorldPoint(1824, 5224, 2), "When you're ready, fight Robert.");
-		killRobertTheStrong.addText("Use Protect from Missiles");
+		killRobertTheStrong.addText("Use Protect from Missiles.");
 		killRobertTheStrong.addText("When he shouts 'See if you can hide from this!', hide behind a pillar.");
 
 		talkToBobAfterRobertFight = new NpcStep(this, NpcID.BOB_8111, new WorldPoint(2074, 3912, 0), "Talk to Bob next to the brazier.");


### PR DESCRIPTION
This fixes a tiny typo where it appears the quest instructs you to *pray missiles when he shouts.*, as opposed to always praying missiles during the whole fight like I think it meant.

Example:

![image](https://user-images.githubusercontent.com/9123458/183795804-d9287557-8c0f-4ca4-8978-766b6bd25891.png)

