### PR TITLE
EnemiesToDefeat -> To wiki..

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/ardougne/ArdougneElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/ardougne/ArdougneElite.java
@@ -43,11 +43,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,7 +59,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.ARDOUGNE_ELITE
@@ -325,9 +321,12 @@ public class ArdougneElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Nightmare Zone monsters (levels vary)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		CombatStep nmz = new CombatStep(this, -1, "Nightmare Zone monster (levels vary)");
+		reqs.add(nmz);
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/ardougne/ArdougneMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/ardougne/ArdougneMedium.java
@@ -45,11 +45,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -64,7 +61,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.vars.AccountType;
 import net.runelite.client.game.FishingSpot;
 
@@ -350,9 +346,12 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Swordchick (lvl 46)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add( new CombatStep(this, NpcID.SWORDCHICK, "Swordchick (lvl 46)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertEasy.java
@@ -38,10 +38,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,7 +52,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.DESERT_EASY
@@ -216,8 +213,8 @@ public class DesertEasy extends ComplexStateQuestHelper
 			"Have Zahur in Nardah clean a grimy herb for you.", grimyHerb, coins.quantity(200));
 		nardahHerb.addDialogStep("Please clean all my herbs.");
 
-		killVulture = new NpcStep(this, NpcID.VULTURE, new WorldPoint(3334, 2865, 0),
-			"Kill a vulture.", true);
+		killVulture = new CombatStep(this, NpcID.VULTURE, new WorldPoint(3334, 2865, 0),
+			"Kill a vulture.","Kill a Vulture (lvl 31)", true);
 		killVulture.addAlternateNpcs(NpcID.VULTURE_1268);
 
 		moveToPyramidPlunder = new ObjectStep(this, 26622, new WorldPoint(3289, 2800, 0),
@@ -276,9 +273,12 @@ public class DesertEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill a Vulture (lvl 31), tank hits from Kalphite Soldier (lvl 85)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killVulture);
+		reqs.add(new CombatStep(this, ItemID.KALPHITE_SOLDIER, "tank hits from Kalphite Soldier (lvl 85)"));
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertHard.java
@@ -38,11 +38,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,7 +53,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.DESERT_HARD
@@ -227,8 +223,8 @@ public class DesertHard extends ComplexStateQuestHelper
 
 		moveToSmoke = new ObjectStep(this, ObjectID.SMOKEY_WELL, new WorldPoint(3310, 2962, 0),
 			"Go down the Smokey well.");
-		killDust = new NpcStep(this, NpcID.DUST_DEVIL, new WorldPoint(3219, 9370, 0),
-			"Kill a Dust devil with a slayer helm equipped.", slayerHelm.equipped());
+		killDust = new CombatStep(this, NpcID.DUST_DEVIL, new WorldPoint(3219, 9370, 0),
+			"Kill a Dust devil with a slayer helm equipped.", "Kill a Dust devil (lvl 93)", slayerHelm.equipped());
 
 		moveToPyramid = new ObjectStep(this, ObjectID.TUNNEL_6481, new WorldPoint(3233, 2889, 0),
 			"Enter the Jaldraocht Pyramid.");
@@ -250,8 +246,8 @@ public class DesertHard extends ComplexStateQuestHelper
 			"Climb down the ladder to enter the Sophanem Dungeon.", combatGear, lightsource);
 		moveToSoph2 = new ObjectStep(this, ObjectID.LADDER_20278, new WorldPoint(2800, 5159, 0),
 			"Climb down the ladder again.", combatGear, lightsource);
-		killLocustRider = new NpcStep(this, NpcID.LOCUST_RIDER_796, new WorldPoint(3296, 9267, 2),
-			"Kill a Scarab mage or Locust rider with keris.", true, combatGear, keris.equipped());
+		killLocustRider = new CombatStep(this, NpcID.LOCUST_RIDER_796, new WorldPoint(3296, 9267, 2),
+			"Kill a Scarab mage or Locust rider with keris.", "Locust rider (lvl 98)", true, combatGear, keris.equipped());
 		killLocustRider.addAlternateNpcs(NpcID.SCARAB_MAGE, NpcID.SCARAB_MAGE_799, NpcID.LOCUST_RIDER,
 			NpcID.LOCUST_RIDER_800, NpcID.LOCUST_RIDER_801);
 
@@ -297,9 +293,14 @@ public class DesertHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill a Dust devil (lvl 93), Locust rider (lvl 98), Kalphite Queen (lvl 333)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDust);
+		reqs.add(killLocustRider);
+		reqs.add(new CombatStep(this, NpcID.KALPHITE_QUEEN, "Kalphite Queen (lvl 333)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/desert/DesertMedium.java
@@ -40,12 +40,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +55,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.DESERT_MEDIUM
@@ -237,8 +232,8 @@ public class DesertMedium extends ComplexStateQuestHelper
 		chopTeak = new ObjectStep(this, ObjectID.TEAK, new WorldPoint(3510, 3073, 0),
 			"Chop some teak logs near Uzer.", axe);
 
-		desertLizard = new NpcStep(this, NpcID.SMALL_LIZARD, new WorldPoint(3437, 3067, 0),
-			"Use an Ice cooler on a low hp Lizard in the desert.", iceCooler, combatGear);
+		desertLizard = new CombatStep(this, NpcID.SMALL_LIZARD, new WorldPoint(3437, 3067, 0),
+			"Use an Ice cooler on a low hp Lizard in the desert.", "Kill a Desert lizard (lvl 24)", iceCooler, combatGear);
 
 		prayElidinis = new ObjectStep(this, ObjectID.ELIDINIS_STATUETTE, new WorldPoint(3427, 2930, 0),
 			"Pray at the Elidinis Statuette in Nardah. If it doesn't complete expend some prayer points then try again.");
@@ -306,9 +301,12 @@ public class DesertMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill a Desert lizard (lvl 24)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(desertLizard);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorElite.java
@@ -223,12 +223,12 @@ public class FaladorElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Giant Mole (level 230)");
-		reqs.add("Skeletal Wyvern (level 140)");
-		reqs.add("Blue dragon (level 140)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.GIANT_MOLE, "Giant Mole (level 230)"));
+		reqs.add(new CombatStep(this, NpcID.SKELETAL_WYVERN, "Skeletal Wyvern (level 140)"));
+		reqs.add(new CombatStep(this, NpcID.BLUE_DRAGON, "Blue dragon (level 140)"));
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/falador/FaladorHard.java
@@ -244,16 +244,16 @@ public class FaladorHard extends ComplexStateQuestHelper
 		//Giant Mole
 		goToGiantMole = new ObjectStep(this, ObjectID.MOLE_HILL, new WorldPoint(2989, 3378, 0),
 			"Use a spade on one of the Mole Hills in Falador Park", combatGear, food, lightSource, spade);
-		killGiantMole = new NpcStep(this, NpcID.GIANT_MOLE,
-			"Kill the Giant Mole.", combatGear, food, lightSource);
+		killGiantMole = new CombatStep(this, NpcID.GIANT_MOLE,
+			"Kill the Giant Mole.", "Giant Mole (level 230)", combatGear, food, lightSource);
 
 		//Wyvern
 		goToIceDungeon = new ObjectStep(this, ObjectID.TRAPDOOR_1738, new WorldPoint(3008, 3150, 0),
 			"Go down the ladder south of Port Sarim.", combatGear, food, wyvernProtection);
 		enterWyvernCavern = new ObjectStep(this, ObjectID.ICY_CAVERN_10596, new WorldPoint(3055, 9560, 0),
 			"Enter the Icy Cavern at the back of the dungeon.", combatGear, food, wyvernProtection);
-		killWyvern = new NpcStep(this, NpcID.SKELETAL_WYVERN,
-			"Kill a Skeletal Wyvern.", combatGear, food, wyvernProtection);
+		killWyvern = new CombatStep(this, NpcID.SKELETAL_WYVERN,
+			"Kill a Skeletal Wyvern.", "Skeletal Wyvern (level 140)", combatGear, food, wyvernProtection);
 
 		//Agi Course
 		completeAgiCourse = new ObjectStep(this, ObjectID.ROUGH_WALL_14898, new WorldPoint(3036, 3341, 0),
@@ -270,8 +270,8 @@ public class FaladorHard extends ComplexStateQuestHelper
 			"Go to the Hero's Guild south of Burthorpe. You can get here faster by teleporting with a Combat Bracelet to the Warriors Guild.", combatGear, food, dragonfireProtection);
 		enterHerosGuildBasement = new ObjectStep(this, ObjectID.LADDER_17384, new WorldPoint(2892, 3507, 0),
 			"Climb down the ladder in the Hero's Guild.");
-		killBlueDragon = new NpcStep(this, NpcID.BLUE_DRAGON_266,
-			"Kill the Blue Dragon to complete your task.");
+		killBlueDragon = new CombatStep(this, NpcID.BLUE_DRAGON_266,
+			"Kill the Blue Dragon to complete your task.", "Blue dragon (level 140)");
 
 		//Rogues Den
 		enterRoguesDen = new ObjectStep(this, ObjectID.TRAPDOOR_7257, new WorldPoint(2905, 3537, 0),
@@ -305,9 +305,14 @@ public class FaladorHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Giant Mole (lvl 230)", "Skeletal Wyvern (lvl 140)", "Blue dragon (lvl 111)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGiantMole);
+		reqs.add(killWyvern);
+		reqs.add(killBlueDragon);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/DagRouteHelper.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/DagRouteHelper.java
@@ -34,6 +34,7 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.player.PrayerRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.steps.CombatStep;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.QuestStep;
 import java.util.ArrayList;
@@ -99,9 +100,11 @@ public class DagRouteHelper extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Tank many hits in the Waterbirth Island Dungeon");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Tank many hits in the Waterbirth Island Dungeon"));
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikEasy.java
@@ -212,8 +212,8 @@ public class FremennikEasy extends ComplexStateQuestHelper
 	{
 		catchCerulean = new ObjectStep(this, ObjectID.BIRD_SNARE_9375, new WorldPoint(2724, 3773, 0),
 			"Catch a Cerulean Twitch in the Rellekka Hunter area.", birdSnare.highlighted());
-		killedCrabs = new NpcStep(this, NpcID.ROCK_CRAB, new WorldPoint(2707, 3723, 0),
-			"Kill 5 Rock crabs.", true, combatGear);
+		killedCrabs = new CombatStep(this, NpcID.ROCK_CRAB, new WorldPoint(2707, 3723, 0),
+			"Kill 5 Rock crabs.","5 Rock Crabs (Level 13)", true, combatGear);
 		killedCrabs.addAlternateNpcs(NpcID.ROCK_CRAB_102);
 
 		chopOak = new ObjectStep(this, ObjectID.OAK_10820, new WorldPoint(2714, 3664, 0),
@@ -287,9 +287,12 @@ public class FremennikEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("5 Rock Crabs (Level 13)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killedCrabs);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikElite.java
@@ -361,9 +361,19 @@ public class FremennikElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("God Wars Generals (level ~600), 3 Dagannoth Kings (level 303), and a Spiritual mage (level 120)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.GENERAL_GRAARDOR, "", "Bandos' General Graardor (level 624)"));
+		reqs.add(new CombatStep(this, NpcID.COMMANDER_ZILYANA, "", "Saradomin's Commander Zilyana (level 596)"));
+		reqs.add(new CombatStep(this, NpcID.KREEARRA, "", "Armadyl General, Kree'arra (level 580)"));
+		reqs.add(new CombatStep(this, NpcID.KRIL_TSUTSAROTH, "", "Zammorak General, K'ril Tsutsaroth (level 624)"));
+		reqs.add(new CombatStep(this, -1, "tank many hits in the Waterbirth Island Dungeon"));
+		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_PRIME, "", "Dagannoth Prime (level 303)" ));
+		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_REX, "", "Dagannoth Rex (level 303)" ));
+		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_SUPREME, "", "Dagannoth Supreme  (level 303)" ));
+		reqs.add(new CombatStep(this, NpcID.SPIRITUAL_MAGE, "", "Spiritual Mage (level 120)"));
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikElite.java
@@ -364,15 +364,15 @@ public class FremennikElite extends ComplexStateQuestHelper
 	public List<QuestStep> getCombatRequirements()
 	{
 		ArrayList<QuestStep> reqs = new ArrayList<>();
-		reqs.add(new CombatStep(this, NpcID.GENERAL_GRAARDOR, "", "Bandos' General Graardor (level 624)"));
-		reqs.add(new CombatStep(this, NpcID.COMMANDER_ZILYANA, "", "Saradomin's Commander Zilyana (level 596)"));
-		reqs.add(new CombatStep(this, NpcID.KREEARRA, "", "Armadyl General, Kree'arra (level 580)"));
-		reqs.add(new CombatStep(this, NpcID.KRIL_TSUTSAROTH, "", "Zammorak General, K'ril Tsutsaroth (level 624)"));
+		reqs.add(new CombatStep(this, NpcID.GENERAL_GRAARDOR, "Bandos' General Graardor (level 624)"));
+		reqs.add(new CombatStep(this, NpcID.COMMANDER_ZILYANA, "Saradomin's Commander Zilyana (level 596)"));
+		reqs.add(new CombatStep(this, NpcID.KREEARRA, "Armadyl General, Kree'arra (level 580)"));
+		reqs.add(new CombatStep(this, NpcID.KRIL_TSUTSAROTH, "Zammorak General, K'ril Tsutsaroth (level 624)"));
 		reqs.add(new CombatStep(this, -1, "tank many hits in the Waterbirth Island Dungeon"));
-		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_PRIME, "", "Dagannoth Prime (level 303)" ));
-		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_REX, "", "Dagannoth Rex (level 303)" ));
-		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_SUPREME, "", "Dagannoth Supreme  (level 303)" ));
-		reqs.add(new CombatStep(this, NpcID.SPIRITUAL_MAGE, "", "Spiritual Mage (level 120)"));
+		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_PRIME, "Dagannoth Prime (level 303)" ));
+		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_REX, "Dagannoth Rex (level 303)" ));
+		reqs.add(new CombatStep(this, NpcID.DAGANNOTH_SUPREME, "Dagannoth Supreme  (level 303)" ));
+		reqs.add(new CombatStep(this, NpcID.SPIRITUAL_MAGE, "Spiritual Mage (level 120)"));
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikMedium.java
@@ -301,8 +301,8 @@ public class FremennikMedium extends ComplexStateQuestHelper
 		enterBrineCave = new DigStep(this, new WorldPoint(2749, 3732, 0),
 			"Use a spade to enter the Brine Rat Cavern.", spade, combatGear, olafsQuest);
 		enterBrineCave.addIcon(ItemID.SPADE);
-		slayBrineRat = new NpcStep(this, NpcID.BRINE_RAT, new WorldPoint(2706, 10133, 0),
-			"Kill a brine rat.", true);
+		slayBrineRat = new CombatStep(this, NpcID.BRINE_RAT, new WorldPoint(2706, 10133, 0),
+			"Kill a brine rat.", "Brine rat (level 70)",  true);
 		rollBoulderExit = new NpcStep(this, NpcID.BOULDER_4502, new WorldPoint(2692, 10125, 0),
 			"Roll the boulder and exit the cave.");
 		travelMisc = new ObjectStep(this, 29495, new WorldPoint(2744, 3719, 0),
@@ -425,9 +425,13 @@ public class FremennikMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Brine rat (level 70) and tank many hits in the Waterbirth Island Dungeon");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(slayBrineRat);
+		reqs.add(new CombatStep(this, -1, "tank many hits in the Waterbirth Island Dungeon"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinEasy.java
@@ -246,9 +246,15 @@ public class KandarinEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("4 level 35 elementals");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.FIRE_ELEMENTAL, "Fire Elemental (level 35)"));
+		reqs.add(new CombatStep(this, NpcID.WATER_ELEMENTAL, "Water Elemental (level 35)"));
+		reqs.add(new CombatStep(this, NpcID.AIR_ELEMENTAL, "Air Elemental (level 35)"));
+		reqs.add(new CombatStep(this, NpcID.EARTH_ELEMENTAL, "Earth Elemental (level 35)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinElite.java
@@ -277,9 +277,12 @@ public class KandarinElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Mithril Dragons (level 304) for chewed bones");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.MITHRIL_DRAGON, "Mithril Dragons (level 304) for chewed bones"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinHard.java
@@ -250,8 +250,8 @@ public class KandarinHard extends ComplexStateQuestHelper
 		fancyStone.addDialogStep("Can you redecorate my house please?");
 		moveToShadow = new ObjectStep(this, NullObjectID.NULL_6560, new WorldPoint(2547, 3421, 0),
 			"Climb down the shadow ladder south of Glarial's Tomb.", ringOfVis.equipped(), combatGear);
-		shadowHound = new NpcStep(this, NpcID.SHADOW_HOUND, new WorldPoint(2699, 5095, 0),
-			"Kill a shadow hound.", true);
+		shadowHound = new CombatStep(this, NpcID.SHADOW_HOUND, new WorldPoint(2699, 5095, 0),
+			"Kill a shadow hound.", "Shadow Hound (Level 63)", true);
 		catchStur = new NpcStep(this, NpcID.FISHING_SPOT_1542, new WorldPoint(2501, 3504, 0),
 			"Catch a leaping Sturgeon south of Barbarian Assault.", true, barbRod, feather.quantity(20));
 		addySpear = new ObjectStep(this, ObjectID.BARBARIAN_ANVIL, new WorldPoint(2502, 3485, 0),
@@ -263,8 +263,8 @@ public class KandarinHard extends ComplexStateQuestHelper
 			"Go down the stairs.");
 		moveToAncient3 = new ObjectStep(this, ObjectID.STAIRS_25339, new WorldPoint(1778, 5345, 0),
 			"Go up the stairs in the east of the cavern.");
-		mithrilDrag = new NpcStep(this, NpcID.MITHRIL_DRAGON, new WorldPoint(1779, 5344, 1),
-			"Kill a mithril dragon.", true, combatGear, antidragonfire.equipped(), food);
+		mithrilDrag = new CombatStep(this, NpcID.MITHRIL_DRAGON, new WorldPoint(1779, 5344, 1),
+			"Kill a mithril dragon.", "Mithril Dragon (level 304)", true, combatGear, antidragonfire.equipped(), food);
 		buyGranite = new NpcStep(this, NpcID.COMMANDER_CONNAD, new WorldPoint(2535, 3576, 0),
 			"Buy and equip a granite body from Commander Connad. (Requires at least 1 Penance Queen kill)",
 			coins.quantity(95000));
@@ -329,9 +329,13 @@ public class KandarinHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Shadow Hound (Level 63), Mithril Dragon (level 304)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(shadowHound);
+		reqs.add(mithrilDrag);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kandarin/KandarinMedium.java
@@ -253,8 +253,8 @@ public class KandarinMedium extends ComplexStateQuestHelper
 		mineCoal.addIcon(ItemID.RUNE_PICKAXE);
 		moveToWaterfall = new ObjectStep(this, ObjectID.DOOR_2010, new WorldPoint(2511, 3464, 0),
 			"Enter the waterfall dungeon.", rope, combatGear);
-		fireGiant = new NpcStep(this, NpcID.FIRE_GIANT_2080, new WorldPoint(2566, 9887, 0),
-			"Kill a Fire giant.", true, combatGear);
+		fireGiant = new CombatStep(this, NpcID.FIRE_GIANT_2080, new WorldPoint(2566, 9887, 0),
+			"Kill a Fire giant.","Fire giant (Level 86)", true, combatGear);
 		fireGiant.addAlternateNpcs(NpcID.FIRE_GIANT_2079, NpcID.FIRE_GIANT_2078);
 		moveToWorkshop = new ObjectStep(this, ObjectID.STAIRCASE_3415, new WorldPoint(2711, 3498, 0),
 			"Enter the Elemental Workshop.", batteredKey, primedMind);
@@ -347,9 +347,12 @@ public class KandarinMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Fire giant (Level 86)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(fireGiant);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendEasy.java
@@ -207,8 +207,8 @@ public class KourendEasy extends ComplexStateQuestHelper
 		mineIron.addAlternateObjects(ObjectID.ROCKS_11365);
 
 		// Kill a sand crab
-		sandCrab = new NpcStep(this, NpcID.SAND_CRAB, new WorldPoint(1739, 3468, 0),
-			"Kill a sand crab.", true, combatGear, food);
+		sandCrab = new CombatStep(this, NpcID.SAND_CRAB, new WorldPoint(1739, 3468, 0),
+			"Kill a sand crab.", "Kill a Sand Crab (level 15)", true, combatGear, food);
 
 		// Hand in a book in the Arceuus library
 		arceuusBook = new NpcStep(this, NpcID.PROFESSOR_GRACKLEBONE, new WorldPoint(1625, 3801, 0),
@@ -279,9 +279,12 @@ public class KourendEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill a Sand Crab (level 15)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(sandCrab);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendElite.java
@@ -281,7 +281,7 @@ public class KourendElite extends ComplexStateQuestHelper
 		enterSkotizoLair = new ObjectStep(this, ObjectID.ALTAR_28900, "Enter Skotizo's Lair.",
 			darkTotem.highlighted());
 		enterSkotizoLair.addIcon(ItemID.DARK_TOTEM);
-		defeatSkotizo = new NpcStep(this, NpcID.SKOTIZO, "Defeat Skotizo.", combatGear, food, prayerPotion);
+		defeatSkotizo = new CombatStep(this, NpcID.SKOTIZO, "Defeat Skotizo.", "Kill Skotizo (level 321)", combatGear, food, prayerPotion);
 
 		// Catch and cook and an anglerfish
 		catchAngler = new NpcStep(this, NpcID.ROD_FISHING_SPOT_6825, "Catch a raw anglerfish.",
@@ -294,8 +294,8 @@ public class KourendElite extends ComplexStateQuestHelper
 			"Enter the Mount Karuulm Slayer Dungeon.");
 		enterHydraArea = new ObjectStep(this, ObjectID.ROCKS_34544, new WorldPoint(1312, 10215, 0),
 			"Enter the hydra area.", bootsOfStone.equipped());
-		killHydra = new NpcStep(this, NpcID.HYDRA, new WorldPoint(1312, 10232, 0),
-			"Kill a hydra.", combatGear, food);
+		killHydra = new CombatStep(this, NpcID.HYDRA, new WorldPoint(1312, 10232, 0),
+			"Kill a hydra.", "Kill a Hydra (level 194)", combatGear, food);
 		killHydra.addSubSteps(enterMountKaruulmDungeon, enterHydraArea);
 
 		// Create an Ape Atoll teleport tab
@@ -328,12 +328,14 @@ public class KourendElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList(
-			"Kill Skotizo (level 321)",
-			"Kill a Hydra (level 194)",
-			"Various enemies in Chambers of Xeric");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(defeatSkotizo);
+		reqs.add(killHydra);
+		reqs.add(new CombatStep(this, -1, "Various enemies in Chambers of Xeric"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
@@ -248,8 +248,8 @@ public class KourendHard extends ComplexStateQuestHelper
 		enterLizardmanTemple = new ObjectStep(this, ObjectID.LIZARD_DWELLING_34405, new WorldPoint(1312, 3686, 0),
 			"Enter the lizardman temple.", shayzienHelmet.equipped(), shayzienBody.equipped(), shayzienGreaves.equipped(),
 			shayzienBoots.equipped(), shayzienGloves.equipped(), antipoison, combatGear);
-		killLizardmanShaman = new NpcStep(this, NpcID.LIZARDMAN_SHAMAN_8565, new WorldPoint(1292, 10096, 0),
-			"Kill a Lizardman Shaman.", shayzienFavour, shayzienHelmet.equipped(), shayzienBody.equipped(),
+		killLizardmanShaman = new CombatStep(this, NpcID.LIZARDMAN_SHAMAN_8565, new WorldPoint(1292, 10096, 0),
+			"Kill a Lizardman Shaman.", "Kill a Lizardman Shaman (level 150)", shayzienFavour, shayzienHelmet.equipped(), shayzienBody.equipped(),
 			shayzienGreaves.equipped(), shayzienBoots.equipped(), shayzienGloves.equipped(), antipoison, combatGear);
 
 		// Mine some lovakite ore
@@ -270,8 +270,8 @@ public class KourendHard extends ComplexStateQuestHelper
 		// Kill a zombie
 		entershayzienCrypt = new ObjectStep(this, ObjectID.CRYPT_ENTRANCE, new WorldPoint(1483, 3548, 0),
 			"Enter the shayzien crypt.", lightSource);
-		killZombie = new NpcStep(this, NpcID.ZOMBIE_8068, new WorldPoint(1491, 9949, 3),
-			"Kill a zombie in the shayzien crypt.", combatGear, food);
+		killZombie = new CombatStep(this, NpcID.ZOMBIE_8068, new WorldPoint(1491, 9949, 3),
+			"Kill a zombie in the shayzien crypt.", "Kill a Zombie (level 132)", combatGear, food);
 		killZombie.addSubSteps(entershayzienCrypt);
 
 		// Teleport to Xeric's heart
@@ -292,8 +292,8 @@ public class KourendHard extends ComplexStateQuestHelper
 			"Enter the Mount Karuulm Slayer Dungeon.", bootsOfStone.equipped(), combatGear, food);
 		enterWyrmArea = new ObjectStep(this, ObjectID.ROCKS_34544, new WorldPoint(1302, 10205, 0),
 			"Enter the wyrm area.", bootsOfStone.equipped());
-		killWyrm = new NpcStep(this, NpcID.WYRM, new WorldPoint(1282, 10189, 0),
-			"Kill a wyrm.", combatGear, food);
+		killWyrm = new CombatStep(this, NpcID.WYRM, new WorldPoint(1282, 10189, 0),
+			"Kill a wyrm.", "Kill a Wyrm (level 99)", combatGear, food);
 		killWyrm.addSubSteps(enterMountKaruulmDungeon, enterWyrmArea);
 
 		// Cast monster examine
@@ -309,12 +309,14 @@ public class KourendHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList(
-			"Kill a Lizardman Shaman (level 150)",
-			"Kill a Zombie (level 132)",
-			"Kill a Wyrm (level 99)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killLizardmanShaman);
+		reqs.add(killZombie);
+		reqs.add(killWyrm);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendMedium.java
@@ -267,8 +267,8 @@ public class KourendMedium extends ComplexStateQuestHelper
 			"Travel from any fairy ring to south of Mount Karuulm (CIR).", dramenStaff.highlighted());
 
 		// Kill a lizardman
-		killLizardman = new NpcStep(this, NpcID.LIZARDMAN, new WorldPoint(1507, 3683, 0),
-			"Kill a lizardman.", true, combatGear, antipoison, food);
+		killLizardman = new CombatStep(this, NpcID.LIZARDMAN, new WorldPoint(1507, 3683, 0),
+			"Kill a lizardman.", "Kill a Lizardman (level 53)",true, combatGear, antipoison, food);
 		killLizardman.addAlternateNpcs(NpcID.LIZARDMAN_6915, NpcID.LIZARDMAN_6916, NpcID.LIZARDMAN_6917,
 			NpcID.LIZARDMAN_BRUTE, NpcID.LIZARDMAN_BRUTE_6919);
 
@@ -339,9 +339,12 @@ public class KourendMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill a Lizardman (level 53)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killLizardman);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
@@ -40,10 +40,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,7 +55,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.LUMBRIDGE_EASY
@@ -220,8 +217,8 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		moveToDraySewer = new ObjectStep(this, ObjectID.TRAPDOOR_6435, new WorldPoint(3118, 3244, 0),
 			"Climb down into the Draynor Sewer.");
 		moveToDraySewer.addAlternateObjects(ObjectID.TRAPDOOR_6434);
-		killZombie = new NpcStep(this, NpcID.ZOMBIE_38, new WorldPoint(3123, 9648, 0),
-			"Kill a zombie.", true);
+		killZombie = new CombatStep(this, NpcID.ZOMBIE_38, new WorldPoint(3123, 9648, 0),
+			"Kill a zombie.", "Zombie (level 13)", true);
 		killZombie.addAlternateNpcs(NpcID.ZOMBIE_40, NpcID.ZOMBIE_57, NpcID.ZOMBIE_55, NpcID.ZOMBIE_56);
 
 		moveToSed = new ObjectStep(this, ObjectID.LADDER_2147, new WorldPoint(3104, 3162, 0),
@@ -241,8 +238,8 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 			lightSource, rope.highlighted(), combatGear);
 		addRopeToHole.addSubSteps(moveToDarkHole);
 		addRopeToHole.addIcon(ItemID.ROPE);
-		killCaveBug = new NpcStep(this, NpcID.CAVE_BUG, new WorldPoint(3151, 9574, 0),
-			"Kill a Cave Bug.", combatGear, lightSource);
+		killCaveBug = new CombatStep(this, NpcID.CAVE_BUG, new WorldPoint(3151, 9574, 0),
+			"Kill a Cave Bug.", "Cave bug (level 6)", combatGear, lightSource);
 
 		moveToWaterAltar = new ObjectStep(this, 34815, new WorldPoint(3185, 3165, 0),
 			"Enter the water altar in Lumbridge Swamp.", waterAccessOrAbyss.highlighted(), runeEss);
@@ -309,9 +306,13 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Zombie (lvl 13) and cave bug (lvl 6)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killZombie);
+		reqs.add(killCaveBug);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaEasy.java
@@ -40,12 +40,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +55,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MORYTANIA_EASY
@@ -211,8 +206,8 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 
 	public void setupSteps()
 	{
-		killGhoul = new NpcStep(this, NpcID.GHOUL, new WorldPoint(3434, 3461, 0),
-			"Kill a ghoul in Morytania.", combatGear);
+		killGhoul = new CombatStep(this, NpcID.GHOUL, new WorldPoint(3434, 3461, 0),
+			"Kill a ghoul in Morytania.", "Ghoul (lvl 42)", combatGear);
 		enterSwamp = new ObjectStep(this, ObjectID.GATE_3507, new WorldPoint(3443, 3458, 0),
 			"Enter the Mort Myre Swamp.");
 		craftSnelm = new ItemStep(this, "Craft a snelm in Morytania. Note: Do not be in the swamp when completing " +
@@ -223,11 +218,11 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		restorePrayer = new ObjectStep(this, ObjectID.ALTAR_OF_NATURE, new WorldPoint(3442, 9741, 1),
 			"Pray at the altar.");
 
-		killBanshee = new NpcStep(this, NpcID.BANSHEE, new WorldPoint(3436, 3550, 0),
-			"Kill a banshee.", true, earProtection.equipped(), combatGear);
+		killBanshee = new CombatStep(this, NpcID.BANSHEE, new WorldPoint(3436, 3550, 0),
+			"Kill a banshee.", "Banshee (lvl 23)",  true, earProtection.equipped(), combatGear);
 
-		killWerewolf = new NpcStep(this, NpcID.ZOJA, new WorldPoint(3501, 3488, 0),
-			"Kill any attackable NPC in Canifis with the wolfbane dagger.", wolfbane.equipped());
+		killWerewolf = new CombatStep(this, NpcID.ZOJA, new WorldPoint(3501, 3488, 0),
+			"Kill any attackable NPC in Canifis with the wolfbane dagger.", "Werewolf in human form (lvl 24)", wolfbane.equipped());
 		mazchna = new NpcStep(this, NpcID.MAZCHNA, new WorldPoint(3513, 3510, 0),
 			"Get a slayer task from Mazchna.");
 		sbottTan = new NpcStep(this, NpcID.SBOTT, new WorldPoint(3490, 3501, 0),
@@ -296,9 +291,14 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Ghoul (lvl 42)", "Banshee (lvl 23)", "Werewolf in human form (lvl 24)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGhoul);
+		reqs.add(killBanshee);
+		reqs.add(killWerewolf);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaElite.java
@@ -40,10 +40,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -58,7 +56,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MORYTANIA_ELITE
@@ -229,8 +226,8 @@ public class MorytaniaElite extends ComplexStateQuestHelper
 		moveToSlayer3 = new ObjectStep(this, ObjectID.STAIRCASE_2119, new WorldPoint(3415, 3541, 1),
 			"Climb the stairs or the Spikey chains in the Slayer tower to ascend to the higher level.", combatGear,
 			food);
-		abyssalDemon = new NpcStep(this, NpcID.ABYSSAL_DEMON_415, new WorldPoint(3420, 3569, 2),
-			"Kill an Abyssal demon.", combatGear, food);
+		abyssalDemon = new CombatStep(this, NpcID.ABYSSAL_DEMON_415, new WorldPoint(3420, 3569, 2),
+			"Kill an Abyssal demon.", "Abyssal demon (lvl 124)", combatGear, food);
 
 		moveToCanifisBank = new DetailedQuestStep(this, new WorldPoint(3511, 3480, 0),
 			"Move to the bank in Canifis.", blackLeather.quantity(3).highlighted(), needle.highlighted(), thread);
@@ -284,9 +281,12 @@ public class MorytaniaElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("One Abyssal Demon (lvl 124)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(abyssalDemon);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaHard.java
@@ -40,11 +40,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,7 +57,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MORYTANIA_HARD
@@ -285,8 +281,8 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 			"Talk to Bill Teach to travel to Mos Le'Harmless.", witchwoodIcon.equipped(), lightSource, combatGear, food);
 		moveToCaveHorror = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_3650, new WorldPoint(3748, 2973, 0),
 			"Enter the Mos Le'Harmless Cave.", witchwoodIcon.equipped(), lightSource, combatGear, food);
-		caveHorror = new NpcStep(this, NpcID.CAVE_HORROR, new WorldPoint(3740, 9373, 0),
-			"Kill a Cave horror.", witchwoodIcon.equipped());
+		caveHorror = new CombatStep(this, NpcID.CAVE_HORROR, new WorldPoint(3740, 9373, 0),
+			"Kill a Cave horror.", "Cave horror (lvl 80)", witchwoodIcon.equipped());
 		caveHorror.addAlternateNpcs(NpcID.CAVE_HORROR_1048, NpcID.CAVE_HORROR_1049, NpcID.CAVE_HORROR_1050,
 			NpcID.CAVE_HORROR_1051);
 		moveToCaptMaho = new ObjectStep(this, ObjectID.GANGPLANK_11209, new WorldPoint(3710, 3496, 0),
@@ -363,9 +359,12 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill a cave horror (lvl 80)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(caveHorror);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/morytania/MorytaniaMedium.java
@@ -41,10 +41,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +57,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MORYTANIA_MEDIUM
@@ -276,8 +273,8 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 		getToTerrorDogs = new TarnRoute(this);
 		moveToMine = new ObjectStep(this, ObjectID.CART_TUNNEL, new WorldPoint(3440, 3232, 0),
 			"Enter the Haunted Mine or use slayer ring to teleport directly to Tarn's Lair.");
-		terrorDog = new NpcStep(this, NpcID.TERROR_DOG, new WorldPoint(3149, 4652, 0),
-			"Kill a terror dog. You can enter the room with the diary if you need a safe zone.", true);
+		terrorDog = new CombatStep(this, NpcID.TERROR_DOG, new WorldPoint(3149, 4652, 0),
+			"Kill a terror dog. You can enter the room with the diary if you need a safe zone.", "Terror dog (lvl 100)", true);
 		terrorDog.addAlternateNpcs(NpcID.TERROR_DOG_6474);
 
 		canifisAgi = new ObjectStep(this, ObjectID.TALL_TREE_14843, new WorldPoint(3507, 3489, 0),
@@ -311,8 +308,8 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 		moveToBrainDeath.addDialogStep("Okay!");
 		moveToDownstairs = new ObjectStep(this, ObjectID.LADDER_10168, new WorldPoint(2139, 5105, 1),
 			"Climb down the ladder.");
-		feverSpider = new NpcStep(this, NpcID.FEVER_SPIDER, new WorldPoint(2141, 5103, 0),
-			"Kill a Fever spider.", slayerGloves, combatGear, food);
+		feverSpider = new CombatStep(this, NpcID.FEVER_SPIDER, new WorldPoint(2141, 5103, 0),
+			"Kill a Fever spider.", "Fever spider (lvl 49)", slayerGloves, combatGear, food);
 
 		moveToCapt = new ObjectStep(this, ObjectID.GANGPLANK_11209, new WorldPoint(3710, 3496, 0),
 			"Cross the gangplank to Bill Teach's ship. Alternatively use the Group finder to teleport directly there.");
@@ -362,9 +359,14 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("a Terror dog (lvl 100) and a Fever spider (lvl 49)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(terrorDog);
+		reqs.add(feverSpider);
+
+		return reqs;
+
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/varrock/VarrockHard.java
@@ -390,9 +390,12 @@ public class VarrockHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill various monsters in the stronghold of security (levels 13-86)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Kill various monsters in the stronghold of security (levels 13-86)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternEasy.java
@@ -37,11 +37,8 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,7 +52,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WESTERN_EASY
@@ -198,8 +194,8 @@ public class WesternEasy extends ComplexStateQuestHelper
 			"Have Brimstail teleport you to the Essence mine");
 		brimstailEssence.addDialogStep("I need to mine some rune essence.");
 
-		terrorbird = new NpcStep(this, NpcID.TERRORBIRD, new WorldPoint(2379, 3432, 0),
-			"Kill a terrorbird in the terrorbird enclosure.", true, combatGear);
+		terrorbird = new CombatStep(this, NpcID.TERRORBIRD, new WorldPoint(2379, 3432, 0),
+			"Kill a terrorbird in the terrorbird enclosure.", "Terrorbird (level 28)",true, combatGear);
 		terrorbird.addAlternateNpcs(NpcID.TERRORBIRD_2065, NpcID.TERRORBIRD_2066);
 
 		gnomeBall = new NpcStep(this, NpcID.GNOME_BALL_REFEREE, new WorldPoint(2385, 3487, 0),
@@ -264,9 +260,13 @@ public class WesternEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Terror bird (lvl 28)", "Complete a Novice Pest Control game");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(terrorbird);
+		reqs.add(new CombatStep(this, -1, "Complete a Novice Pest Control game"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternElite.java
@@ -39,10 +39,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,7 +54,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WESTERN_ELITE
@@ -191,8 +188,8 @@ public class WesternElite extends ComplexStateQuestHelper
 			"Enter the Smoke Devil Dungeon.", combatGear, food, mouthProtection);
 		moveToThermy = new ObjectStep(this, ObjectID.CREVICE, new WorldPoint(2378, 9452, 0),
 			"Enter the boss area of the Thermonuclear smoke devil.", combatGear, food, mouthProtection);
-		killThermy = new NpcStep(this, NpcID.THERMONUCLEAR_SMOKE_DEVIL, new WorldPoint(2356, 9456, 0),
-			"Defeat the Thermonuclear smoke devil. You are allowed one kill off-task for the diary.", combatGear, food,
+		killThermy = new CombatStep(this, NpcID.THERMONUCLEAR_SMOKE_DEVIL, new WorldPoint(2356, 9456, 0),
+			"Defeat the Thermonuclear smoke devil. You are allowed one kill off-task for the diary.", "Thermonuclear smoke devil (lvl 301)", combatGear, food,
 			mouthProtection);
 
 		advancedAgi = new ObjectStep(this, ObjectID.ROCKS_16515, new WorldPoint(2337, 3253, 0),
@@ -247,9 +244,12 @@ public class WesternElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Thermonuclear smoke devil (lvl 301)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killThermy);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/westernprovinces/WesternHard.java
@@ -42,11 +42,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,7 +58,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WESTERN_HARD
@@ -363,9 +359,13 @@ public class WesternHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill Zulrah (lvl 725) and an elf (lvl 108)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.ZULRAH, "Zulrah (lvl 725)"));
+		reqs.add(new CombatStep(this, -1, "an elf (lvl 108)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessEasy.java
+++ b/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessEasy.java
@@ -41,11 +41,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +56,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WILDERNESS_EASY
@@ -196,8 +192,8 @@ public class WildernessEasy extends ComplexStateQuestHelper
 
 	public void setupSteps()
 	{
-		killMammoth = new NpcStep(this, NpcID.MAMMOTH, new WorldPoint(3164, 3593, 0),
-			"Kill a Mammoth in the Wilderness.", combatGear);
+		killMammoth = new CombatStep(this, NpcID.MAMMOTH, new WorldPoint(3164, 3593, 0),
+			"Kill a Mammoth in the Wilderness.", "Mammoth (level 80)",combatGear);
 
 		moveToEdgeSpider = new ObjectStep(this, ObjectID.TRAPDOOR_1581, new WorldPoint(3097, 3468, 0),
 			"Enter the Edgeville dungeon.", food);
@@ -229,8 +225,8 @@ public class WildernessEasy extends ComplexStateQuestHelper
 		spiderEggs = new ItemStep(this, new WorldPoint(3122, 9953, 0), "Pickup 5 red spider eggs in the Edgeville " +
 			"Wilderness Dungeon.", redSpiderEggs);
 
-		earthWarrior = new NpcStep(this, NpcID.EARTH_WARRIOR, new WorldPoint(3121, 9972, 0),
-			"Kill an Earth warrior in the north of the Edgeville Wilderness Dungeon.", combatGear, food);
+		earthWarrior = new CombatStep(this, NpcID.EARTH_WARRIOR, new WorldPoint(3121, 9972, 0),
+			"Kill an Earth warrior in the north of the Edgeville Wilderness Dungeon.", "Earth warrior (level 51)", combatGear, food);
 
 		wildyLever = new ObjectStep(this, ObjectID.LEVER_26761, new WorldPoint(3090, 3475, 0),
 			"Pull the Lever in Edgeville. This will take you to DEEP Wilderness, bank anything you aren't willing to lose.");
@@ -278,9 +274,13 @@ public class WildernessEasy extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kill an Earth Warrior (lvl 51) and a Mammoth (lvl 80).");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(earthWarrior);
+		reqs.add(killMammoth);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessElite.java
@@ -41,11 +41,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +56,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WILDERNESS_ELITE
@@ -236,8 +232,8 @@ public class WildernessElite extends ComplexStateQuestHelper
 
 		moveToResource2 = new ObjectStep(this, ObjectID.GATE_26760, new WorldPoint(3184, 3944, 0),
 			"Enter the Wilderness Resource Area.", coins.quantity(6000), combatGear, food, pickaxe, coal.quantity(16), hammer);
-		runiteGolem = new NpcStep(this, NpcID.RUNITE_GOLEM, new WorldPoint(3189, 3938, 0),
-			"Kill and mine the Runite Golems in the Resource Area.", true, combatGear, food,
+		runiteGolem = new CombatStep(this, NpcID.RUNITE_GOLEM, new WorldPoint(3189, 3938, 0),
+			"Kill and mine the Runite Golems in the Resource Area.", "Runite Golem (level 178)",true, combatGear, food,
 			pickaxe, coal.quantity(16), hammer);
 		runiteGolem.addAlternateNpcs(NpcID.ROCKS_6601);
 		smeltBar = new ObjectStep(this, ObjectID.FURNACE_26300, new WorldPoint(3191, 3936, 0),
@@ -260,8 +256,8 @@ public class WildernessElite extends ComplexStateQuestHelper
 		moveToGodWars2 = new ObjectStep(this, ObjectID.CREVICE_26767, new WorldPoint(3066, 10142, 0),
 			"Use the crevice to enter the Wilderness God Wars Dungeon. The Strength entrance is to the west.",
 			combatGear, food, godEquip);
-		spiritMage = new NpcStep(this, NpcID.SPIRITUAL_MAGE, new WorldPoint(3050, 10131, 0),
-			"Kill a Spiritual Warrior in the Wilderness God Wars Dungeon.", combatGear, food, godEquip);
+		spiritMage = new CombatStep(this, NpcID.SPIRITUAL_MAGE, new WorldPoint(3050, 10131, 0),
+			"Kill a Spiritual Warrior in the Wilderness God Wars Dungeon.", "Spiritual Mage (level 121)", combatGear, food, godEquip);
 		spiritMage.addAlternateNpcs(NpcID.SPIRITUAL_MAGE_2244, NpcID.SPIRITUAL_MAGE_3161, NpcID.SPIRITUAL_MAGE_3168);
 
 		threeBosses = new NpcStep(this, NpcID.CALLISTO, new WorldPoint(3291, 3844, 0),
@@ -311,10 +307,16 @@ public class WildernessElite extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Callisto (lvl 470)", "Venenatis (lvl 464)", "Vet'ion (lvl 454)",
-			"Runite Golem (lvl 178)", "Spiritual Mage (lvl 121)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.CALLISTO, "Callisto (level 470)"));
+		reqs.add(new CombatStep(this, NpcID.VENENATIS, "Venenatis (level 464)"));
+		reqs.add(new CombatStep(this, NpcID.VETION, "Vet'ion (level 454)"));
+		reqs.add(runiteGolem);
+		reqs.add(spiritMage);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessHard.java
@@ -41,11 +41,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +56,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WILDERNESS_HARD
@@ -216,15 +212,15 @@ public class WildernessHard extends ComplexStateQuestHelper
 		airOrb = new ObjectStep(this, ObjectID.OBELISK_OF_AIR, new WorldPoint(3088, 3569, 0),
 			"Cast charge air orb on the Obelisk of Air.", airRune.quantity(30), cosmicRune.quantity(3), unpoweredOrb);
 
-		chaosEle = new NpcStep(this, NpcID.CHAOS_ELEMENTAL, new WorldPoint(3263, 3918, 0),
-			"Kill the Chaos Elemental.", combatGear, food);
+		chaosEle = new CombatStep(this, NpcID.CHAOS_ELEMENTAL, new WorldPoint(3263, 3918, 0),
+			"Kill the Chaos Elemental.", "Chaos Elemental (level 305)", combatGear, food);
 		chaosEle.addAlternateNpcs(NpcID.CHAOS_ELEMENTAL_6505);
 
 		blackSally = new ObjectStep(this, ObjectID.YOUNG_TREE_9000, new WorldPoint(3296, 3671, 0),
 			"Set a trap and catch a Black salamander in the Wilderness.", true);
 
-		lavaDrag = new NpcStep(this, NpcID.LAVA_DRAGON, new WorldPoint(3209, 3848, 0),
-			"Kill a Lava dragon and bury the bones on Lava Dragon Isle.", true, combatGear, food);
+		lavaDrag = new CombatStep(this, NpcID.LAVA_DRAGON, new WorldPoint(3209, 3848, 0),
+			"Kill a Lava dragon and bury the bones on Lava Dragon Isle.", "Lava dragon (level 252)",true, combatGear, food);
 		buryBone = new ItemStep(this, "Bury the dragon bones", lavaDragonBones.highlighted());
 
 		rawLavaEel = new NpcStep(this, NpcID.FISHING_SPOT_6784, new WorldPoint(3071, 3839, 0),
@@ -240,8 +236,8 @@ public class WildernessHard extends ComplexStateQuestHelper
 		moveToGodWars2 = new ObjectStep(this, ObjectID.CREVICE_26767, new WorldPoint(3066, 10142, 3),
 			"Use the crevice to enter the Wilderness God Wars Dungeon. The Strength entrance is to the West.",
 			combatGear, food, godEquip);
-		sprirtualWarrior = new NpcStep(this, NpcID.SPIRITUAL_WARRIOR, new WorldPoint(3050, 10131, 0),
-			"Kill a Spiritual Warrior in the Wilderness God Wars Dungeon.", combatGear, food, godEquip);
+		sprirtualWarrior = new CombatStep(this, NpcID.SPIRITUAL_WARRIOR, new WorldPoint(3050, 10131, 0),
+			"Kill a Spiritual Warrior in the Wilderness God Wars Dungeon.", "Spiritual warrior (level 115-134)", combatGear, food, godEquip);
 		sprirtualWarrior.addAlternateNpcs(NpcID.SPIRITUAL_WARRIOR_2243, NpcID.SPIRITUAL_WARRIOR_3159,
 			NpcID.SPIRITUAL_WARRIOR_3166);
 
@@ -290,10 +286,17 @@ public class WildernessHard extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Chaos Elemental (lvl 305)", "Crazy archaeologist (lvl 204)",
-			"Chaos Fanatic (lvl 202)", "Lava dragon (lvl 252)", "Scorpia (lvl 225)", "Spiritual warrior (lvl 115-134)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(chaosEle);
+		reqs.add(new CombatStep(this, NpcID.CRAZY_ARCHAEOLOGIST, "Crazy archaeologist (level 204)"));
+		reqs.add(new CombatStep(this, NpcID.CHAOS_FANATIC, "Chaos Fanatic (level 202)"));
+		reqs.add(new CombatStep(this, NpcID.SCORPIA, "Scorpia (level 225)"));
+		reqs.add(lavaDrag);
+		reqs.add(sprirtualWarrior);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessMedium.java
@@ -40,9 +40,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,7 +55,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.WILDERNESS_MEDIUM
@@ -211,19 +209,19 @@ public class WildernessMedium extends ComplexStateQuestHelper
 
 	public void setupSteps()
 	{
-		entYew = new NpcStep(this, NpcID.ENT, new WorldPoint(3227, 3666, 0),
-			"Kill an Ent in the wilderness and cut yew logs from its trunk after killing it.", combatGear, runeAxe);
+		entYew = new CombatStep(this, NpcID.ENT, new WorldPoint(3227, 3666, 0),
+			"Kill an Ent in the wilderness and cut yew logs from its trunk after killing it.", "Ent (level 101)",combatGear, runeAxe);
 		entYew.addAlternateNpcs(NpcID.ENT_TRUNK);
 
 		moveToSlayer1 = new ObjectStep(this, ObjectID.STAIRS_40388, new WorldPoint(3260, 3665, 0),
 			"Enter the Wilderness Slayer Cave.", combatGear, food);
-		killAnkou = new NpcStep(this, NpcID.ANKOU_7864, new WorldPoint(3373, 10073, 0),
-			"Kill an Ankou in the Wilderness Slayer Cave.", true, combatGear, food);
+		killAnkou = new CombatStep(this, NpcID.ANKOU_7864, new WorldPoint(3373, 10073, 0),
+			"Kill an Ankou in the Wilderness Slayer Cave.", "Ankou (level 98)",true, combatGear, food);
 
 		moveToSlayer2 = new ObjectStep(this, ObjectID.STAIRS_40388, new WorldPoint(3260, 3665, 0),
 			"Enter the Wilderness Slayer Cave.", combatGear, food, antiDragonShield);
-		killGreenDrag = new NpcStep(this, NpcID.GREEN_DRAGON_7868, new WorldPoint(3412, 10066, 0),
-			"Kill a Green dragon in the Wilderness Slayer Cave.", true, combatGear, food, antiDragonShield);
+		killGreenDrag = new CombatStep(this, NpcID.GREEN_DRAGON_7868, new WorldPoint(3412, 10066, 0),
+			"Kill a Green dragon in the Wilderness Slayer Cave.", "Green dragon (level 88)",true, combatGear, food, antiDragonShield);
 		killGreenDrag.addAlternateNpcs(NpcID.GREEN_DRAGON_7869, NpcID.GREEN_DRAGON_7870);
 
 		moveToGodWars1 = new ObjectStep(this, ObjectID.CAVE_26766, new WorldPoint(3017, 3738, 0),
@@ -233,8 +231,8 @@ public class WildernessMedium extends ComplexStateQuestHelper
 		wildyGodwars = new ObjectStep(this, ObjectID.CREVICE_26767, new WorldPoint(3066, 10142, 3),
 			"Use the crevice to enter the Wilderness God Wars Dungeon. The Strength entrance is to the West.",
 			combatGear, food, godEquip);
-		wildyGWBloodveld = new NpcStep(this, NpcID.BLOODVELD_3138, new WorldPoint(3050, 10131, 0),
-			"Kill a Bloodveld in the Wilderness God Wars Dungeon.", combatGear, food, godEquip);
+		wildyGWBloodveld = new CombatStep(this, NpcID.BLOODVELD_3138, new WorldPoint(3050, 10131, 0),
+			"Kill a Bloodveld in the Wilderness God Wars Dungeon.", "Bloodveld (level 81)", combatGear, food, godEquip);
 
 		mineMith = new ObjectStep(this, ObjectID.ROCKS_11373, new WorldPoint(3057, 3944, 0),
 			"Mine mithril in the Wilderness.", pickaxe);
@@ -301,10 +299,15 @@ public class WildernessMedium extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Bloodveld (lvl 81)", "Green dragon (lvl 88)", "Ankou (lvl 98)",
-			"Ent (lvl 101)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(wildyGWBloodveld);
+		reqs.add(killGreenDrag);
+		reqs.add(killAnkou);
+		reqs.add(entYew);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -43,10 +43,12 @@ import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
 
+import com.questhelper.requirements.npc.NpcRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
+import com.questhelper.steps.CombatStep;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
@@ -219,7 +221,7 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		return null;
 	}
 
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
 		return null;
 	}

--- a/src/main/java/com/questhelper/quests/akingdomdivided/AKingdomDivided.java
+++ b/src/main/java/com/questhelper/quests/akingdomdivided/AKingdomDivided.java
@@ -48,11 +48,7 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -584,9 +580,9 @@ public class AKingdomDivided extends BasicQuestHelper
 			"Port Piscarilius, ready to fight the Judge of Yama.");
 		talkToCabinBoyHerbertSidebar.addSubSteps(talkToCabinBoyHerbert);
 
-		fightJudgeofYama = new NpcStep(this, NpcID.JUDGE_OF_YAMA_10938,
+		fightJudgeofYama = new CombatStep(this, NpcID.JUDGE_OF_YAMA_10938,
 			"Fight the Judge of Yama. This boss uses magic + range prayer so melee is required. Run in the gaps of " +
-				"the fire waves to approach the boss.", combatGearForJudgeOfYama, food);
+				"the fire waves to approach the boss.", "Judge of Yama (level 168)", combatGearForJudgeOfYama, food);
 
 		enterJudgeOfYamaFightPortal = new ObjectStep(this, ObjectID.PORTAL_41808, new WorldPoint(1823, 3686, 0),
 			"Prepare to fight the Judge of Yama. This boss uses magic + range prayer so melee is required. Run in the " +
@@ -631,7 +627,7 @@ public class AKingdomDivided extends BasicQuestHelper
 		talkToMartinHoltSettlementRuins = new NpcStep(this, NpcID.MARTIN_HOLT_10891, new WorldPoint(1545, 3895, 0),
 			"Talk to Martin Holt again in the Settlement Ruins south west of the Wintertodt camp. " +
 			"Be prepared to fight a level 132 assassin who uses a dragon dagger and dragon darts.", combatGear, food);
-		killAssassin = new NpcStep(this, NpcID.ASSASSIN_10940, "Kill the Assassin.", combatGear, food);
+		killAssassin = new CombatStep(this, NpcID.ASSASSIN_10940, "Kill the Assassin.", "2 Assassins (level 132)",combatGear, food);
 		talkToMartinHoltSettlementRuins.addSubSteps(killAssassin);
 		talkToMartinHoltSettlementRuins2 = new NpcStep(this, NpcID.MARTIN_HOLT_10891, new WorldPoint(1545, 3895, 0), "Talk to Martin Holt again in the Settlement Ruins south west of the Wintertodt camp.");
 		castFireSpellOnIce = new NpcStep(this, NpcID.ICE_CHUNKS_11029, new WorldPoint(1541, 3886, 0), "Cast FIRE bolt or stronger on the ice chunks south west of Martin Holt in the Settlement Ruins.", fireSpellGear);
@@ -689,7 +685,7 @@ public class AKingdomDivided extends BasicQuestHelper
 
 		fightXamphurSidebar = new DetailedQuestStep(this, "Fight Xamphur.", combatGearForXamphur, food);
 		fightXamphurSidebar.addText("Xamphur uses several special mechanics. It is recommended to read or watch a guide on the fight.");
-		fightXamphur = new NpcStep(this, NpcID.XAMPHUR_10955, "Fight Xamphur.", combatGearForXamphur, food);
+		fightXamphur = new CombatStep(this, NpcID.XAMPHUR_10955, "Fight Xamphur.", "Xamphur (level 239)", combatGearForXamphur, food);
 		fightXamphurSidebar.addSubSteps(openXamphurGate, openDoorNearKahtNoKey, fightXamphur, enterLizardTempleToFightXamphur);
 
 		watchCutsceneAfterXamphur = new DetailedQuestStep(this, "");
@@ -746,7 +742,7 @@ public class AKingdomDivided extends BasicQuestHelper
 		useShieldingPotionOnDinhsDoor = new ObjectStep(this, ObjectID.DOORS_OF_DINH, new WorldPoint(1630, 3965, 0), "Use the Shielding potion on the Doors of Dinh in the Wintertodt camp. Use a games necklace to get there quickly.", shieldingPotion.highlighted());
 		useShieldingPotionOnDinhsDoor.addIcon(ItemID.SHIELDING_POTION);
 		goDownLadderInKourendWoodland = new ObjectStep(this, ObjectID.LADDER_41924, new WorldPoint(1582, 3428, 0), "Fight and kill the Barbarian Warlord (level 91) in the Kourend Woodlands. Use a skills necklace (woodcutting guild) or Radas blessing to get there quickly.", combatGear, food);
-		killBarbarianInKourendWoodland = new NpcStep(this, NpcID.BARBARIAN_WARLORD, "Fight and kill the Barbarian Warlord (level 91) in the Kourend Woodlands. Use a skills necklace (woodcutting guild) or Radas blessing to get there quickly.", combatGear, food);
+		killBarbarianInKourendWoodland = new CombatStep(this, NpcID.BARBARIAN_WARLORD, "Fight and kill the Barbarian Warlord (level 91) in the Kourend Woodlands. Use a skills necklace (woodcutting guild) or Radas blessing to get there quickly.", "Barbarian Warlord (level 91)", combatGear, food);
 		goDownLadderInKourendWoodland.addSubSteps(killBarbarianInKourendWoodland);
 		goDownLadderInKourendAfterBarbFight = new ObjectStep(this, ObjectID.LADDER_41924, new WorldPoint(1582, 3428, 0), "Talk to Phileas Rimor in the Barbarian Warlords prison.");
 		talkToPhileasRimor = new NpcStep(this, NpcID.PHILEAS_RIMOR, "Talk to Phileas Rimor in the Barbarian Warlords prison.");
@@ -819,14 +815,15 @@ public class AKingdomDivided extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Lizardman Brute (level 75)");
-		reqs.add("Barbarian Warlord (level 91)");
-		reqs.add("2 Assassins (level 132)");
-		reqs.add("Judge of Yama (level 168)");
-		reqs.add("Xamphur (level 239)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.LIZARDMAN, "Lizardman (level 75)"));
+		reqs.add(killBarbarianInKourendWoodland);
+		reqs.add(killAssassin);
+		reqs.add(fightJudgeofYama);
+		reqs.add(fightXamphur);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/anightatthetheatre/ANightAtTheTheatre.java
+++ b/src/main/java/com/questhelper/quests/anightatthetheatre/ANightAtTheTheatre.java
@@ -43,12 +43,8 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -210,7 +206,7 @@ public class ANightAtTheTheatre extends BasicQuestHelper
 		enterVerSinhazaCrypts.addDialogSteps("Yes.");
 
 		killVyrewatchForKey = new NpcStep(this, NpcID.VYREWATCH_11173,
-			"Kill a vyrewatch for a key. You must have your flail equipped in order to damage the vyrewatches.", true, flail.equipped(), combatGear, food);
+			"Kill a vyrewatch for a key. You must have your flail equipped in order to damage the vyrewatches.",  true, flail.equipped(), combatGear, food);
 		((NpcStep) killVyrewatchForKey).addAlternateNpcs(NpcID.VYREWATCH_11169, NpcID.VYREWATCH_11170, NpcID.VYREWATCH_11171, NpcID.VYREWATCH_11172, NpcID.VYREWATCH_11173);
 		pickupCryptKey = new ItemStep(this, "Pick up the crypt key", cryptKey);
 		killVyrewatchForKey.addSubSteps(pickupCryptKey);
@@ -335,7 +331,7 @@ public class ANightAtTheTheatre extends BasicQuestHelper
 				hesporiFightText, combatGear, food, antipoison, axe);
 		goToHesporiFight.addSubSteps(exitNatureGrotto, activateHesporiFight);
 
-		fightHespori = new NpcStep(this, NpcID.HESPORI_11192, "Fight Hespori.");
+		fightHespori = new CombatStep(this, NpcID.HESPORI_11192, "Fight Hespori.", "Hespori (level 302)");
 
 		chopHesporiForBark = new ObjectStep(this, ObjectID.HESPORI_42592, new WorldPoint(3507, 3357, 0), "Chop Hespori to obtain Hespori bark.", axe);
 		returnToMysteriousStrangerWithBark = new NpcStep(this, NpcID.MYSTERIOUS_STRANGER_10876, new WorldPoint(3673, 3223, 0),
@@ -441,13 +437,18 @@ public class ANightAtTheTheatre extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Vyrewatch (level 105)");
-		reqs.add("Several venomous spiders (level 87 and 123)");
-		reqs.add("Hespori (level 302)");
-		reqs.add("All ToB Bosses");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.VYREWATCH_11173,"Vyrewatch (level 105)" ));
+		reqs.add(new CombatStep(this, NpcID.SPIDER_11176, "Several venomous spiders (level 87 and 123)"));
+		reqs.add(fightHespori);
+		reqs.add(new CombatStep(this, NpcID.THE_MAIDEN_OF_SUGADINTI, "Maiden of Sugadinti -ToB Boss #1 (940)"));
+		reqs.add(new CombatStep(this, NpcID.PESTILENT_BLOAT, "Pestilent Bloat -ToB Boss #2 (870)"));
+		reqs.add(new CombatStep(this, NpcID.NYLOCAS, "Nylocas Vasilias -ToB Boss #3 (800)"));
+		reqs.add(new CombatStep(this, NpcID.SOTETSEG, "Sotetseg -ToB Boss #4 (995)"));
+		reqs.add(new CombatStep(this, NpcID.XARPUS, "Xarpus -ToB Boss #5"));
+		reqs.add(new CombatStep(this, NpcID.VERZIK_VITUR, "Verzik Vitur -ToB FINAL Boss"));
 
 		return reqs;
 	}

--- a/src/main/java/com/questhelper/quests/anothersliceofham/AnotherSliceOfHam.java
+++ b/src/main/java/com/questhelper/quests/anothersliceofham/AnotherSliceOfHam.java
@@ -48,11 +48,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -365,8 +362,8 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 			"defeat him.",	ancientMace.equipped().highlighted());
 		((NpcStep) useSpecial).addAlternateNpcs(NpcID.SIGMUND_5143, NpcID.SIGMUND_5144, NpcID.SIGMUND_5145);
 
-		defeatSigmund = new NpcStep(this, NpcID.SIGMUND_5146, new WorldPoint(2543, 5511, 0),
-			"Defeat Sigmund.");
+		defeatSigmund = new CombatStep(this, NpcID.SIGMUND_5146, new WorldPoint(2543, 5511, 0),
+			"Defeat Sigmund.", "Sigmund (level 64)");
 		useSpecial.addSubSteps(defeatSigmund);
 
 		untieZanik = new ObjectStep(this, ObjectID.ZANIK_23284, new WorldPoint(2542, 5513, 0), "Untie Zanik.");
@@ -435,9 +432,14 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("H.A.M. Archer (level 30)", "H.A.M. Mage (level 30)", "Sigmund (level 64)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.HAM_ARCHER, "H.A.M. Archer (level 30)"));
+		reqs.add(new CombatStep(this, NpcID.HAM_MAGE, "H.A.M. Mage (level 30)"));
+		reqs.add(defeatSigmund);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/quests/aporcineofinterest/APorcineOfInterest.java
@@ -37,11 +37,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -148,7 +145,7 @@ public class APorcineOfInterest extends BasicQuestHelper
 		talkToSpria = new NpcStep(this, NpcID.SPRIA_10434, new WorldPoint(3092, 3267, 0), "Talk to Spria in Draynor Village.");
 
 		enterHoleAgain = new ObjectStep(this, NullObjectID.NULL_40341, new WorldPoint(3151, 3348, 0), "Climb down into the Strange Hole east of Draynor Manor. Be prepared to fight Sourhog (level 37)", reinforcedGoggles, slashItem, combatGear);
-		killSourhog = new NpcStep(this, NpcID.SOURHOG_10436, "Kill Sourhog.", reinforcedGoggles);
+		killSourhog = new CombatStep(this, NpcID.SOURHOG_10436, "Kill Sourhog.", "Sourhog (level 37)", reinforcedGoggles);
 		killSourhog.addDialogStep("Yes");
 
 		enterHoleForFoot = new ObjectStep(this, NullObjectID.NULL_40341, new WorldPoint(3151, 3348, 0), "Climb down into the Strange Hole east of Draynor Manor.", slashItem);
@@ -174,9 +171,12 @@ public class APorcineOfInterest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Sourhog (level 37)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSourhog);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/asoulsbane/ASoulsBane.java
+++ b/src/main/java/com/questhelper/quests/asoulsbane/ASoulsBane.java
@@ -42,11 +42,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -289,9 +286,12 @@ public class ASoulsBane extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Multiple level 40-46 enemies");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Multiple level 40-46 enemies"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/atasteofhope/ATasteOfHope.java
+++ b/src/main/java/com/questhelper/quests/atasteofhope/ATasteOfHope.java
@@ -35,9 +35,7 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
@@ -59,8 +57,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.A_TASTE_OF_HOPE
@@ -485,7 +481,7 @@ public class ATasteOfHope extends BasicQuestHelper
 		enterBaseAfterSerafina.addSubSteps(pressDecoratedWallAfterSerafina);
 
 		talkToSafalaanForAbominationFight = new NpcStep(this, NpcID.SAFALAAN_HALLOW, new WorldPoint(3627, 9644, 0), "Talk to Safalaan, ready for a fight.");
-		killAbomination = new NpcStep(this, NpcID.ABOMINATION, new WorldPoint(3627, 9644, 0), "Kill the abomination. It can be safe spotted with a long-ranged weapon.");
+		killAbomination = new CombatStep(this, NpcID.ABOMINATION, new WorldPoint(3627, 9644, 0), "Kill the abomination. It can be safe spotted with a long-ranged weapon.", "Abomination (level 149, safespottable)");
 		((NpcStep) (killAbomination)).addAlternateNpcs(NpcID.ABOMINATION_8261, NpcID.ABOMINATION_8262);
 		talkToSafalaanAfterAbominationFight = new NpcStep(this, NpcID.SAFALAAN_HALLOW_8219, new WorldPoint(3627, 9644, 0), "Talk to Safalaan.");
 
@@ -526,8 +522,8 @@ public class ATasteOfHope extends BasicQuestHelper
 		killRanisSidebar.addText("In his last phase he will only attack with melee, so make sure to use protect from melee!");
 
 
-		killRanis = new NpcStep(this, NpcID.RANIS_DRAKAN_8244, new WorldPoint(2082, 4891, 0), "Defeat Ranis. His " +
-			"various mechanics are listed in the helper's sidebar.", ivandisFlailEquipped, food);
+		killRanis = new CombatStep(this, NpcID.RANIS_DRAKAN_8244, new WorldPoint(2082, 4891, 0), "Defeat Ranis. His " +
+			"various mechanics are listed in the helper's sidebar.", "Ranis Drakan (level 233, melee only)", ivandisFlailEquipped, food);
 		((NpcStep) (killRanis)).addAlternateNpcs(NpcID.RANIS_DRAKAN_8245, NpcID.RANIS_DRAKAN_8246, NpcID.RANIS_DRAKAN_8247, NpcID.RANIS_DRAKAN_8248);
 		killRanisSidebar.addSubSteps(killRanis);
 
@@ -551,9 +547,13 @@ public class ATasteOfHope extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Abomination (level 149, safespottable)", "Ranis Drakan (level 233, melee only)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killAbomination);
+		reqs.add(killRanis);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/belowicemountain/BelowIceMountain.java
+++ b/src/main/java/com/questhelper/quests/belowicemountain/BelowIceMountain.java
@@ -224,8 +224,8 @@ public class BelowIceMountain extends BasicQuestHelper
 			"dungeon to finish the quest.");
 		reenterDungeon.addDialogStep("Yes.");
 
-		defeatGuardian = new NpcStep(this, NpcID.ANCIENT_GUARDIAN, "Defeat the Lvl-25 Ancient Guardian. " +
-			"Alternatively, with Level 10 Mining, mine the 4 pillars in the corners.");
+		defeatGuardian = new CombatStep(this, NpcID.ANCIENT_GUARDIAN, "Defeat the Lvl-25 Ancient Guardian. " +
+			"Alternatively, with Level 10 Mining, mine the 4 pillars in the corners.", "Ancient Guardian (level 25), or 10 mining + a pickaxe");
 		defeatGuardian.addSubSteps(reenterDungeon);
 
 		watchCutscene = new ObjectStep(this, NullObjectID.NULL_41357, new WorldPoint(3000, 3494, 0), "Watch the cutscene to " +
@@ -251,9 +251,12 @@ public class BelowIceMountain extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Ancient Guardian (level 25), or 10 mining + a pickaxe");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(defeatGuardian);
+
+	return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/beneathcursedsands/BeneathCursedSands.java
+++ b/src/main/java/com/questhelper/quests/beneathcursedsands/BeneathCursedSands.java
@@ -23,13 +23,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.WidgetStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -392,7 +387,7 @@ public class BeneathCursedSands extends BasicQuestHelper
 		talkToCitizenOrGuard = new NpcStep(this, NpcID.CITIZEN_11537, new WorldPoint(3347, 2718, 0), "Prepare to fight the Head Menaphite Guard, and talk to either a citizen or Menaphite Guard to start the fight.", true);
 		((NpcStep) talkToCitizenOrGuard).addAlternateNpcs(NpcID.CITIZEN_11536, NpcID.CITIZEN_11534, NpcID.MENAPHITE_GUARD_11515, NpcID.MENAPHITE_GUARD_11516, NpcID.MENAPHITE_GUARD_11518);
 
-		fightHeadMenaphiteGuard = new NpcStep(this, NpcID.HEAD_MENAPHITE_GUARD_11529, "Fight the Head Menaphite Guard. This boss uses melee, and can hit up to 16. DO NOT USE ANY OVERHEAD PROTECTION PRAYERS, OR YOU WILL GET HIT FOR 1/3RD OF YOUR HITPOINTS", meleeCombatGear, food);
+		fightHeadMenaphiteGuard = new CombatStep(this, NpcID.HEAD_MENAPHITE_GUARD_11529, "Fight the Head Menaphite Guard. This boss uses melee, and can hit up to 16. DO NOT USE ANY OVERHEAD PROTECTION PRAYERS, OR YOU WILL GET HIT FOR 1/3RD OF YOUR HITPOINTS", "Head Menaphite Guard (lvl 174) without protection prayers", meleeCombatGear, food);
 
 		talkToMaisaPostFightCutsceneInterruption = new NpcStep(this, NpcID.MAISA_11474, new WorldPoint(3327, 2740, 0), "Talk to Maisa to continue the quest.");
 
@@ -439,7 +434,7 @@ public class BeneathCursedSands extends BasicQuestHelper
 		enterDungeonToFightScarabMages = new ObjectStep(this, NullObjectID.NULL_6643, new WorldPoint(3409, 2848, 0),
 			"Enter the dungeon.", meleeCombatGear, food);
 		enterDungeon = new ObjectStep(this, NullObjectID.NULL_6643, new WorldPoint(3409, 2848, 0), "Enter the dungeon.");
-		fightScarabMages = new NpcStep(this, NpcID.SCARAB_MAGE_11508, "Use Protect from Magic and defeat the two Scarab Mages.", meleeCombatGear, food, antipoison);
+		fightScarabMages = new CombatStep(this, NpcID.SCARAB_MAGE_11508, "Use Protect from Magic and defeat the two Scarab Mages.", "Two Scabarite Mages (lvl 119)", meleeCombatGear, food, antipoison);
 
 		climbDownStairsAgain = new ObjectStep(this, ObjectID.STAIRS_43959, "Climb down the stairs.");
 		((ObjectStep) climbDownStairsAgain).addAlternateObjects(ObjectID.STAIRS_43958);
@@ -478,7 +473,7 @@ public class BeneathCursedSands extends BasicQuestHelper
 
 		openBossDoor = new ObjectStep(this, ObjectID.DOOR_43960, "Prepare to fight the Champion of Scabaras, and open the door to start the fight.", rangedCombatGear, food, antipoison, staminaPotions, prayerPotions);
 
-		fightChampionOfScabaras = new NpcStep(this, NpcID.CHAMPION_OF_SCABARAS_11483, "Fight the Champion of Scabaras.", rangedCombatGear, food, antipoison, staminaPotions, prayerPotions);
+		fightChampionOfScabaras = new CombatStep(this, NpcID.CHAMPION_OF_SCABARAS_11483, "Fight the Champion of Scabaras.", "Champion of Scabaras (lvl 379)", rangedCombatGear, food, antipoison, staminaPotions, prayerPotions);
 		fightChampionOfScabaras.addText("Protect from Magic, and keep 4+ tiles distance at all times.");
 		fightChampionOfScabaras.addText("Whenever a rift or swarm appears, kill it.");
 		fightChampionOfScabaras.addText("He is weak to ranged attacks, so bring your best ranged gear.");
@@ -522,9 +517,9 @@ public class BeneathCursedSands extends BasicQuestHelper
 		// Fight with the Menaphite Akh
 		prepareFightMenaphiteAkh = new NpcStep(this, NpcID.MAISA_11474, new WorldPoint(3327, 2740, 0), "Prepare to fight the Menaphite Akh (lvl 351), and talk to Maisa in Necropolis when ready.", meleeCombatGear, waterskins);
 
-		defeatMenaphiteAkh = new NpcStep(this, NpcID.MENAPHITE_AKH_11492, "Defeat the Menaphite Akh. This boss uses melee, and will occasionally cast lightning in front of her, " +
+		defeatMenaphiteAkh = new CombatStep(this, NpcID.MENAPHITE_AKH_11492, "Defeat the Menaphite Akh. This boss uses melee, and will occasionally cast lightning in front of her, " +
 			"so be prepared to walk behind her to avoid this attack. Whenever a shadow version of them appears, kill " +
-			"them quickly as they'll deal a lot of damage.", meleeCombatGear,waterskins);
+			"them quickly as they'll deal a lot of damage.", "Menaphite Akh (lvl 351)", meleeCombatGear,waterskins);
 //		defeatMenaphiteShadow = new NpcStep(this, NpcID.MENAPHITE_SHADOW, "Quickly defeat the Menaphite Shadow, which attack using Ranged and Magic and can deal large damage.");
 
 		talkToOsman = new NpcStep(this, NpcID.OSMAN_11486, new WorldPoint(3369, 2799, 0), "Talk to Osman");
@@ -546,9 +541,16 @@ public class BeneathCursedSands extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Head Menaphite Guard (lvl 174) without protection prayers", "Two Scabarite Mages (lvl 119)", "Champion of Scabaras (lvl 379)", "Menaphite Akh (lvl 351)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(fightHeadMenaphiteGuard);
+		reqs.add(fightScarabMages);
+		reqs.add(fightChampionOfScabaras);
+		reqs.add(defeatMenaphiteAkh);
+
+		return reqs;
+
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/betweenarock/BetweenARock.java
+++ b/src/main/java/com/questhelper/quests/betweenarock/BetweenARock.java
@@ -44,11 +44,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -370,8 +367,8 @@ public class BetweenARock extends BasicQuestHelper
 
 		talkToSecondFlame = new ObjectStep(this, ObjectID.WALL_OF_FLAME_5979, new WorldPoint(2373, 4956, 0),
 			"TALK to the central wall of flame.", goldHelmetEquipped);
-		killAvatar = new NpcStep(this, NpcID.ARZINIAN_AVATAR_OF_MAGIC, new WorldPoint(2375, 4953, 0), "Kill the " +
-			"avatar. Make sure to keep the gold ores in your inventory.", goldHelmetEquipped);
+		killAvatar = new CombatStep(this, NpcID.ARZINIAN_AVATAR_OF_MAGIC, new WorldPoint(2375, 4953, 0), "Kill the " +
+			"avatar. Make sure to keep the gold ores in your inventory.", "Arzinian Being of Bordanzan (level 75 - 125)", goldHelmetEquipped);
 		killAvatar.addAlternateNpcs(NpcID.ARZINIAN_AVATAR_OF_MAGIC_1234, NpcID.ARZINIAN_AVATAR_OF_MAGIC_1235,
 			NpcID.ARZINIAN_AVATAR_OF_RANGING, NpcID.ARZINIAN_AVATAR_OF_RANGING_1231, NpcID.ARZINIAN_AVATAR_OF_RANGING_1232,
 			NpcID.ARZINIAN_AVATAR_OF_STRENGTH, NpcID.ARZINIAN_AVATAR_OF_STRENGTH_1228, NpcID.ARZINIAN_AVATAR_OF_STRENGTH_1229);
@@ -392,11 +389,12 @@ public class BetweenARock extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Scorpion (level 14)");
-		reqs.add("Arzinian Being of Bordanzan (level 75 - 125)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Scorpion (level 14)"));
+		reqs.add(killAvatar);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
+++ b/src/main/java/com/questhelper/quests/bigchompybirdhunting/BigChompyBirdHunting.java
@@ -43,11 +43,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -282,7 +279,7 @@ public class BigChompyBirdHunting extends BasicQuestHelper
 		talkToRantzForBow.addDialogSteps("Come on, let me have a go...", "I'm actually quite strong...please let me try.");
 		placeAnotherToad = new DetailedQuestStep(this, new WorldPoint(2635, 2967, 0), "Drop another bloated toad in the clearing south of Rantz, and wait for a chompy to come.", ogreBow, ogreArrows);
 
-		killChompy = new NpcStep(this, NpcID.CHOMPY_BIRD, new WorldPoint(2635, 2966, 0), "Kill the chompy. You can only hurt it with an ogre bow + ogre arrows.", ogreBow, ogreArrows);
+		killChompy = new CombatStep(this, NpcID.CHOMPY_BIRD, new WorldPoint(2635, 2966, 0), "Kill the chompy. You can only hurt it with an ogre bow + ogre arrows.", "Chompy (level 6) ", ogreBow, ogreArrows);
 		pluckCarcass = new NpcStep(this, NpcID.CHOMPY_BIRD_1476, new WorldPoint(2635, 2966, 0), "Pluck the chompy.");
 		talkToRantzWithChompy = new NpcStep(this, NpcID.RANTZ, new WorldPoint(2631, 2982, 0), "Talk to Rantz in the east of Feldip Hills.", chompy);
 
@@ -313,9 +310,12 @@ public class BigChompyBirdHunting extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Chompy");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killChompy);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/biohazard/Biohazard.java
+++ b/src/main/java/com/questhelper/quests/biohazard/Biohazard.java
@@ -41,11 +41,8 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -257,7 +254,7 @@ public class Biohazard extends BasicQuestHelper
 		enterMournerHeadquarters = new ObjectStep(this, ObjectID.DOOR_2036, new WorldPoint(2551, 3320, 0), "Enter the Mourners' Headquarters whilst wearing the medical gown.", medicalGownEquipped);
 
 		goUpstairsInMournerBuilding = new ObjectStep(this, ObjectID.STAIRCASE_16671, new WorldPoint(2543, 3325, 0), "Go upstairs and kill the mourner there.");
-		killMourner = new NpcStep(this, NpcID.MOURNER_9008, new WorldPoint(2549, 3325, 1), "Kill the mourner here for a key to the caged area.");
+		killMourner = new CombatStep(this, NpcID.MOURNER_9008, new WorldPoint(2549, 3325, 1), "Kill the mourner here for a key to the caged area.", "Mourner (level 13)");
 		goUpstairsInMournerBuilding.addSubSteps(killMourner);
 
 		searchCrateForDistillator = new ObjectStep(this, ObjectID.CRATE_2064, new WorldPoint(2554, 3327, 1), "Search the crate in the caged area for Elena's Distillator.");
@@ -298,10 +295,11 @@ public class Biohazard extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Mourner (level 13)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killMourner);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/blackknightfortress/BlackKnightFortress.java
+++ b/src/main/java/com/questhelper/quests/blackknightfortress/BlackKnightFortress.java
@@ -15,10 +15,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -290,9 +288,12 @@ public class BlackKnightFortress extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Able to survive being attacked by multiple level 33 Black Knights");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.BLACK_KNIGHT, "Able to survive being attacked by multiple level 33 Black Knights"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/cabinfever/CabinFever.java
+++ b/src/main/java/com/questhelper/quests/cabinfever/CabinFever.java
@@ -43,11 +43,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -631,9 +628,12 @@ public class CabinFever extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Able to survive multiple pirates (level 57) attacking you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.PIRATE, "Able to survive multiple pirates (level 57) attacking you"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/quests/clocktower/ClockTower.java
@@ -41,9 +41,7 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,8 +54,6 @@ import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.CLOCK_TOWER
@@ -343,9 +339,12 @@ public class ClockTower extends BasicQuestHelper
     }
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Able to survive a hit or 2 from an Ogre (level 53)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.OGRE, "Able to survive a hit or 2 from an Ogre (level 53)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/quests/coldwar/ColdWar.java
@@ -18,12 +18,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -411,7 +407,7 @@ public class ColdWar extends BasicQuestHelper
 
 		enterWarRoom = new ObjectStep(this, ObjectID.DOOR_21160, new WorldPoint(2671, 10418, 0), "Enter the war room and walk a few steps in to be captured.");
 
-		killIcelords = new NpcStep(this, NpcID.ICELORD, new WorldPoint(2647, 10425, 0), "Kill icelords until you are able to leave through the door to the west. May take up to 3 kills.", true);
+		killIcelords = new CombatStep(this, NpcID.ICELORD, new WorldPoint(2647, 10425, 0), "Kill icelords until you are able to leave through the door to the west. May take up to 3 kills.", "1-3 Icelords (level 51)", true);
 		((NpcStep) killIcelords).addAlternateNpcs(NpcID.ICELORD_853, NpcID.ICELORD_854, NpcID.ICELORD_855);
 		exitIcelordPen = new ObjectStep(this, ObjectID.DOOR_21167, new WorldPoint(2639, 10424, 0), "Leave through the door to the west.");
 		killIcelords.addSubSteps(killIcelords);
@@ -439,10 +435,11 @@ public class ColdWar extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("1-3 Icelords (level 51)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killIcelords);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/contact/Contact.java
+++ b/src/main/java/com/questhelper/quests/contact/Contact.java
@@ -37,11 +37,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 
@@ -51,7 +47,6 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
@@ -260,8 +255,8 @@ public class Contact extends BasicQuestHelper
 				"and use protection prayers against the monsters.");
 		((DetailedQuestStep) goDownToChasmAgain).setLinePoints(path);
 
-		killGiantScarab = new NpcStep(this, NpcID.GIANT_SCARAB, new WorldPoint(2272, 4323, 0),
-			"Kill the Giant Scarab near the chasm. It can extinguish your light source and poison you, so be careful. Pray melee if you are meleeing it, range if you are attacking it from a distance.");
+		killGiantScarab = new CombatStep(this, NpcID.GIANT_SCARAB, new WorldPoint(2272, 4323, 0),
+			"Kill the Giant Scarab near the chasm. It can extinguish your light source and poison you, so be careful. Pray melee if you are meleeing it, range if you are attacking it from a distance.", "Giant Scarab (level 191)");
 
 		pickUpKeris = new ItemStep(this, "Pick up the Keris.", keris);
 
@@ -293,10 +288,11 @@ public class Contact extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Giant Scarab (level 191)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGiantScarab);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
+++ b/src/main/java/com/questhelper/quests/creatureoffenkenstrain/CreatureOfFenkenstrain.java
@@ -45,13 +45,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -299,8 +294,8 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 		enterExperimentCave = new ObjectStep(this, ObjectID.MEMORIAL, new WorldPoint(3578, 3528, 0),
 			"Push the memorial south east of the castle.");
 
-		killExperiment = new NpcStep(this, NpcID.EXPERIMENT, new WorldPoint(3557, 9946, 0),
-			"Kill the level 51 Experiment north-west of the ladder to get a key.", true);
+		killExperiment = new CombatStep(this, NpcID.EXPERIMENT, new WorldPoint(3557, 9946, 0),
+			"Kill the level 51 Experiment north-west of the ladder to get a key.", "Able to defeat an experiment (level 51)", true);
 
 		pickupKey = new ItemStep(this, "Pick up the key.", cavernKey);
 		killExperiment.addSubSteps(pickupKey);
@@ -384,9 +379,13 @@ public class CreatureOfFenkenstrain extends BasicQuestHelper
 	}
 
 	@Override
-	public ArrayList<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return new ArrayList<>(Collections.singletonList("Able to defeat an experiment (level 51)"));
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killExperiment);
+
+		return reqs;
+
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/darknessofhallowvale/DarknessOfHallowvale.java
+++ b/src/main/java/com/questhelper/quests/darknessofhallowvale/DarknessOfHallowvale.java
@@ -47,11 +47,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -772,9 +769,13 @@ public class DarknessOfHallowvale extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Able to survive 5 hits from Vanstrom Klause (level 169)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.VANSTROM_KLAUSE_3734, "Able to survive 5 hits from Vanstrom Klause (level 169)"));
+
+		return reqs;
+
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deathtothedorgeshuun/DeathToTheDorgeshuun.java
+++ b/src/main/java/com/questhelper/quests/deathtothedorgeshuun/DeathToTheDorgeshuun.java
@@ -45,11 +45,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -383,8 +380,8 @@ public class DeathToTheDorgeshuun extends BasicQuestHelper
 		searchCrate = new ObjectStep(this, ObjectID.CRATE_15704, new WorldPoint(3228, 3280, 0), "Search a crate south of the farm east of the Lumbridge.", zanikFollower, combatGear, hamSet);
 		searchCrate.addDialogSteps("I don't know, what are you thinking?", "Good idea.");
 		enterMill = new ObjectStep(this, NullObjectID.NULL_15765, new WorldPoint(3230, 3286, 0), "Enter the trapdoor outside the farm.", combatGear, hamSet);
-		killGuards = new NpcStep(this, NpcID.GUARD, new WorldPoint(2000, 5087, 0), "Kill the guards to the west.", true);
-		killSigmund = new NpcStep(this, NpcID.SIGMUND_991, new WorldPoint(2000, 5087, 0), "Defeat Sigmund. You need to use magic or melee to hurt him.", combatGear);
+		killGuards = new CombatStep(this, NpcID.GUARD, new WorldPoint(2000, 5087, 0), "Kill the guards to the west.", "3 H.A.M. Guards (level 22)", true);
+		killSigmund = new CombatStep(this, NpcID.SIGMUND_991, new WorldPoint(2000, 5087, 0), "Defeat Sigmund. You need to use magic or melee to hurt him.", "Sigmund (level 50, melee or magic only)", combatGear);
 		smashDrill = new ObjectStep(this, ObjectID.DRILLING_MACHINE, new WorldPoint(1998, 5088, 0), "Destroy the drilling machine.");
 		enterExit = new ObjectStep(this, NullObjectID.NULL_15764, new WorldPoint(3245, 9661, 0), "Leave the area via the exit to the south to finish the quest.");
 	}
@@ -499,9 +496,13 @@ public class DeathToTheDorgeshuun extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("3 H.A.M. Guards (level 22)", "Sigmund (level 50, melee or magic only)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGuards);
+		reqs.add(killSigmund);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/demonslayer/DemonSlayer.java
+++ b/src/main/java/com/questhelper/quests/demonslayer/DemonSlayer.java
@@ -33,10 +33,7 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.conditional.NpcCondition;
@@ -50,7 +47,6 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -221,7 +217,7 @@ public class DemonSlayer extends BasicQuestHelper
 		getSilverlightBack = new NpcStep(this, NpcID.SIR_PRYSIN, new WorldPoint(3203, 3472, 0), "Get Silverlight back from Sir Prysin in the south west of Varrock Castle.");
 		returnToPrysin.addSubSteps(getSilverlightBack);
 
-		killDelrithStep = new NpcStep(this, NpcID.DELRITH, new WorldPoint(3227, 3370, 0), "Kill Delrith (level 27) using Silverlight at the dark wizards south of Varrock. Once defeated, you'll need to say the magic words to banish him.", silverlightEquipped, combatGear);
+		killDelrithStep = new CombatStep(this, NpcID.DELRITH, new WorldPoint(3227, 3370, 0), "Kill Delrith (level 27) using Silverlight at the dark wizards south of Varrock. Once defeated, you'll need to say the magic words to banish him.", "Delrith (level 27)", silverlightEquipped, combatGear);
 
 		killDelrith = new IncantationStep(this, killDelrithStep);
 	}
@@ -239,9 +235,12 @@ public class DemonSlayer extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Delrith (level 27)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDelrith);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
+++ b/src/main/java/com/questhelper/quests/deserttreasure/DesertTreasure.java
@@ -46,11 +46,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -444,7 +440,7 @@ public class DesertTreasure extends BasicQuestHelper
 		enterFareedRoom = new ObjectStep(this, ObjectID.GATE_6452, new WorldPoint(3305, 9376, 0),
 			"Enter the gate in the east of the dungeon. Be prepared to fight Fareed. If you aren't wearing ice gloves he'll unequip your weapon.", iceGloves, waterSpellOrMelee);
 		useWarmKey.addSubSteps(enterFareedRoom);
-		killFareed = new NpcStep(this, NpcID.FAREED, new WorldPoint(3315, 9375, 0), "Kill Fareed. Either use melee with ice gloves, or water spells.", iceGloves, waterSpellOrMelee);
+		killFareed = new CombatStep(this, NpcID.FAREED, new WorldPoint(3315, 9375, 0), "Kill Fareed. Either use melee with ice gloves, or water spells.", "Fareed (level 167)", iceGloves, waterSpellOrMelee);
 
 		talkToRasolo = new NpcStep(this, NpcID.RASOLO, new WorldPoint(2531, 3420, 0), "Talk to Rasolo south of Baxtorian Falls.");
 		talkToRasolo.addDialogStep("Ask about the Diamonds of Azzanadra");
@@ -466,7 +462,7 @@ public class DesertTreasure extends BasicQuestHelper
 
 		waitForDamis = new DetailedQuestStep(this, new WorldPoint(2745, 5115, 0), "Go to the far eastern room of the dungeon, and wait for Damis to spawn.");
 
-		killDamis1 = new NpcStep(this, NpcID.DAMIS, new WorldPoint(2745, 5115, 0), "Kill both phases of Damis. You can safespot him by attacking a bat and keeping the bat between the two of you.");
+		killDamis1 = new CombatStep(this, NpcID.DAMIS, new WorldPoint(2745, 5115, 0), "Kill both phases of Damis. You can safespot him by attacking a bat and keeping the bat between the two of you.", "Damis (level 103, then level 174 in second phase)");
 		killDamis2 = new NpcStep(this, NpcID.DAMIS_683, new WorldPoint(2745, 5115, 0), "Kill both phases of Damis. You can safespot him by attacking a bat and keeping the bat between the two of you.");
 		killDamis1.addSubSteps(killDamis2);
 
@@ -487,7 +483,7 @@ public class DesertTreasure extends BasicQuestHelper
 		usePotOnGrave = new ObjectStep(this, ObjectID.VAMPYRE_TOMB, new WorldPoint(3570, 3402, 0),
 			"Use the blessed pot on the vampyre tomb in the graveyard south east of Canifis. Be prepared to fight Dessous.", potComplete);
 		usePotOnGrave.addIcon(ItemID.BLESSED_POT_4665);
-		killDessous = new NpcStep(this, NpcID.DESSOUS, new WorldPoint(3570, 3403, 0), "Kill Dessous.");
+		killDessous = new CombatStep(this, NpcID.DESSOUS, new WorldPoint(3570, 3403, 0), "Kill Dessous.", "Dessous (level 139)");
 
 		talkToMalakForDiamond = new NpcStep(this, NpcID.MALAK, new WorldPoint(3496, 3479, 0), "Return to Malak in Canifis to get the Blood Diamond.");
 
@@ -497,13 +493,13 @@ public class DesertTreasure extends BasicQuestHelper
 		talkToChildTroll.addDialogStep("Yes");
 
 		enterIceGate = new ObjectStep(this, ObjectID.ICE_GATE, new WorldPoint(2838, 3740, 0), "Enter the ice gate east of the troll child. Make sure you're prepared for combat, and your stats to be continually drained.", fireSpells, spikedBoots);
-		killIceTrolls = new NpcStep(this, NpcID.ICE_TROLL_699, new WorldPoint(2854, 3733, 0), "Kill 5 ice trolls.", true);
+		killIceTrolls = new CombatStep(this, NpcID.ICE_TROLL_699, new WorldPoint(2854, 3733, 0), "Kill 5 ice trolls.", "5 ice trolls (level 120-124)", true);
 		killIceTrolls.addAlternateNpcs(NpcID.ICE_TROLL_700, NpcID.ICE_TROLL_701, NpcID.ICE_TROLL_702, NpcID.ICE_TROLL_703, NpcID.ICE_TROLL_704, NpcID.ICE_TROLL_705);
 		enterTrollCave = new ObjectStep(this, NullObjectID.NULL_6440, new WorldPoint(2869, 3719, 0), "Continue along the path through the cave to the east.");
 
-		killKamil = new NpcStep(this, NpcID.KAMIL, new WorldPoint(2863, 3757, 0),
+		killKamil = new CombatStep(this, NpcID.KAMIL, new WorldPoint(2863, 3757, 0),
 			"Continue along the path until you find Kamil. Kill him with fire spells. Get into melee distance and " +
-				"protect from melee.", fireSpells);
+				"protect from melee.", "Kamil (level 154)", fireSpells);
 		climbOnToLedge = new ObjectStep(this, ObjectID.ICE_LEDGE, new WorldPoint(2837, 3804, 0),
 			"Equip the spiked boots, then continue along the path until you reach an ice ledge. Climb up it.", spikedBootsEquipped);
 		goThroughPathGate = new ObjectStep(this, ObjectID.ICE_GATE_6462, new WorldPoint(2854, 3811, 1),
@@ -573,14 +569,15 @@ public class DesertTreasure extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Dessous (level 139)");
-		reqs.add("Kamil (level 154)");
-		reqs.add("Fareed (level 167)");
-		reqs.add("Damis (level 103, then level 174 in second phase)");
-		reqs.add("5 ice trolls (level 120-124)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDessous);
+		reqs.add(killKamil);
+		reqs.add(killFareed);
+		reqs.add(killDamis1);
+		reqs.add(killIceTrolls);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/deviousminds/DeviousMinds.java
+++ b/src/main/java/com/questhelper/quests/deviousminds/DeviousMinds.java
@@ -35,10 +35,7 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.Requirement;
 import java.util.*;
 import net.runelite.api.*;
@@ -47,7 +44,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
@@ -217,10 +213,13 @@ public class DeviousMinds extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return new ArrayList<>(Collections.singletonList("Survive against Abyssal Creatures in multicombat in the " +
-			"Abyss"));
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Survive against Abyssal Creatures in multicombat in the " +
+				"Abyss"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dragonslayer/DragonSlayer.java
+++ b/src/main/java/com/questhelper/quests/dragonslayer/DragonSlayer.java
@@ -33,6 +33,7 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.requirements.npc.NpcRequirement;
 import com.questhelper.requirements.quest.QuestPointRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
@@ -44,11 +45,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -78,6 +76,8 @@ public class DragonSlayer extends BasicQuestHelper
 		inRoomToBasement, inZombieRoom, inMelzarRoom, inDemonRoom, inLastMelzarRoom, hasShield, inShipHull, onShipDeck, hasBoughtBoat,
 		hasRepairedHullOnce, hasRepairedHullTwice, fullyRepairedHull, onCrandorSurface, inCrandorUnderground, inElvargArea, inKaramjaVolcano, unlockedShortcut;
 
+	NpcRequirement
+			enemRat, enemGhost, enemSkele, enemMelz, enemElvarg, enemDem, enemZomb;
 	ConditionalStep getLozarPiece, getThalzarPiece, getMelzarPiece, getShieldSteps;
 
 	QuestStep startQuest, talkToOziach, returnToGuildmaster, askAboutShield, askAboutMelzar, askAboutThalzar, askAboutLozar, talkToOracle,
@@ -392,28 +392,36 @@ public class DragonSlayer extends BasicQuestHelper
 		enterMelzarsMaze = new ObjectStep(this, ObjectID.DOOR_2595, new WorldPoint(2941, 3248, 0), "Enter Melzar's Maze north of Rimmington. Be prepared to fight multiple monsters up to a level 82 lesser demon.", melzarsKey);
 		enterMelzarsMaze.addDialogSteps("About my quest to kill the dragon...", "I talked to Oziach...", "How can I find the route to Crandor?", "Where is Melzar's map piece?");
 
-		killRat = new NpcStep(this, NpcID.ZOMBIE_RAT, new WorldPoint(2933, 3250, 0), "Kill the marked zombie rat for a key.");
+		killRat = new CombatStep(this, NpcID.ZOMBIE_RAT, new WorldPoint(2933, 3250, 0), "Kill the marked zombie rat for a key.", "Zombie Rat (level 3)");
+
+
 		openRedDoor = new ObjectStep(this, ObjectID.RED_DOOR, new WorldPoint(2926, 3253, 0), "Go through the north west red door", ratKey);
 		goUpRatLadder = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2928, 3256, 0), "Climb up the ladder.");
 
-		killGhost = new NpcStep(this, NpcID.GHOST_3975, new WorldPoint(2927, 3253, 1), "Kill the marked ghost for a key.", ghostKey);
+		killGhost = new CombatStep(this, NpcID.GHOST_3975, new WorldPoint(2927, 3253, 1), "Kill the marked ghost for a key.", "Ghosts (level 19)", ghostKey);
+
 
 		openOrangeDoor = new ObjectStep(this, ObjectID.ORANGE_DOOR, new WorldPoint(2931, 3253, 1), "Go through second yellow door from the north.", ghostKey);
 		goUpGhostLadder = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2934, 3254, 1), "Climb up the ladder.");
 
-		killSkeleton = new NpcStep(this, NpcID.SKELETON_3972, new WorldPoint(2927, 3253, 2), "Kill the marked skeleton for a key", skeletonKey);
+		killSkeleton = new CombatStep(this, NpcID.SKELETON_3972, new WorldPoint(2927, 3253, 2), "Kill the marked skeleton for a key", "Skeletons (level 22)", skeletonKey);
+
 		openYellowDoor = new ObjectStep(this, ObjectID.YELLOW_DOOR, new WorldPoint(2924, 3249, 2), "Go through south west yellow door.", skeletonKey);
 		goDownSkeletonLadder = new ObjectStep(this, ObjectID.LADDER_16679, new WorldPoint(2940, 3240, 2), "Climb down the ladder.");
 
 		goDownLadderRoomLadder = new ObjectStep(this, ObjectID.LADDER_16679, new WorldPoint(2937, 3240, 1), "Climb down again.");
 		goDownBasementEntryLadder = new ObjectStep(this, ObjectID.LADDER_2605, new WorldPoint(2932, 3240, 0), "Climb down the ladder into the basement.");
-		killZombie = new NpcStep(this, NpcID.ZOMBIE_3980, new WorldPoint(2932, 9643, 0), "Kill the marked zombie for a key", zombieKey);
+		killZombie = new CombatStep(this, NpcID.ZOMBIE_3980, new WorldPoint(2932, 9643, 0), "Kill the marked zombie for a key", "Zombies (level 24)", zombieKey);
+
 		openBlueDoor = new ObjectStep(this, ObjectID.BLUE_DOOR, new WorldPoint(2931, 9644, 0), "Go through the blue door in the north west corner.");
 
-		killMelzar = new NpcStep(this, NpcID.MELZAR_THE_MAD, new WorldPoint(2929, 9649, 0), "Kill Melzar the Mad for a magenta key.", melzarKey);
+		killMelzar = new CombatStep(this, NpcID.MELZAR_THE_MAD, new WorldPoint(2929, 9649, 0),
+				"Kill Melzar the Mad for a magenta key.", "Melzar the Mad (level 43)", melzarKey);
+
 		openMagntaDoor = new ObjectStep(this, ObjectID.MAGENTA_DOOR, new WorldPoint(2929, 9652, 0), "Go through the magenta door.");
 
-		killLesserDemon = new NpcStep(this, NpcID.LESSER_DEMON_3982, new WorldPoint(2936, 9652, 0), "Kill the lesser demon. You can safe spot it from the spot east of the magenta door.", demonKey);
+		killLesserDemon = new CombatStep(this, NpcID.LESSER_DEMON_3982, new WorldPoint(2936, 9652, 0), "Kill the lesser demon. You can safe spot it from the spot east of the magenta door.", "Lesser Demon (level 82) (safespottable)", demonKey);
+
 		openGreenDoor = new ObjectStep(this, ObjectID.GREEN_DOOR, new WorldPoint(2936, 9655, 0), "Go through the green door.", demonKey);
 
 		openMelzarChest = new ObjectStep(this, ObjectID.CHEST_2603, new WorldPoint(2935, 9657, 0), "Open the chest and get Melzar's map part.");
@@ -461,22 +469,23 @@ public class DragonSlayer extends BasicQuestHelper
 		repairShipAgainAndSail = new DetailedQuestStep(this, "As you did not unlock the shortcut, you will need to repair your ship again and sail to Crandor.", planks3, nails90, hammer);
 		enterElvargArea.addSubSteps(goDownIntoKaramjaVolcano, repairShipAgainAndSail);
 
-		killElvarg = new NpcStep(this, NpcID.ELVARG_8033, new WorldPoint(2855, 9637, 0), "Kill Elvarg.");
+
+		killElvarg = new CombatStep(this, NpcID.ELVARG_8033, new WorldPoint(2855, 9637, 0), "Kill Elvarg.", "Elvarg (level 83)");
 
 		finishQuest = new NpcStep(this, NpcID.OZIACH, new WorldPoint(3068, 3517, 0), "Talk to Oziach in his house in north western Edgeville to finish the quest.");
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Zombie rats (level 3)");
-		reqs.add("Ghosts (level 19)");
-		reqs.add("Skeletons (level 22)");
-		reqs.add("Zombies (level 24)");
-		reqs.add("Melzar the Mad (level 43)");
-		reqs.add("Lesser demon (level 82) (safespottable)");
-		reqs.add("Elvarg (level 83)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killRat);
+		reqs.add(killGhost);
+		reqs.add(killSkeleton);
+		reqs.add(killZombie);
+		reqs.add(killMelzar);
+		reqs.add(killLesserDemon);
+		reqs.add(killElvarg);
 
 		return reqs;
 	}
@@ -502,7 +511,6 @@ public class DragonSlayer extends BasicQuestHelper
 	public List<ItemRequirement> getItemRecommended()
 	{
 		ArrayList<ItemRequirement> reqs = new ArrayList<>();
-
 		reqs.add(chronicle);
 		reqs.add(rimmingtonTeleport);
 		reqs.add(edgevilleTeleport);

--- a/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
@@ -48,11 +48,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -726,7 +723,7 @@ public class DragonSlayerII extends BasicQuestHelper
 
 		enterBlockage = new ObjectStep(this, NullObjectID.NULL_29873, new WorldPoint(2860, 9648, 0), "Enter the passage in the north east of Elvarg's Lair.", combatGear);
 		investigateMural = new ObjectStep(this, ObjectID.ANCIENT_MURAL, new WorldPoint(2867, 9680, 0), "Inspect the mural.");
-		killSpawn = new NpcStep(this, NpcID.SPAWN_8056, new WorldPoint(2867, 9676, 0), "Kill the spawn.", combatGear);
+		killSpawn = new CombatStep(this, NpcID.SPAWN_8056, new WorldPoint(2867, 9676, 0), "Kill the spawn.", "Spawn (level 100)", combatGear);
 		investigateMuralAgain = new ObjectStep(this, ObjectID.ANCIENT_MURAL, new WorldPoint(2867, 9680, 0), "Investigate the mural again.");
 		talkToDallasAfterMural = new NpcStep(this, NpcID.DALLAS_JONES, new WorldPoint(2867, 9680, 0), "Talk to Dallas about the mural.");
 
@@ -803,7 +800,7 @@ public class DragonSlayerII extends BasicQuestHelper
 
 		talkToBobInDream = new NpcStep(this, NpcID.BOB_8112, new WorldPoint(1824, 5209, 2), "Talk to Bob in the dream.");
 		talkToBobInDream.addSubSteps(talkToBobToEnterDreamAgain);
-		killRobertTheStrong = new NpcStep(this, NpcID.ROBERT_THE_STRONG_8057, new WorldPoint(1824, 5224, 2), "When you're ready, fight Robert.");
+		killRobertTheStrong = new CombatStep(this, NpcID.ROBERT_THE_STRONG_8057, new WorldPoint(1824, 5224, 2), "When you're ready, fight Robert.", "Robert the Strong (level 194)");
 		killRobertTheStrong.addText("Use Protect from Missiles");
 		killRobertTheStrong.addText("When he shouts 'See if you can hide from this!', hide behind a pillar.");
 
@@ -850,8 +847,8 @@ public class DragonSlayerII extends BasicQuestHelper
 			"sidebar first.", rangedCombatGear);
 		((NpcStep) (killVorkath)).addAlternateNpcs(NpcID.VORKATH_8058, NpcID.VORKATH_8059, NpcID.VORKATH_8060, NpcID.VORKATH_8061);
 
-		killVorkathSidebar = new NpcStep(this, NpcID.VORKATH, new WorldPoint(2273, 4065, 0), "Defeat Vorkath. " +
-			"This is a hard fight, so if you're unfamiliar with it it's recommended you watch a video on it first.", rangedCombatGear);
+		killVorkathSidebar = new CombatStep(this, NpcID.VORKATH, new WorldPoint(2273, 4065, 0), "Defeat Vorkath. " +
+			"This is a hard fight, so if you're unfamiliar with it it's recommended you watch a video on it first.", "Vorkath (level 392)", rangedCombatGear);
 		killVorkathSidebar.addSubSteps(killVorkath);
 
 			killVorkathSidebar.addText("Protect from Magic, and drink an antifire and antivenom potion.");
@@ -1062,8 +1059,8 @@ public class DragonSlayerII extends BasicQuestHelper
 		killMithAddyAndRuneDragons.addText("Occasionally Galvek will shoot a fireball in the air, move to avoid it.");
 		killMithAddyAndRuneDragons.addText("");
 		((NpcStep) (killMithAddyAndRuneDragons)).addAlternateNpcs(NpcID.MITHRIL_DRAGON_8089, NpcID.ADAMANT_DRAGON, NpcID.ADAMANT_DRAGON_8090, NpcID.RUNE_DRAGON, NpcID.RUNE_DRAGON_8091);
-		killGalvek = new NpcStep(this, NpcID.GALVEK_8095, new WorldPoint(1631, 5735, 2), "Kill Galvek. Read the " +
-			"sidebar for more details.",true);
+		killGalvek = new CombatStep(this, NpcID.GALVEK_8095, new WorldPoint(1631, 5735, 2), "Kill Galvek. Read the " +
+			"sidebar for more details.", "Galvek (level 608)", true);
 		((NpcStep) (killGalvek)).addAlternateNpcs(NpcID.GALVEK_8096, NpcID.GALVEK_8097, NpcID.GALVEK_8098);
 
 		killGalvekSidebar = new NpcStep(this, NpcID.GALVEK_8095, new WorldPoint(1631, 5735, 2),
@@ -1139,9 +1136,16 @@ public class DragonSlayerII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Spawn (level 100)", "Robert the Strong (level 194)", "Vorkath (level 392)", "Numerous chromatic and metal dragons", "Galvek (level 608)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSpawn);
+		reqs.add(killRobertTheStrong);
+		reqs.add(killVorkath);
+		reqs.add(new CombatStep(this, -1, "Numerous chromatic and metal dragons"));
+		reqs.add(killGalvek);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/dreammentor/DreamMentor.java
+++ b/src/main/java/com/questhelper/quests/dreammentor/DreamMentor.java
@@ -46,11 +46,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -355,10 +352,10 @@ public class DreamMentor extends BasicQuestHelper
 		talkToCyrisusForDream = new NpcStep(this, NpcID.CYRISUS_3468, new WorldPoint(2075, 3912, 0), "Talk to Cyrisus to enter the dream.", combatGear, sealOfPassage);
 		((NpcStep) (talkToCyrisusForDream)).addAlternateNpcs(NpcID.CYRISUS_3469, NpcID.CYRISUS_3470, NpcID.CYRISUS_3471);
 		talkToCyrisusForDream.addDialogStep("Yes, let's go!");
-		killInadaquacy = new NpcStep(this, NpcID.THE_INADEQUACY, new WorldPoint(1824, 5150, 2), "Kill The Inadequacy.");
-		killEverlasting = new NpcStep(this, NpcID.THE_EVERLASTING, new WorldPoint(1824, 5150, 2), "Kill The Everlasting. You can safe spot it by the entry book.");
-		killUntouchable = new NpcStep(this, NpcID.THE_UNTOUCHABLE, new WorldPoint(1824, 5150, 2), "Kill The Untouchable. You can safe spot it by the entry book.");
-		killIllusive = new NpcStep(this, NpcID.THE_ILLUSIVE, new WorldPoint(1824, 5150, 2), "Kill The Illusive.");
+		killInadaquacy = new CombatStep(this, NpcID.THE_INADEQUACY, new WorldPoint(1824, 5150, 2), "Kill The Inadequacy.", "The Inadequacy (level 343)");
+		killEverlasting = new CombatStep(this, NpcID.THE_EVERLASTING, new WorldPoint(1824, 5150, 2), "Kill The Everlasting. You can safe spot it by the entry book.", "The Everlasting (level 223, safespottable)");
+		killUntouchable = new CombatStep(this, NpcID.THE_UNTOUCHABLE, new WorldPoint(1824, 5150, 2), "Kill The Untouchable. You can safe spot it by the entry book.", "The Untouchable (level 274, safespottable)");
+		killIllusive = new CombatStep(this, NpcID.THE_ILLUSIVE, new WorldPoint(1824, 5150, 2), "Kill The Illusive.", "The Illusive (level 108, won't attack you)");
 		returnToOneiromancer = new NpcStep(this, NpcID.ONEIROMANCER, new WorldPoint(2151, 3867, 0), "Talk to the Oneiromancer to finish the quest!", sealOfPassage);
 		returnToOneiromancer.addDialogStep("Cyrisus.");
 	}
@@ -370,9 +367,15 @@ public class DreamMentor extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("The Inadequacy (level 343)", "The Everlasting (level 223, safespottable)", "The Untouchable (level 274, safespottable)", "The Illusive (level 108, won't attack you)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killInadaquacy);
+		reqs.add(killEverlasting);
+		reqs.add(killUntouchable);
+		reqs.add(killIllusive);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/elementalworkshopi/ElementalWorkshopI.java
+++ b/src/main/java/com/questhelper/quests/elementalworkshopi/ElementalWorkshopI.java
@@ -46,12 +46,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -209,8 +205,8 @@ public class ElementalWorkshopI extends ComplexStateQuestHelper
 		useLavaOnFurnace.addIcon(ItemID.A_STONE_BOWL_2889);
 		mineRock = new NpcStep(this, NpcID.ELEMENTAL_ROCK, new WorldPoint(2703, 9894, 0),
 			"Mine one of the elemental rocks in the west room, ready to fight a level 35.", true, pickaxe);
-		killRock = new NpcStep(this, NpcID.EARTH_ELEMENTAL_1367, new WorldPoint(2703, 9897, 0),
-			"Kill the rock elemental that appeared.");
+		killRock = new CombatStep(this, NpcID.EARTH_ELEMENTAL_1367, new WorldPoint(2703, 9897, 0),
+			"Kill the rock elemental that appeared.", "Earth elemental (level 35)");
 		pickUpOre = new ItemStep(this, "Pick up the elemental ore.", elementalOre);
 		forgeBar = new ObjectStep(this, NullObjectID.NULL_3410, new WorldPoint(2726, 9875, 0),
 			"Use the elemental ore on the furnace in the south room.", elementalOre, coal4);
@@ -308,9 +304,12 @@ public class ElementalWorkshopI extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Earth elemental (level 35)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killRock);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/elementalworkshopii/ElementalWorkshopII.java
+++ b/src/main/java/com/questhelper/quests/elementalworkshopii/ElementalWorkshopII.java
@@ -48,12 +48,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -453,8 +449,8 @@ public class ElementalWorkshopII extends BasicQuestHelper
 		mineRock = new NpcStep(this, NpcID.ELEMENTAL_ROCK, new WorldPoint(2703, 9894, 0),
 			"You need 2 elemental bars. Mine one of the elemental rocks in the west room, ready to fight a level 35.",
 			true, pickaxe);
-		killRock = new NpcStep(this, NpcID.EARTH_ELEMENTAL_1367, new WorldPoint(2703, 9897, 0),
-			"Kill the rock elemental that appeared.");
+		killRock = new CombatStep(this, NpcID.EARTH_ELEMENTAL_1367, new WorldPoint(2703, 9897, 0),
+			"Kill the rock elemental that appeared.", "2 Earth elementals (level 35)");
 		pickUpOre = new ItemStep(this, "Pick up the elemental ore.", elementalOre);
 		forgeBars = new ObjectStep(this, NullObjectID.NULL_3410, new WorldPoint(2726, 9875, 0),
 			"Use the elemental ores on the furnace in the south room.", elementalOre.quantity(2), coal.quantity(8));
@@ -618,9 +614,12 @@ public class ElementalWorkshopII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("2 Earth elementals (level 35)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killRock);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/ernestthechicken/ErnestTheChicken.java
+++ b/src/main/java/com/questhelper/quests/ernestthechicken/ErnestTheChicken.java
@@ -40,11 +40,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -249,10 +246,11 @@ public class ErnestTheChicken extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Able to survive a skeleton (level 22) attacking you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.SKELETON, "Able to survive a skeleton (level 22) attacking you"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
+++ b/src/main/java/com/questhelper/quests/fairytalei/FairytaleI.java
@@ -42,12 +42,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -270,8 +266,8 @@ public class FairytaleI extends BasicQuestHelper
 					dramenOrLunarStaff, magicSecateurs);
 		enterTanglefootRoom = new ObjectStep(this, NullObjectID.NULL_11999, new WorldPoint(2399, 4379, 0),
 			"Enter the tanglefoot lair in the south of Zanaris, near the cosmic altar.", magicSecateursEquipped, food);
-		killTanglefoot = new NpcStep(this, NpcID.TANGLEFOOT, new WorldPoint(2375, 4385, 0), "Kill the large " +
-			"Tanglefoot with the Magic Secateurs. You can flinch it on a corner.", magicSecateursEquipped);
+		killTanglefoot = new CombatStep(this, NpcID.TANGLEFOOT, new WorldPoint(2375, 4385, 0), "Kill the large " +
+			"Tanglefoot with the Magic Secateurs. You can flinch it on a corner.", "Tanglefoot (level 111)", magicSecateursEquipped);
 		pickUpSecateurs = new ItemStep(this, "Pick up the queen's secateurs.", queensSecateurs);
 
 		enterZanarisForEnd = new ObjectStep(this, ObjectID.DOOR_2406, new WorldPoint(3202, 3169, 0),
@@ -303,9 +299,12 @@ public class FairytaleI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Tanglefoot (level 111)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killTanglefoot);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/fairytaleii/FairytaleII.java
+++ b/src/main/java/com/questhelper/quests/fairytaleii/FairytaleII.java
@@ -47,12 +47,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -327,7 +323,7 @@ public class FairytaleII extends BasicQuestHelper
 		goToDir = new ObjectStep(this, NullObjectID.NULL_29560, "Travel to D.I.R. with a Fairy Ring, ready to kill a " +
 			"Gorak. Goraks can hit through protection prayers.", dramenOrLunarStaff.equipped(), combatGear);
 		((ObjectStep) goToDir).addAlternateObjects(NullObjectID.NULL_29495);
-		killGorak = new NpcStep(this, NpcID.GORAK, "Kill Goraks for their claws.", true);
+		killGorak = new CombatStep(this, NpcID.GORAK, "Kill Goraks for their claws.", "At least 1 Gorak (level 145)", true);
 		pickupGorakClaw = new ItemStep(this, "Pickup the gorak's claws.", gorakClaw);
 
 		useStarFlowerOnVial = new DetailedQuestStep(this, "Add the star flower to a vial of water.",
@@ -378,9 +374,12 @@ public class FairytaleII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("At least 1 Gorak (level 145)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGorak);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/familycrest/FamilyCrest.java
+++ b/src/main/java/com/questhelper/quests/familycrest/FamilyCrest.java
@@ -39,12 +39,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -288,9 +284,9 @@ public class FamilyCrest extends BasicQuestHelper
 			"Enter the Edgeville Wilderness Dungeon, ready to kill Chronozon. Other players will be able to attack you.", runesForBlasts);
 		goDownToChronizon.addAlternateObjects(ObjectID.TRAPDOOR_1579);
 
-		killChronizon = new NpcStep(this, NpcID.CHRONOZON, new WorldPoint(3087, 9936, 0),
+		killChronizon = new CombatStep(this, NpcID.CHRONOZON, new WorldPoint(3087, 9936, 0),
 			"Kill Chronozon in the south west corner of the Edgeville Wilderness Dungeon. You need to hit him at least once with all 4 elemental blast spell.",
-			runesForBlasts);
+				"Chronozon (level 170, in the Wilderness)", runesForBlasts);
 		killChronizon.addSubSteps(goDownToChronizon);
 
 		pickUpCrest3 = new ItemStep(this, "Pick up the crest part.", crestPiece3);
@@ -336,10 +332,11 @@ public class FamilyCrest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Chronozon (level 170, in the Wilderness)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killChronizon);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/fightarena/FightArena.java
+++ b/src/main/java/com/questhelper/quests/fightarena/FightArena.java
@@ -40,10 +40,8 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -180,20 +178,20 @@ public class FightArena extends BasicQuestHelper
 			"Get ready to fight the monsters (all safespottable), starting with Khazard Ogre (level 63). Use the keys on Sammy's cell door to free him.", combatGear, cellKeys);
 		openCell.addIcon(ItemID.KHAZARD_CELL_KEYS);
 		talkToSammy = new NpcStep(this, NpcID.SAMMY_SERVIL_1221, new WorldPoint(2602, 3153, 0), "Talk to Sammy, then fight the ogre.");
-		killOgre = new NpcStep(this, NpcID.KHAZARD_OGRE, new WorldPoint(2601, 3163, 0),
-			"Kill the Ogre. You can lure it behind a skeleton to safespot it.", combatGear);
+		killOgre = new CombatStep(this, NpcID.KHAZARD_OGRE, new WorldPoint(2601, 3163, 0),
+			"Kill the Ogre. You can lure it behind a skeleton to safespot it.", "Khazard Ogre (level 63) (safespottable)", combatGear);
 		killOgre.addSubSteps(talkToSammy);
-		talkToKhazard = new NpcStep(this, NpcID.GENERAL_KHAZARD, new WorldPoint(2605, 3153, 0), "Talk to General Khazard.");
+		talkToKhazard = new CombatStep(this, NpcID.GENERAL_KHAZARD, new WorldPoint(2605, 3153, 0), "Talk to General Khazard.", "General Khazard (level 112) (safespottable) (optional)");
 		talkToHengrad = new NpcStep(this, NpcID.HENGRAD, new WorldPoint(2599, 3143, 0),
 			"Talk to Hengrad.");
 		talkToHengrad.addSubSteps(talkToKhazard);
 		talkToSammyForScorpion = new NpcStep(this, NpcID.SAMMY_SERVIL_1221, new WorldPoint(2602, 3153, 0), "Talk to Sammy, then fight the scorpion.");
-		killScorpion = new NpcStep(this, NpcID.KHAZARD_SCORPION, new WorldPoint(2601, 3163, 0),
-			"Kill the Scorpion. You can lure it behind a skeleton to safespot it.", combatGear);
+		killScorpion = new CombatStep(this, NpcID.KHAZARD_SCORPION, new WorldPoint(2601, 3163, 0),
+			"Kill the Scorpion. You can lure it behind a skeleton to safespot it.", "Khazard Scorpion (level 44) (safespottable)", combatGear);
 		killScorpion.addSubSteps(talkToSammyForScorpion);
 		talkToSammyForBouncer = new NpcStep(this, NpcID.SAMMY_SERVIL_1221, new WorldPoint(2602, 3153, 0), "Talk to Sammy, then fight Bouncer.");
-		killBouncer = new NpcStep(this, NpcID.BOUNCER, new WorldPoint(2601, 3163, 0),
-			"Kill Bouncer. You can lure it behind a skeleton to safespot it. Warning: After Bouncer is killed, you will be unable to re-enter the arena.", combatGear);
+		killBouncer = new CombatStep(this, NpcID.BOUNCER, new WorldPoint(2601, 3163, 0),
+			"Kill Bouncer. You can lure it behind a skeleton to safespot it. Warning: After Bouncer is killed, you will be unable to re-enter the arena.", "Bouncer (level 137) (safespottable)", combatGear);
 		killBouncer.addSubSteps(talkToSammyForBouncer);
 		leaveArena = new ObjectStep(this, ObjectID.DOOR_82, new WorldPoint(2606, 3152, 0),
 			"Exit the arena (can ignore General Khazard). Warning: You will be unable to re-enter the arena.");
@@ -214,13 +212,14 @@ public class FightArena extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Khazard Scorpion (level 44) (safespottable)");
-		reqs.add("Khazard Ogre (level 63) (safespottable)");
-		reqs.add("Bouncer (level 137) (safespottable)");
-		reqs.add("General Khazard (level 112) (safespottable) (optional)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killScorpion);
+		reqs.add(killOgre);
+		reqs.add(killBouncer);
+		reqs.add(talkToKhazard);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/gettingahead/GettingAhead.java
+++ b/src/main/java/com/questhelper/quests/gettingahead/GettingAhead.java
@@ -42,12 +42,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -260,8 +256,8 @@ public class GettingAhead extends BasicQuestHelper
 
 		goToMine = new ObjectStep(this, ObjectID.CAVE_20852, new WorldPoint(1212, 3647, 0), "Enter the Kebos Lowlands mine just west of the bridge and kill the Headless Beast (level 82).");
 		goToMine.addDialogStep("Yes.");
-		killBeast = new NpcStep(this, NpcID.HEADLESS_BEAST_10506, new WorldPoint(1191, 10021, 0), "Kill the headless " +
-			"beast. You can safespot it from the south west corner of the pond in the cave.");
+		killBeast = new CombatStep(this, NpcID.HEADLESS_BEAST_10506, new WorldPoint(1191, 10021, 0), "Kill the headless " +
+			"beast. You can safespot it from the south west corner of the pond in the cave.", "Headless Beast (level 82, safespottable)");
 		((NpcStep) killBeast).addSafeSpots(new WorldPoint(1190, 10017, 0));
 		goToMine.addSubSteps(killBeast);
 
@@ -319,9 +315,12 @@ public class GettingAhead extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Headless Beast (level 82, safespottable)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBeast);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/ghostsahoy/GhostsAhoy.java
+++ b/src/main/java/com/questhelper/quests/ghostsahoy/GhostsAhoy.java
@@ -43,13 +43,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.util.LogicType;
@@ -350,7 +344,7 @@ public class GhostsAhoy extends BasicQuestHelper
 
 		searchChestForLobster = new ObjectStep(this, ObjectID.CLOSED_CHEST_16118, new WorldPoint(3618, 3542, 0), "Attempt to search the chest in the east of the hull of the ship west of Port Phasmatys. A giant lobster will spawn you need to kill.");
 		((ObjectStep) (searchChestForLobster)).addAlternateObjects(ObjectID.OPEN_CHEST_16119);
-		killLobster = new NpcStep(this, NpcID.GIANT_LOBSTER, "Kill the Giant Lobster.");
+		killLobster = new CombatStep(this, NpcID.GIANT_LOBSTER, "Kill the Giant Lobster.", "Giant lobster (level 32) (safespottable)");
 		searchChestAfterLobster = new ObjectStep(this, ObjectID.CLOSED_CHEST_16118, new WorldPoint(3618, 3542, 0), "Search the chest in the east of the hull again.");
 		((ObjectStep) (searchChestAfterLobster)).addAlternateObjects(ObjectID.OPEN_CHEST_16119);
 
@@ -444,9 +438,12 @@ public class GhostsAhoy extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Giant lobster (level 32) (safespottable)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killLobster);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/grimtales/GrimTales.java
+++ b/src/main/java/com/questhelper/quests/grimtales/GrimTales.java
@@ -43,13 +43,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.WidgetStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -354,7 +349,7 @@ public class GrimTales extends BasicQuestHelper
 		climbBean = new ObjectStep(this, NullObjectID.NULL_24884, new WorldPoint(2922, 3425, 0), "Climb the bean stalk, ready to fight Glod.", combatGear);
 		climbBeanForStatue = new ObjectStep(this, NullObjectID.NULL_24884, new WorldPoint(2922, 3425, 0), "Climb the bean stalk for another golden goblin.");
 
-		killGlod = new NpcStep(this, NpcID.GLOD, "Kill Glod.");
+		killGlod = new CombatStep(this, NpcID.GLOD, "Kill Glod.", "Glod (level 138)");
 
 		pickUpGoldenGoblin = new ItemStep(this, "Pick up the golden goblin.", goldenGoblin);
 
@@ -374,10 +369,11 @@ public class GrimTales extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Glod (level 138)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGlod);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
+++ b/src/main/java/com/questhelper/quests/hauntedmine/HauntedMine.java
@@ -46,11 +46,7 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -352,7 +348,7 @@ public class HauntedMine extends BasicQuestHelper
 
 		tryToPickUpKey = new NpcStep(this, NpcID.INNOCENTLOOKING_KEY, new WorldPoint(2788, 4455, 0), "Attempt to pick up the innocent-looking key. Treus Dayth (level 95) will spawn. Kill him.");
 
-		killDayth = new NpcStep(this, NpcID.TREUS_DAYTH, new WorldPoint(2788, 4450, 0), "Kill Treus Dayth.");
+		killDayth = new CombatStep(this, NpcID.TREUS_DAYTH, new WorldPoint(2788, 4450, 0), "Kill Treus Dayth.", "Treus Dayth (level 95)");
 
 		tryToPickUpKey.addSubSteps(killDayth);
 
@@ -386,10 +382,11 @@ public class HauntedMine extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Treus Dayth (level 95)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDayth);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/hazeelcult/HazeelCult.java
+++ b/src/main/java/com/questhelper/quests/hazeelcult/HazeelCult.java
@@ -41,11 +41,8 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -292,8 +289,8 @@ public class HazeelCult extends BasicQuestHelper
 			"Re-enter the cave.");
 		boardRaftToKill = new ObjectStep(this, ObjectID.RAFT, new WorldPoint(2568, 9679, 0),
 			"Board the raft.");
-		killAlomone = new NpcStep(this, NpcID.ALOMONE, new WorldPoint(2607, 9673, 0),
-			"Kill Almone and pickup the carnillean armour.");
+		killAlomone = new CombatStep(this, NpcID.ALOMONE, new WorldPoint(2607, 9673, 0),
+			"Kill Almone and pickup the carnillean armour.", "Alomone (level 13) if taking Ceril's side");
 		pickupArmour = new ItemStep(this, "Pickup the armour.", carnilleanArmour);
 		killAlomone.addSubSteps(pickupArmour);
 		returnOnRaftAfterKilling = new ObjectStep(this, ObjectID.RAFT, new WorldPoint(2607, 9693, 0),
@@ -324,9 +321,12 @@ public class HazeelCult extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Alomone (level 13) if taking Ceril's side");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killAlomone);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/quests/heroesquest/HeroesQuest.java
@@ -46,12 +46,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -391,7 +387,7 @@ public class HeroesQuest extends BasicQuestHelper
 		pushWall = new ObjectStep(this, ObjectID.WALL_2629, new WorldPoint(2787, 3190, 0), "Push the wall to enter Pete's garden.");
 		useKeyOnDoor = new ObjectStep(this, ObjectID.DOOR_2622, new WorldPoint(2781, 3197, 0), "Use the misc key on the door to the north west.", miscKey);
 		useKeyOnDoor.addIcon(ItemID.MISCELLANEOUS_KEY);
-		killGrip = new NpcStep(this, NpcID.GRIP, new WorldPoint(2775, 3192, 0), "Wait for your partner to lure Grip into the room next to yours, and kill him with magic/ranged. Afterwards, trade your partner for a candlestick.");
+		killGrip = new CombatStep(this, NpcID.GRIP, new WorldPoint(2775, 3192, 0), "Wait for your partner to lure Grip into the room next to yours, and kill him with magic/ranged. Afterwards, trade your partner for a candlestick.", "Grip (level 26)");
 		getCandlestick = new DetailedQuestStep(this, "Get your candlestick from your partner.");
 		killGrip.addSubSteps(getCandlestick);
 		enterPhoenixBaseAgain = new ObjectStep(this, ObjectID.LADDER_11803, new WorldPoint(3244, 3383, 0), "Bring the candlestick back to Straven.");
@@ -404,7 +400,7 @@ public class HeroesQuest extends BasicQuestHelper
 		takeLadder3Down = new ObjectStep(this, ObjectID.LADDER_16680, new WorldPoint(2827, 3510, 0), "Take the east ladder down.");
 		takeLadder4Up = new ObjectStep(this, ObjectID.LADDER_17385, new WorldPoint(2857, 9917, 0), "Follow the path around until you reach a ladder, then climb it.");
 		takeLadder5Down = new ObjectStep(this, ObjectID.LADDER_16680, new WorldPoint(2859, 3519, 0), "Take the south ladder down.");
-		killIceQueen = new NpcStep(this, NpcID.ICE_QUEEN, new WorldPoint(2865, 9948, 0), "Kill the Ice Queen for ice gloves.");
+		killIceQueen = new CombatStep(this, NpcID.ICE_QUEEN, new WorldPoint(2865, 9948, 0), "Kill the Ice Queen for ice gloves.", "Ice Queen (level 111) for ice gloves");
 		pickupIceGloves = new DetailedQuestStep(this, "Pick up the ice gloves.", iceGloves);
 		killIceQueen.addSubSteps(pickupIceGloves);
 
@@ -416,13 +412,13 @@ public class HeroesQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Ice Queen (level 111) for ice gloves");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killIceQueen);
 		if (!inBlackArmGang.check(client))
 		{
-			reqs.add("Grip (level 26)");
+			reqs.add(killGrip);
 		}
 		return reqs;
 	}

--- a/src/main/java/com/questhelper/quests/holygrail/HolyGrail.java
+++ b/src/main/java/com/questhelper/quests/holygrail/HolyGrail.java
@@ -34,8 +34,7 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.conditional.NpcCondition;
@@ -57,10 +56,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.widgets.WidgetInfo;
 
 @QuestDescriptor(
@@ -273,7 +268,7 @@ public class HolyGrail extends BasicQuestHelper
 		goToTeleportLocation1 = new DetailedQuestStep(this, teleportLocationPoint, "Go to the tower on Karamja near gold mine west of Brimhaven.", twoMagicWhistles, excalibur);
 		blowWhistle1 = new ItemStep(this, "Blow the whistle once you are underneath of the tower.", highlightMagicWhistle1, excalibur);
 
-		attackTitan = new NpcStep(this, NpcID.BLACK_KNIGHT_TITAN, "Kill the Black Knight Titan with Excalibur. (You only need to deal the killing blow with excalibur!)", twoMagicWhistles, excalibur);
+		attackTitan = new CombatStep(this, NpcID.BLACK_KNIGHT_TITAN, "Kill the Black Knight Titan with Excalibur. (You only need to deal the killing blow with excalibur!)", "Black Knight Titan (level 120)", twoMagicWhistles, excalibur);
 		talkToFisherman = new NpcStep(this, NpcID.FISHERMAN_4065, new WorldPoint(2798, 4706, 0), "Talk to the fisherman by the river. After talking to him walk West to the castle.");
 		talkToFisherman.addDialogStep("Any idea how to get into the castle?");
 		pickupBell = new DetailedQuestStep(this, new WorldPoint(2762, 4694, 0), "Pickup the bell outside of the castle.");
@@ -301,10 +296,11 @@ public class HolyGrail extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Black Knight Titan (level 120)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(attackTitan);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/hopespearswill/HopespearsWill.java
+++ b/src/main/java/com/questhelper/quests/hopespearswill/HopespearsWill.java
@@ -231,11 +231,11 @@ public class HopespearsWill extends BasicQuestHelper
 				"Unequip all weapons and armour (the ring of visibility and ghostspeak amulet can stay on but you MUST unequip Morytania legs). Say Strongbones's name at the north grave.");
 		sayNameStrongbones.addDialogStep("Strongbones.");
 
-		defeatSnothead = new NpcStep(this, NpcID.SNOTHEAD, "Defeat Snothead WITHOUT using weapons, armour, or magic. He attacks using melee.");
-		defeatSnailfeet = new NpcStep(this, NpcID.SNAILFEET, "Defeat Snailfeet WITHOUT using weapons, armour, or magic. He attacks using melee and range.");
-		defeatMosschin = new NpcStep(this, NpcID.MOSSCHIN, "Defeat Mosschin WITHOUT using weapons, armour, or magic. He attacks using melee and magic.");
-		defeatRedeyes = new NpcStep(this, NpcID.REDEYES, "Defeat Redeyes WITHOUT using weapons, armour, or magic. He attacks using melee and magic, and lowers your attack, strength, and defence.");
-		defeatStrongbones = new NpcStep(this, NpcID.STRONGBONES, "Defeat Strongbones WITHOUT using weapons, armour, or magic. He attacks using all 3 combat styles, lowers your attack, strength and defence. Ignore the level 29 Skoblins he spawns.");
+		defeatSnothead = new CombatStep(this, NpcID.SNOTHEAD, "Defeat Snothead WITHOUT using weapons, armour, or magic. He attacks using melee.", "Snothead (level 32)");
+		defeatSnailfeet = new CombatStep(this, NpcID.SNAILFEET, "Defeat Snailfeet WITHOUT using weapons, armour, or magic. He attacks using melee and range.", "Snailfeet (level 56)");
+		defeatMosschin = new CombatStep(this, NpcID.MOSSCHIN, "Defeat Mosschin WITHOUT using weapons, armour, or magic. He attacks using melee and magic.", "Mosschin (level 88)");
+		defeatRedeyes = new CombatStep(this, NpcID.REDEYES, "Defeat Redeyes WITHOUT using weapons, armour, or magic. He attacks using melee and magic, and lowers your attack, strength, and defence.", "Redeyes (level 121)");
+		defeatStrongbones = new CombatStep(this, NpcID.STRONGBONES, "Defeat Strongbones WITHOUT using weapons, armour, or magic. He attacks using all 3 combat styles, lowers your attack, strength and defence. Ignore the level 29 Skoblins he spawns.", "Strongbones (level 184)");
 
 		pickUpSnotheadBone = new DetailedQuestStep(this, "Pick up Snothead's bone from the ground.", snotheadBones.hideConditioned(snotheadBuried));
 		pickUpSnailfeetBone = new DetailedQuestStep(this, "Pick up Snailfeet's bone from the ground.", snailfeetBones.hideConditioned(snailfeetBuried));
@@ -276,13 +276,16 @@ public class HopespearsWill extends BasicQuestHelper
 	}
 
 	@Override
-	public ArrayList<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return new ArrayList<>(ImmutableList.of("Snothead (level 32)",
-				"Snailfeet (level 56)",
-				"Mosschin (level 88)",
-				"Redeyes (level 121)",
-				"Strongbones (level 184)"));
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(defeatSnothead);
+		reqs.add(defeatSnailfeet);
+		reqs.add(defeatMosschin);
+		reqs.add(defeatRedeyes);
+		reqs.add(defeatStrongbones);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
+++ b/src/main/java/com/questhelper/quests/horrorfromthedeep/HorrorFromTheDeep.java
@@ -44,10 +44,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -295,10 +293,10 @@ public class HorrorFromTheDeep extends BasicQuestHelper
 		goThroughDoor = new ObjectStep(this, ObjectID.STRANGE_WALL_4545, new WorldPoint(2516, 4627, 0), "Go through " +
 			"the strange wall, ready for fighting.");
 		talkToJossik = new NpcStep(this, NpcID.JOSSIK_4424, new WorldPoint(2518, 4634, 0), "Talk to Jossik.");
-		killDagannoth = new NpcStep(this, NpcID.DAGANNOTH_979, new WorldPoint(2518, 4640, 0), "Defeat the dagannoth.");
-		killMother = new NpcStep(this, NpcID.DAGANNOTH_MOTHER, new WorldPoint(2518, 4640, 0), "Defeat the Dagannoth " +
+		killDagannoth = new CombatStep(this, NpcID.DAGANNOTH_979, new WorldPoint(2518, 4640, 0), "Defeat the dagannoth.", "Dagannoth (level 100)");
+		killMother = new CombatStep(this, NpcID.DAGANNOTH_MOTHER, new WorldPoint(2518, 4640, 0), "Defeat the Dagannoth " +
 			"mother. She can only be hurt by air spells when white, water spells when blue, earth spells when brown, " +
-			"fire spells when red, melee when orange and ranged when green.", protectFromMissiles, magicCombat, combatRunes);
+			"fire spells when red, melee when orange and ranged when green.", "Dagannoth Mother (level 100)", protectFromMissiles, magicCombat, combatRunes);
 		((NpcStep) killMother).addAlternateNpcs(NpcID.DAGANNOTH_MOTHER_981,
 			NpcID.DAGANNOTH_MOTHER_982, NpcID.DAGANNOTH_MOTHER_983, NpcID.DAGANNOTH_MOTHER_984,
 			NpcID.DAGANNOTH_MOTHER_985, NpcID.DAGANNOTH_MOTHER_986, NpcID.DAGANNOTH_MOTHER_987,
@@ -328,9 +326,13 @@ public class HorrorFromTheDeep extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Dagannoth (level 100)", "Dagannoth Mother (level 100)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDagannoth);
+		reqs.add(killMother);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
+++ b/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
@@ -49,11 +49,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -405,7 +402,7 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 
 		enterEastRoomAgain = new ObjectStep(this, ObjectID.DOOR_44060, new WorldPoint(3306, 9199, 0), "Enter the east room again.");
 
-		killPriest = new NpcStep(this, NpcID.POSSESSED_PRIEST, new WorldPoint(3306, 9196, 0), "Kill the possessed priest. Pray protect from magic against the priest.");
+		killPriest = new CombatStep(this, NpcID.POSSESSED_PRIEST, new WorldPoint(3306, 9196, 0), "Kill the possessed priest. Pray protect from magic against the priest.", "Possessed priest (level 91)");
 
 		talkToHighPriestInPyramid = new NpcStep(this, NpcID.HIGH_PRIEST_11603, new WorldPoint(3306, 9196, 0),
 			"Talk to the High Priest in the north east room of the pyramid.");
@@ -426,9 +423,13 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Level 75 or 81 guardian", "Possessed priest (level 91)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Level 75 or 81 guardian"));
+		reqs.add(killPriest);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/impcatcher/ImpCatcher.java
+++ b/src/main/java/com/questhelper/quests/impcatcher/ImpCatcher.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
+import com.questhelper.steps.CombatStep;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.Skill;
@@ -121,8 +122,11 @@ public class ImpCatcher extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Imps (level 2) if you plan on collecting the beads yourself");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.IMP, "Imps (level 2) if you plan on collecting the beads yourself"));
+
+		return reqs;
 	}
 }

--- a/src/main/java/com/questhelper/quests/inaidofthemyreque/InAidOfTheMyreque.java
+++ b/src/main/java/com/questhelper/quests/inaidofthemyreque/InAidOfTheMyreque.java
@@ -45,11 +45,8 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -572,9 +569,13 @@ public class InAidOfTheMyreque extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Gadderanks (level 35)", "Vampyre Juvenites (levels 50-75)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.GADDERANKS, "Gadderanks (level 35)"));
+		reqs.add(new CombatStep(this, NpcID.VAMPYRE_JUVINATE_4487, "Vampyre Juvenites (levels 50-75)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
+++ b/src/main/java/com/questhelper/quests/insearchofknowledge/InSearchOfKnowledge.java
@@ -39,11 +39,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -227,9 +224,12 @@ public class InSearchOfKnowledge extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Many monsters in the Forthos Dungeon");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Many monsters in the Forthos Dungeon"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/insearchofthemyreque/InSearchOfTheMyreque.java
+++ b/src/main/java/com/questhelper/quests/insearchofthemyreque/InSearchOfTheMyreque.java
@@ -44,11 +44,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -310,7 +307,7 @@ public class InSearchOfTheMyreque extends BasicQuestHelper
 			"Climb the tree to the north of the boat.", combatGear);
 		enterDoorsHellhound = new ObjectStep(this, ObjectID.WOODEN_DOORS_5061, new WorldPoint(3509, 3448, 0), "Enter the wooden doors north of Curpile.", combatGear);
 		enterCaveHellhound = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_5046, new WorldPoint(3492, 9823, 0), "Enter the cave to the north on the east side.");
-		killHellhound = new NpcStep(this, NpcID.SKELETON_HELLHOUND, new WorldPoint(3506, 9837, 0), "Kill the Skeleton Hellhound.");
+		killHellhound = new CombatStep(this, NpcID.SKELETON_HELLHOUND, new WorldPoint(3506, 9837, 0), "Kill the Skeleton Hellhound.", "Skeleton hellhound (level 97)");
 		killHellhound.addSubSteps(climbTreeHellhound, enterCaveHellhound, enterDoorsHellhound);
 
 		climbTreeLeave = new ObjectStep(this, NullObjectID.NULL_5003, new WorldPoint(3502, 3426, 0),
@@ -346,9 +343,12 @@ public class InSearchOfTheMyreque extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Skeleton hellhound (level 97)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killHellhound);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
+++ b/src/main/java/com/questhelper/quests/junglepotion/JunglePotion.java
@@ -37,11 +37,8 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -239,10 +236,12 @@ public class JunglePotion extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Survive against level 53 Jogres and level 46 Harpie Bug Swarms.");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.JOGRE, "Survive against Jogres (level 53)"));
+		reqs.add(new CombatStep(this, NpcID.HARPIE_BUG_SWARM, "Survive against Harpie Bug Swarms (level 46)"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/knightswaves/KnightWaves.java
+++ b/src/main/java/com/questhelper/quests/knightswaves/KnightWaves.java
@@ -34,8 +34,8 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,8 +48,6 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.QuestStep;
 import com.questhelper.QuestDescriptor;
 
 @QuestDescriptor(
@@ -192,8 +190,24 @@ public class KnightWaves extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("8 Knights of the Round Table (levels 110-127)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.SIR_BEDIVERE_4345,"Sir Bedivere (level 110)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_PELLEAS_4347, "Sir Pelleas (level 112)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_TRISTRAM, "Sir Tristram (level 115)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_PALOMEDES, "Sir Palomedes (level 118)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_LUCAN, "Sir Lucan (level 120)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_GAWAIN_4356, "Sir Gawain(level 122)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_KAY, "Sir Kay (level 124)"));
+		reqs.add(new CombatStep(this, NpcID.SIR_LANCELOT, "Sir Lancelot(level 126)"));
+
+		return reqs;
+	}
+
+	@Override
+	public List<String> getNotes()
+	{
+		return Collections.singletonList("Do not leave the training room via door. It will reset your wave back to the first one. If you die, you go back to the knight you left off on. You can also freely teleport out of the training room and it will save your progress.");
 	}
 }

--- a/src/main/java/com/questhelper/quests/lairoftarnrazorlor/LairOfTarnRazorlor.java
+++ b/src/main/java/com/questhelper/quests/lairoftarnrazorlor/LairOfTarnRazorlor.java
@@ -42,12 +42,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,7 +120,7 @@ public class LairOfTarnRazorlor extends BasicQuestHelper
 	public void setupSteps()
 	{
 		tarnRoute = new TarnRoute(this);
-		killTarn = new NpcStep(this, NpcID.MUTANT_TARN, new WorldPoint(3186, 4619, 0), "Kill Mutant and Ghost Tarn.");
+		killTarn = new CombatStep(this, NpcID.MUTANT_TARN, new WorldPoint(3186, 4619, 0), "Kill Mutant and Ghost Tarn.", "Tarn (level 69) twice");
 		killTarn.addAlternateNpcs(NpcID.TARN, NpcID.TARN_6476);
 
 		enterFinalRoom = new ObjectStep(this, ObjectID.PASSAGEWAY_15774, new WorldPoint(3186, 4627, 0), "Go into the north passageway. If you would like to complete a task for the Morytania Diary, you should kill a Terror Dog now.");
@@ -138,9 +134,12 @@ public class LairOfTarnRazorlor extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Tarn (level 69) twice");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killTarn);
+
+		return reqs;
 	}
 
 	@Override
@@ -149,6 +148,7 @@ public class LairOfTarnRazorlor extends BasicQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new QuestRequirement(QuestHelperQuest.HAUNTED_MINE, QuestState.FINISHED));
 		req.add(new SkillRequirement(Skill.SLAYER, 40));
+
 		return req;
 	}
 

--- a/src/main/java/com/questhelper/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/quests/landofthegoblins/LandOfTheGoblins.java
@@ -583,11 +583,11 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		sayNameStrongbones = new ObjectStep(this, ObjectID.GRAVE_43126, new WorldPoint(3742, 4393, 0), "Say Strongbones's name at the north grave.");
 		sayNameStrongbones.addDialogStep("Strongbones.");
 
-		defeatSnothead = new NpcStep(this, NpcID.SNOTHEAD, "Defeat Snothead. He attacks using melee.");
-		defeatSnailfeet = new NpcStep(this, NpcID.SNAILFEET, "Defeat Snailfeet. He attacks using melee and range.");
-		defeatMosschin = new NpcStep(this, NpcID.MOSSCHIN, "Defeat Mosschin. He attacks using melee and magic.");
-		defeatRedeyes = new NpcStep(this, NpcID.REDEYES, "Defeat Redeyes. He attacks using melee and magic, and lowers your attack, strength, and defence.");
-		defeatStrongbones = new NpcStep(this, NpcID.STRONGBONES, "Defeat Strongbones. He attacks using all 3 combat styles, lowers your attack, strength and defence. Ignore the level 29 Skoblins he spawns.");
+		defeatSnothead = new CombatStep(this, NpcID.SNOTHEAD, "Defeat Snothead. He attacks using melee.", "Snothead (level 32)");
+		defeatSnailfeet = new CombatStep(this, NpcID.SNAILFEET, "Defeat Snailfeet. He attacks using melee and range.", "Snailfeet (level 56)");
+		defeatMosschin = new CombatStep(this, NpcID.MOSSCHIN, "Defeat Mosschin. He attacks using melee and magic.", "Mosschin (level 88)");
+		defeatRedeyes = new CombatStep(this, NpcID.REDEYES, "Defeat Redeyes. He attacks using melee and magic, and lowers your attack, strength, and defence.", "Redeyes (level 121)");
+		defeatStrongbones = new CombatStep(this, NpcID.STRONGBONES, "Defeat Strongbones. He attacks using all 3 combat styles, lowers your attack, strength and defence. Ignore the level 29 Skoblins he spawns.", "Strongbones (level 184)");
 
 		learnSnailfeet = new NpcStep(this, NpcID.SNOTHEAD_11274, "Talk to Snothead to learn the name of the next priest.");
 		learnSnailfeet.addDialogStep("What was your predecessor's name?");
@@ -672,13 +672,16 @@ public class LandOfTheGoblins extends BasicQuestHelper
 	}
 
 	@Override
-	public ArrayList<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return new ArrayList<>(ImmutableList.of("Snothead (level 32)",
-				"Snailfeet (level 56)",
-				"Mosschin (level 88)",
-				"Redeyes (level 121)",
-				"Strongbones (level 184)"));
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(defeatSnothead);
+		reqs.add(defeatSnailfeet);
+		reqs.add(defeatMosschin);
+		reqs.add(defeatRedeyes);
+		reqs.add(defeatStrongbones);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/quests/legendsquest/LegendsQuest.java
@@ -51,12 +51,7 @@ import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -910,10 +905,10 @@ public class LegendsQuest extends BasicQuestHelper
 			yommiTotemHighlighted,	combatGear);
 		useTotemOnTotem.addAlternateObjects(ObjectID.TOTEM_POLE_2936);
 		useTotemOnTotem.addIcon(ItemID.YOMMI_TOTEM);
-		killRanalph = new NpcStep(this, NpcID.RANALPH_DEVERE, "Kill Ranalph.");
-		killIrvig = new NpcStep(this, NpcID.IRVIG_SENAY, "Kill Irvig.");
-		killSan = new NpcStep(this, NpcID.SAN_TOJALON, "Kill San.");
-		defeatDemon = new NpcStep(this, NpcID.NEZIKCHENED, "Defeat Nezikchened.");
+		killRanalph = new CombatStep(this, NpcID.RANALPH_DEVERE, "Kill Ranalph.", "Ranalph Devere (level 92)");
+		killIrvig = new CombatStep(this, NpcID.IRVIG_SENAY, "Kill Irvig.", "Irvig Senay (level 100)");
+		killSan = new CombatStep(this, NpcID.SAN_TOJALON, "Kill San.", "San Tojalon (level 106)");
+		defeatDemon = new CombatStep(this, NpcID.NEZIKCHENED, "Defeat Nezikchened.", "3 x Nezikchened (level 187)");
 
 		useTotemOnTotemAgain = new ObjectStep(this, ObjectID.TOTEM_POLE_2938, new WorldPoint(2852, 2917, 0), "Use the new totem on one of the corrupted totems.", yommiTotemHighlighted);
 		useTotemOnTotemAgain.addAlternateObjects(ObjectID.TOTEM_POLE_2936);
@@ -935,9 +930,15 @@ public class LegendsQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Nezikchened (level 187) 3 times", "Ranalph Devere (level 92)", "Irvig Senay (level 100)", "San Tojalon (level 106)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killRanalph);
+		reqs.add(killIrvig);
+		reqs.add(killSan);
+		reqs.add(defeatDemon);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/lostcity/LostCity.java
+++ b/src/main/java/com/questhelper/quests/lostcity/LostCity.java
@@ -39,11 +39,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -162,7 +159,7 @@ public class LostCity extends BasicQuestHelper
 		getAxe = new DetailedQuestStep(this, new WorldPoint(2843, 9760, 0), "Kill zombies until one drops a bronze axe.");
 		pickupAxe = new DetailedQuestStep(this, "Pick up the bronze axe", bronzeAxe);
 		attemptToCutDramen = new ObjectStep(this, ObjectID.DRAMEN_TREE, new WorldPoint(2861, 9735, 0), "Attempt to cut a branch from the Dramen tree. Be prepared for a Tree Spirit (level 101) to appear, which you can safespot behind nearby fungus.", bronzeAxe);
-		killDramenSpirit = new NpcStep(this, NpcID.TREE_SPIRIT, new WorldPoint(2859, 9734, 0), "Kill the Tree Spirit. They can be safespotted behind the nearby fungus.");
+		killDramenSpirit = new CombatStep(this, NpcID.TREE_SPIRIT, new WorldPoint(2859, 9734, 0), "Kill the Tree Spirit. They can be safespotted behind the nearby fungus.", "Dramen Tree Spirit (level 101) (can be safespotted)");
 		cutDramenBranch = new ObjectStep(this, ObjectID.DRAMEN_TREE, new WorldPoint(2861, 9735, 0), "Cut at least one branch from the Dramen tree. It's recommended you cut at least 4 branches so you don't have to return in future quests.");
 		teleportAway = new DetailedQuestStep(this, "Teleport away with the branches.", dramenBranch);
 		getAnotherBranch = new DetailedQuestStep(this, "If you've lost your Dramen branch/staff, you will need to return to Entrana and cut another. You will not need to defeat the Tree Spirit again.");
@@ -171,11 +168,12 @@ public class LostCity extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Multiple zombies (level 25) (can be safespotted)");
-		reqs.add("Dramen Tree Spirit (level 101) (can be safespotted)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.ZOMBIE, "Multiple zombies (level 25) (can be safespotted)"));
+		reqs.add(killDramenSpirit);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/src/main/java/com/questhelper/quests/lunardiplomacy/LunarDiplomacy.java
@@ -45,14 +45,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedOwnerStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -732,7 +726,7 @@ public class LunarDiplomacy extends BasicQuestHelper
 		talkToMeteora = new NpcStep(this, NpcID.METEORA, new WorldPoint(2083, 3890, 0), "Talk to Meteora in the south of Lunar Isle's town.", sealOfPassage);
 		talkToSelene = new NpcStep(this, NpcID.SELENE, new WorldPoint(2079, 3912, 0), "Talk to Selene in the west of Lunar Isle's town.", sealOfPassage);
 		talkToSelene.addDialogStep("I'm looking for a ring.");
-		killSuqahForTiara = new NpcStep(this, NpcID.SUQAH, "Kill the Suqah outside the town for a special tiara. You'll also need 4 hides for making clothes, so pick them up.", true);
+		killSuqahForTiara = new CombatStep(this, NpcID.SUQAH, "Kill the Suqah outside the town for a special tiara. You'll also need 4 hides for making clothes, so pick them up.", "Multiple Suqah (level 111)", true);
 		pickUpTiara = new ItemStep(this, "Pick up the tiara.", tiara);
 		killSuqahForTiara.addSubSteps(pickUpTiara);
 		returnTiaraToMeteora = new NpcStep(this, NpcID.METEORA, new WorldPoint(2083, 3890, 0),
@@ -797,7 +791,7 @@ public class LunarDiplomacy extends BasicQuestHelper
 		startRace = new NpcStep(this, NpcID.ETHEREAL_EXPERT, new WorldPoint(1788, 5068, 2), "Talk to the Ethereal Expert. Be prepared to race!");
 		startRace.addDialogStep("Ok.");
 
-		fightMe = new NpcStep(this, NpcID.ME, new WorldPoint(1823, 5087, 2), "Fight Me.");
+		fightMe = new CombatStep(this, NpcID.ME, new WorldPoint(1823, 5087, 2), "Fight Me.", "Me (level 79)");
 		fightMe.addAlternateNpcs(NpcID.ME_786);
 
 		leaveLecturn = new ObjectStep(this, ObjectID.MY_LIFE, new WorldPoint(1760, 5088, 2), "Read My life to return to Lunar Isle.");
@@ -872,9 +866,13 @@ public class LunarDiplomacy extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Multiple Suqah (level 111)", "Me (level 79)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSuqahForTiara);
+		reqs.add(fightMe);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
+++ b/src/main/java/com/questhelper/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
@@ -46,13 +46,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -548,9 +543,9 @@ public class MakingFriendsWithMyArm extends BasicQuestHelper
 		talkToSnowflake = new NpcStep(this, NpcID.SNOWFLAKE, new WorldPoint(2852, 10334, 0), "Talk to Snowflake. Be prepared to fight Don't Know What. Protect from Ranged, and move around to avoid his attacks.", combatRangeMelee);
 		talkToSnowflake.addDialogStep("So I can't teleport, and I may lose stuff? Okay.");
 
-		killDontKnowWhat = new NpcStep(this, NpcID.DONT_KNOW_WHAT_8439, "Kill Don't Know What. Move around and Protect from Ranged to avoid his attacks.");
+		killDontKnowWhat = new CombatStep(this, NpcID.DONT_KNOW_WHAT_8439, "Kill Don't Know What. Move around and Protect from Ranged to avoid his attacks.", "Don't Know What (level 163)");
 
-		killMother = new NpcStep(this, NpcID.MOTHER_8430, "Kill Mother. Protect from Ranged, keep moving and keep your distance.");
+		killMother = new CombatStep(this, NpcID.MOTHER_8430, "Kill Mother. Protect from Ranged, keep moving and keep your distance.", "Mother (level 198)");
 		killMother.addAlternateNpcs(NpcID.MOTHER_8428, NpcID.MOTHER_8429);
 
 		pickUpBucket = new ObjectStep(this, ObjectID.BUCKETS, new WorldPoint(2867, 3934, 0), "You now need to put out the fire. Pick up a bucket from the bucket pile.");
@@ -590,9 +585,14 @@ public class MakingFriendsWithMyArm extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Don't Know What (level 163)", "Mother (level 198)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDontKnowWhat);
+		reqs.add(killMother);
+
+		return reqs;
+
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/merlinscrystal/MerlinsCrystal.java
+++ b/src/main/java/com/questhelper/quests/merlinscrystal/MerlinsCrystal.java
@@ -40,11 +40,8 @@ import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -226,7 +223,7 @@ public class MerlinsCrystal extends BasicQuestHelper
 
 		goToFirstFloor = new ObjectStep(this, ObjectID.STAIRCASE_15645, new WorldPoint(2770, 3405, 0), "Go up the stairs in the fortress.");
 		goToSecondFloor = new ObjectStep(this, ObjectID.STAIRCASE_15645, new WorldPoint(2770, 3399, 1), "Go up another floor.");
-		attackMordred = new NpcStep(this, NpcID.SIR_MORDRED, new WorldPoint(2770, 3403, 2), "Attack Sir Mordred down to 0hp to cause Morgan Le Faye to spawn.");
+		attackMordred = new CombatStep(this, NpcID.SIR_MORDRED, new WorldPoint(2770, 3403, 2), "Attack Sir Mordred down to 0hp to cause Morgan Le Faye to spawn.", "Sir Mordred (level 39)");
 		attackMordred.addDialogStep("Tell me how to untrap Merlin and I might.");
 		attackMordred.addDialogStep("Ok I will do all that.");
 		talkToMorgan = new DetailedQuestStep(this, "Go through Morgan le Faye's dialog. IF YOU EXIT FROM THIS DIALOG YOU WILL HAVE TO FIGHT MORDRED AGAIN.");
@@ -278,10 +275,11 @@ public class MerlinsCrystal extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Sir Mordred (level 39)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(attackMordred);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -43,11 +43,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -719,10 +716,11 @@ public class MonkeyMadnessI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Jungle Demon (level 195)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.JUNGLE_DEMON, "Jungle Demon (level 195)"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/monkeymadnessii/MonkeyMadnessII.java
+++ b/src/main/java/com/questhelper/quests/monkeymadnessii/MonkeyMadnessII.java
@@ -54,12 +54,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -541,7 +537,7 @@ public class MonkeyMadnessII extends BasicQuestHelper
 		talkToKob.setWorldMapPoint(new WorldPoint(2962, 10120, 0));
 		talkToKob.addDialogSteps("I know about your deal with the monkeys.", "You won't be around to crush anyone when I'm done with you.", "I accept your challenge.");
 
-		fightKob = new NpcStep(this, NpcID.KOB_7107, new WorldPoint(2831, 10060, 2), "Fight Kob. He can be safespotted from the doorway.");
+		fightKob = new CombatStep(this, NpcID.KOB_7107, new WorldPoint(2831, 10060, 2), "Fight Kob. He can be safespotted from the doorway.", "Kob (level 185, safespottable)");
 		fightKob.setWorldMapPoint(new WorldPoint(2962, 10120, 0));
 
 		if (client.getBoostedSkillLevel(Skill.AGILITY) >= 71)
@@ -554,7 +550,7 @@ public class MonkeyMadnessII extends BasicQuestHelper
 		}
 		talkToKeef.addDialogSteps("I know about your deal with the monkeys.", "I offer to spare your life.", "I accept your challenge.");
 
-		fightKeef = new NpcStep(this, NpcID.KEEF_7105, new WorldPoint(2542, 3031, 0), "Fight Keef. He can be safespotted.");
+		fightKeef = new CombatStep(this, NpcID.KEEF_7105, new WorldPoint(2542, 3031, 0), "Fight Keef. He can be safespotted.", "Keef (level 178, safespottable)");
 		talkToGarkorAfterKeef = new NpcStep(this, NpcID.GARKOR_7158, new WorldPoint(2807, 2762, 0), "Talk to Garkor on Ape Atoll.", krukGreegree);
 		findSmith = new DetailedQuestStep(this, "Search around the various rooftops in Ape Atoll for Assistant Le Smith.", krukGreegree);
 		talkToSmith = new NpcStep(this, NpcID.ASSISTANT_LE_SMITH_6806, "Talk to Assistant Le Smith.", krukGreegree);
@@ -600,7 +596,7 @@ public class MonkeyMadnessII extends BasicQuestHelper
 
 		enterNorthOfTreeNoNieve = new ObjectStep(this, NullObjectID.NULL_28807, new WorldPoint(2435, 3520, 0), "Enter the breach north west of the Grand Tree.", combatGear, food, prayerPotions);
 
-		fightGlough = new NpcStep(this, NpcID.GLOUGH_7101, new WorldPoint(2075, 5677, 0), "Defeat Glough. He has 3 phases, changing rooms each time. You can safe spot the first 2 phases. Protect from Melee if you're next to him, or Protect from Magic if not in the third phase.", true);
+		fightGlough = new CombatStep(this, NpcID.GLOUGH_7101, new WorldPoint(2075, 5677, 0), "Defeat Glough. He has 3 phases, changing rooms each time. You can safe spot the first 2 phases. Protect from Melee if you're next to him, or Protect from Magic if not in the third phase.", "Glough (level 378)", true);
 		fightGlough.addText("The easiest way to do phase 3 is to attack him from 1 tile away, have Protect from Magic on, and step away a tile whenever he pulls you closer.");
 		((NpcStep) (fightGlough)).addAlternateNpcs(NpcID.GLOUGH_7102, NpcID.GLOUGH_7103, NpcID.GLOUGH_7100);
 		((NpcStep) (fightGlough)).setMaxRoamRange(200);
@@ -667,9 +663,17 @@ public class MonkeyMadnessII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Kruk (level 149, flinchable)", "Keef (level 178, safespottable)", "Kob (level 185, safespottable)", "9 Tortured gorillas (level 141)", "2 Demonic Gorillas (level 275)", "Glough (level 378)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.KRUK_6805, "Kruk (level 149, flinchable)"));
+		reqs.add(fightKeef);
+		reqs.add(fightKob);
+		reqs.add(new CombatStep(this, NpcID.TORTURED_GORILLA_7150, "9 Tortured gorillas (level 141)"));
+		reqs.add(new CombatStep(this, NpcID.DEMONIC_GORILLA_7152, "2 Demonic Gorillas (level 275)"));
+		reqs.add(fightGlough);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
+++ b/src/main/java/com/questhelper/quests/mountaindaughter/MountainDaughter.java
@@ -43,12 +43,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -363,7 +359,7 @@ public class MountainDaughter extends BasicQuestHelper
 		talkToKendal.addDialogStep("I humbly request to be given the remains.");
 		talkToKendal.addDialogStep("I will kill you myself!");
 
-		killKendal = new NpcStep(this, NpcID.THE_KENDAL, new WorldPoint(2788, 10081, 0), "Kill the kendal.");
+		killKendal = new CombatStep(this, NpcID.THE_KENDAL, new WorldPoint(2788, 10081, 0), "Kill the kendal.", "The Kendal (level 70)");
 		talkToKendal.addSubSteps(killKendal);
 
 		grabCorpse = new TileStep(this, new WorldPoint(2784, 10078, 0), "Pick up the Corpse of Woman.");
@@ -409,9 +405,12 @@ public class MountainDaughter extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("The Kendal (level 70)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killKendal);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
+++ b/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
@@ -36,9 +36,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
@@ -60,8 +58,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MOURNINGS_END_PART_I
@@ -326,7 +322,7 @@ public class MourningsEndPartI extends BasicQuestHelper
 
 		talkToArianwyn = new NpcStep(this, NpcID.ARIANWYN_9014, new WorldPoint(2354, 3170, 0), "Talk to Arianwyn in Lletya.");
 		talkToArianwyn.addDialogStep("Okay, let's begin.");
-		killMourner = new NpcStep(this, NpcID.MOURNER_9013, new WorldPoint(2385, 3326, 0), "Kill a mourner travelling through the Arandar pass. This is more easily accessed from the north entrance. You'll need 7 free inventory spaces.", true);
+		killMourner = new CombatStep(this, NpcID.MOURNER_9013, new WorldPoint(2385, 3326, 0), "Kill a mourner travelling through the Arandar pass. This is more easily accessed from the north entrance. You'll need 7 free inventory spaces.", "Mourner (level 11)", true);
 		pickUpLoot = new DetailedQuestStep(this, "Pick up everything the mourner dropped.", mournerBoots, mournerCloak, mournerGloves, mournerLegsBroken, mournerMask, mournerLetter, bloodyMournerBody);
 
 		searchLaundry = new ObjectStep(this, ObjectID.LAUNDRY_BASKET, new WorldPoint(2912, 3418, 0), "Search Tegid's laundry basket in south Taverley for some soap.");
@@ -449,9 +445,12 @@ public class MourningsEndPartI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Mourner (level 11)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killMourner);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/quests/mourningsendpartii/MourningsEndPartII.java
@@ -44,11 +44,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1003,9 +1000,12 @@ public class MourningsEndPartII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Able to survive Shadows (level 73) continually attacking you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.SHADOW, "Able to survive Shadows (level 73) continually attacking you"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
+++ b/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
@@ -44,12 +44,7 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -406,11 +401,11 @@ public class MyArmsBigAdventure extends BasicQuestHelper
 
 		talkToMyArmAfterGrow = new NpcStep(this, NpcID.MY_ARM_742, new WorldPoint(2829, 3695, 0),
 			"Talk to My Arm. Be prepared to fight a baby and giant Roc.");
-		killBabyRoc = new NpcStep(this, NpcID.BABY_ROC, "Kill the Baby Roc.");
+		killBabyRoc = new CombatStep(this, NpcID.BABY_ROC, "Kill the Baby Roc.", "Baby Roc (level 75)");
 		talkToMyArmAfterBaby = new NpcStep(this, NpcID.MY_ARM_742, new WorldPoint(2829, 3695, 0),
 			"Talk to My Arm. Be prepared to fight the Giant Roc.");
 
-		killGiantRoc = new NpcStep(this, NpcID.GIANT_ROC, "Kill the Giant Roc.");
+		killGiantRoc = new CombatStep(this, NpcID.GIANT_ROC, "Kill the Giant Roc.", "Giant Roc (level 172)");
 		talkToMyArmAfterHarvest = new NpcStep(this, NpcID.MY_ARM_742, new WorldPoint(2829, 3695, 0), "Talk to My Arm.");
 		giveSpade = new NpcStep(this, NpcID.MY_ARM_742, new WorldPoint(2829, 3695, 0), "Give My Arm a spade.", spadeHighlight);
 		giveSpade.addIcon(ItemID.SPADE);
@@ -449,11 +444,12 @@ public class MyArmsBigAdventure extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Baby Roc (level 75)");
-		reqs.add("Giant Roc (level 172)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBabyRoc);
+		reqs.add(killGiantRoc);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/naturespirit/NatureSpirit.java
+++ b/src/main/java/com/questhelper/quests/naturespirit/NatureSpirit.java
@@ -43,11 +43,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -268,7 +265,7 @@ public class NatureSpirit extends BasicQuestHelper
 		talkToFillimanInGrotto = new NpcStep(this, NpcID.FILLIMAN_TARLOCK, new WorldPoint(3441, 9738, 0), "Talk to Filliman in the grotto to bless your sickle.", ghostspeak, silverSickle);
 		blessSickle = new NpcStep(this, NpcID.NATURE_SPIRIT, new WorldPoint(3441, 9738, 0), "Talk to the Nature Spirit in the grotto to bless your sickle.", ghostspeak, silverSickle);
 		fillPouches = new DetailedQuestStep(this, "Right-click 'bloom' the blessed sickle next to rotten logs for mort myre fungi. Use these to fill the druid pouch.", blessedSickle);
-		killGhasts = new NpcStep(this, NpcID.GHAST, "Use the filled druid pouch on a ghast to make it attackable and kill it. You'll need to kill 3.", druidPouchFull);
+		killGhasts = new CombatStep(this, NpcID.GHAST, "Use the filled druid pouch on a ghast to make it attackable and kill it. You'll need to kill 3.", "3 Ghasts (level 30)", druidPouchFull);
 		killGhast = new NpcStep(this, NpcID.GHAST_946, "Kill the ghast.", druidPouchFull);
 		killGhasts.addSubSteps(killGhast);
 		enterGrottoAgain = new ObjectStep(this, ObjectID.GROTTO, new WorldPoint(3440, 3337, 0), "Enter the Grotto in the south of Mort Myre.", ghostspeak);
@@ -296,9 +293,12 @@ public class NatureSpirit extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("3 Ghasts (level 30)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGhasts);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/observatoryquest/ObservatoryQuest.java
+++ b/src/main/java/com/questhelper/quests/observatoryquest/ObservatoryQuest.java
@@ -40,11 +40,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -182,9 +179,9 @@ public class ObservatoryQuest extends BasicQuestHelper
 			"Unmarked chests contain monsters and may poison you.");
 		((ObjectStep) searchChests).addAlternateObjects(ObjectID.CHEST_25386, ObjectID.CHEST_25387,
 			ObjectID.CHEST_25388, ObjectID.CHEST_25389, ObjectID.CHEST_25390);
-		prodGuard = new NpcStep(this, NpcID.SLEEPING_GUARD, new WorldPoint(2327, 9394, 0),
+		prodGuard = new CombatStep(this, NpcID.SLEEPING_GUARD, new WorldPoint(2327, 9394, 0),
 			"Prod the sleeping guard in the north of the dungeon. He'll attack you. You need to then either kill him," +
-				" or get him in the marked spot to the north of the gate.");
+				" or get him in the marked spot to the north of the gate.", "Goblin Guard (level 42, or you can lure it/have someone else kill it)");
 		prodGuard.addTileMarker(new WorldPoint(2327, 9399, 0), SpriteID.BARBARIAN_ASSAULT_HORN_FOR_HEALER_ICON);
 		inspectStove = new ObjectStep(this, NullObjectID.NULL_25442, new WorldPoint(2327, 9389, 0),
 			"Either kill or trap the guard on the marked tile to the north, then search the goblin stove.");
@@ -224,9 +221,12 @@ public class ObservatoryQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Goblin Guard (level 42, or you can lure it/have someone else kill it)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(prodGuard);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/olafsquest/OlafsQuest.java
+++ b/src/main/java/com/questhelper/quests/olafsquest/OlafsQuest.java
@@ -46,14 +46,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.WidgetStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -229,7 +222,7 @@ public class OlafsQuest extends BasicQuestHelper
 		talkToOlafAfterPlanks.addDialogStep("Alright, here, have some food. Now give me the map.");
 		digHole = new DigStep(this, new WorldPoint(2748, 3732, 0), "Dig next to the Windswept Tree.");
 
-		killSkeleton = new NpcStep(this, NpcID.SKELETON_FREMENNIK, new WorldPoint(2727, 10141, 0), "Go deeper into the caverns and kill a Skeleton Fremennik for a key.", true);
+		killSkeleton = new CombatStep(this, NpcID.SKELETON_FREMENNIK, new WorldPoint(2727, 10141, 0), "Go deeper into the caverns and kill a Skeleton Fremennik for a key.", "Skeleton fremennik (level 40)", true);
 		killSkeleton.addAlternateNpcs(NpcID.SKELETON_FREMENNIK_4492, NpcID.SKELETON_FREMENNIK_4493, NpcID.SKELETON_FREMENNIK_4494, NpcID.SKELETON_FREMENNIK_4495,
 			NpcID.SKELETON_FREMENNIK_4496, NpcID.SKELETON_FREMENNIK_4497, NpcID.SKELETON_FREMENNIK_4498, NpcID.SKELETON_FREMENNIK_4499);
 
@@ -260,7 +253,7 @@ public class OlafsQuest extends BasicQuestHelper
 		searchChest = new ObjectStep(this, ObjectID.CHEST_14197, new WorldPoint(2740, 10164, 0), "WALK off the remaining walkway, and search the chest in the wreck. Be prepared to fight Ulfric.");
 		searchChest.addAlternateObjects(ObjectID.CHEST_14196);
 
-		killUlfric = new NpcStep(this, NpcID.ULFRIC, new WorldPoint(2740, 10164, 0), "Kill Ulfric.");
+		killUlfric = new CombatStep(this, NpcID.ULFRIC, new WorldPoint(2740, 10164, 0), "Kill Ulfric.", "Ulfric (level 100)");
 
 		searchChestAgain = new ObjectStep(this, ObjectID.CHEST_14197, new WorldPoint(2740, 10164, 0), "Search the chest again to finish the quest.");
 		searchChestAgain.addAlternateObjects(ObjectID.CHEST_14196);
@@ -279,9 +272,13 @@ public class OlafsQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Skeleton fremennik (level 40)", "Ulfric (level 100)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSkeleton);
+		reqs.add(killUlfric);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/onesmallfavour/OneSmallFavour.java
+++ b/src/main/java/com/questhelper/quests/onesmallfavour/OneSmallFavour.java
@@ -42,12 +42,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -679,7 +675,7 @@ public class OneSmallFavour extends BasicQuestHelper
 
 		standNextToSculpture.addSubSteps(readScroll);
 
-		killSlagilith = new NpcStep(this, NpcID.SLAGILITH, new WorldPoint(2617, 9837, 0), "Kill the Slagilith.");
+		killSlagilith = new CombatStep(this, NpcID.SLAGILITH, new WorldPoint(2617, 9837, 0), "Kill the Slagilith.", "Slagilith (level 92)");
 		readScrollAgain = new DetailedQuestStep(this, "Read the animate rock scroll", animateRockScrollHighlight);
 		talkToPetra = new NpcStep(this, NpcID.PETRA_FIYED, new WorldPoint(2617, 9837, 0), "Talk to Petra Fiyed.");
 
@@ -745,7 +741,7 @@ public class OneSmallFavour extends BasicQuestHelper
 		returnToHammerspike = new NpcStep(this, NpcID.HAMMERSPIKE_STOUTBEARD, new WorldPoint(2968, 9811, 0), "Return to Hammerspike Stoutbeard in the west cavern of the Dwarven Mine.");
 		returnToHammerspike.addSubSteps(goDownToHammerspikeAgain);
 
-		killGangMembers = new NpcStep(this, NpcID.DWARF_GANG_MEMBER, new WorldPoint(2968, 9811, 0), "Kill 3 dwarf gang members until Hammerspike gives in. One dwarf gang member should appear after each kill");
+		killGangMembers = new CombatStep(this, NpcID.DWARF_GANG_MEMBER, new WorldPoint(2968, 9811, 0), "Kill 3 dwarf gang members until Hammerspike gives in. One dwarf gang member should appear after each kill", "3x Dwarf gang members (level 44)");
 		talkToHammerspikeFinal = new NpcStep(this, NpcID.HAMMERSPIKE_STOUTBEARD, new WorldPoint(2968, 9811, 0), "Return to Hammerspike Stoutbeard in the west cavern of the Dwarven Mine.");
 		returnToTassie = new NpcStep(this, NpcID.TASSIE_SLIPCAST, new WorldPoint(3085, 3409, 0), "Return to Tassie Slipcast in the Barbarian Village pottery building.");
 		spinPotLid = new ObjectStep(this, ObjectID.POTTERS_WHEEL_14887, new WorldPoint(3087, 3409, 0), "Spin the clay into a pot lid.", softClay);
@@ -809,9 +805,13 @@ public class OneSmallFavour extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Slagilith (level 92)", "3x Dwarf gang members (level 44)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSlagilith);
+		reqs.add(killGangMembers);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/piratestreasure/PiratesTreasure.java
+++ b/src/main/java/com/questhelper/quests/piratestreasure/PiratesTreasure.java
@@ -35,12 +35,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -143,9 +139,12 @@ public class PiratesTreasure extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Gardener (level 4)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.GARDENER, "Gardener (level 4)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
+++ b/src/main/java/com/questhelper/quests/priestinperil/PriestInPeril.java
@@ -40,11 +40,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -263,8 +260,8 @@ public class PriestInPeril extends BasicQuestHelper
 		goDownToDog = new ObjectStep(this, ObjectID.TRAPDOOR_1579, new WorldPoint(3405, 3507, 0), "Go down the ladder north of the temple.");
 		goDownToDog.addDialogStep("Yes.");
 		((ObjectStep) (goDownToDog)).addAlternateObjects(ObjectID.TRAPDOOR_1581);
-		killTheDog = new NpcStep(this, NpcID.TEMPLE_GUARDIAN, new WorldPoint(3405, 9901, 0),
-			"Kill the Temple Guardian (level 30). It is immune to magic so you will need to use either ranged or melee.");
+		killTheDog = new CombatStep(this, NpcID.TEMPLE_GUARDIAN, new WorldPoint(3405, 9901, 0),
+			"Kill the Temple Guardian (level 30). It is immune to magic so you will need to use either ranged or melee.", "Temple Guardian (level 30). You cannot use Magic. Rings of recoil will not award the kill.");
 		climbUpAfterKillingDog = new ObjectStep(this, ObjectID.LADDER_17385, new WorldPoint(3405, 9907, 0),
 			"Climb back up the ladder and return to King Roald.");
 		returnToKingRoald = new NpcStep(this, NpcID.KING_ROALD_5215, new WorldPoint(3222, 3473, 0),
@@ -273,7 +270,7 @@ public class PriestInPeril extends BasicQuestHelper
 
 		returnToTemple = new ObjectStep(this, ObjectID.LARGE_DOOR_3490, new WorldPoint(3408, 3488, 0),
 			"Return to the temple.", bucket, lotsOfRuneEssence, rangedMagedGear);
-		killMonk = new NpcStep(this, NpcID.MONK_OF_ZAMORAK_3486, new WorldPoint(3412, 3488, 0), "Kill a Monk of Zamorak (level 30) for a golden key. You can safespot using the pews.", true, goldenKey);
+		killMonk = new CombatStep(this, NpcID.MONK_OF_ZAMORAK_3486, new WorldPoint(3412, 3488, 0), "Kill a Monk of Zamorak (level 30) for a golden key. You can safespot using the pews.", "Monk of Zamorak (level 30)", true, goldenKey);
 
 		goUpToFloorOneTemple = new ObjectStep(this, ObjectID.STAIRCASE_16671, new WorldPoint(3418, 3493, 0), "Go upstairs.");
 		goUpToFloorTwoTemple = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(3410, 3485, 1), "Climb up the ladder.");
@@ -338,9 +335,14 @@ public class PriestInPeril extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Temple Guardian (level 30). You cannot use Magic. Rings of recoil will not award the kill.",  "Monk of Zamorak (level 30)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killTheDog);
+		reqs.add(killMonk);
+
+		return reqs;
+
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/princealirescue/PrinceAliRescue.java
+++ b/src/main/java/com/questhelper/quests/princealirescue/PrinceAliRescue.java
@@ -40,11 +40,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -252,10 +249,11 @@ public class PrinceAliRescue extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Able to survive jail guards (level 26) attacking you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.JAIL_GUARD, "Able to survive jail guards (level 26) attacking you"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManI.java
+++ b/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManI.java
@@ -40,12 +40,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -342,9 +338,12 @@ public class RagAndBoneManI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("8 low leveled monsters for their bones");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "8 low leveled monsters for their bones"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/quests/ragandboneman/RagAndBoneManII.java
@@ -48,12 +48,8 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -835,9 +831,12 @@ public class RagAndBoneManII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("27 low to mid leveled monsters for their bones");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "27 low to mid leveled monsters for their bones"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDAwowogei.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDAwowogei.java
@@ -45,11 +45,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -230,7 +227,7 @@ public class RFDAwowogei extends BasicQuestHelper
 		goToCrashIsland = new NpcStep(this, NpcID.LUMDO_1454, new WorldPoint(2802, 2706, 0), "Travel to Crash Island with Lumdo.", combatGear);
 		enterCrashHole = new ObjectStep(this, ObjectID.PIT_15572, new WorldPoint(2922, 2722, 0), "Enter the hole on Crash Island. Protect melee when entering as you'll be attacked straight away by snakes.", combatGear, protectMelee);
 		enterCrashHole.addDialogStep("Yes, I'm as hard as nails.");
-		killSnake = new NpcStep(this, NpcID.BIG_SNAKE, new WorldPoint(3019, 5485, 0), "Kill a giant snake for its corpse. Kill a few in case you burn it.", snakeCorpse);
+		killSnake = new CombatStep(this, NpcID.BIG_SNAKE, new WorldPoint(3019, 5485, 0), "Kill a giant snake for its corpse. Kill a few in case you burn it.", "Big Snake (level 84)", snakeCorpse);
 		leaveSnakeHole = new ObjectStep(this, ObjectID.ROPE_15571, new WorldPoint(3024, 5489, 0), "Leave the hole.");
 		returnToApeAtoll = new NpcStep(this, NpcID.LUMDO_1454, new WorldPoint(2892, 2723, 0), "Travel back to Ape Atoll with Lumdo.");
 
@@ -264,9 +261,12 @@ public class RFDAwowogei extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Big Snake (level 84)", "If you need the greegrees still, a zombie, ninja, and guard monkey");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSnake);
+		reqs.add(new CombatStep(this, -1, "If you need the greegrees still, a zombie, ninja, and guard monkey"));
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDDwarf.java
@@ -43,12 +43,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -225,9 +221,12 @@ public class RFDDwarf extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Icefiend if you don't have Ice Gloves");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Icefiend if you don't have Ice Gloves"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDFinal.java
@@ -42,10 +42,7 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -131,27 +128,27 @@ public class RFDFinal extends BasicQuestHelper
 	public void setupSteps()
 	{
 		enterPortal = new ObjectStep(this, NullObjectID.NULL_12354, new WorldPoint(3209, 3218, 0), "Enter the portal in Lumbridge Castle, ready to fight. You can leave between fights to re-gear.", combatGear);
-		killAgrith = new NpcStep(this, NpcID.AGRITHNANA, new WorldPoint(1900, 5355, 2),"Kill Agrith-Na-Na. He uses magic at ranged, and melee up close.");
+		killAgrith = new CombatStep(this, NpcID.AGRITHNANA, new WorldPoint(1900, 5355, 2),"Kill Agrith-Na-Na. He uses magic at ranged, and melee up close.", "Agrith-Na-Na (level 146)");
 
 		enterPortalFlambeed = new ObjectStep(this, NullObjectID.NULL_12354, new WorldPoint(3209, 3218, 0), "Enter the portal in Lumbridge Castle, ready to fight kill Flambeed. Water spells are especially effective.", combatGear, iceGloves);
-		killFlambeed = new NpcStep(this, NpcID.FLAMBEED, new WorldPoint(1900, 5355, 2),"Equip ice gloves and kill Flambeed. Water spells are especially effective.", iceGloves);
+		killFlambeed = new CombatStep(this, NpcID.FLAMBEED, new WorldPoint(1900, 5355, 2),"Equip ice gloves and kill Flambeed. Water spells are especially effective.", "Flambeed (level 149)", iceGloves);
 		killFlambeed.addSubSteps(enterPortalFlambeed);
 
 		enterPortalKaramel = new ObjectStep(this, NullObjectID.NULL_12354, new WorldPoint(3209, 3218, 0), "Enter the portal to fight Karamel. Stand in melee distance, and bring restore potions to as they drain your stats. Fire spells are especially effective.", combatGear, restorePotions);
-		killKaramel = new NpcStep(this, NpcID.KARAMEL, new WorldPoint(1900, 5355, 2), "Kill Karamel. Stand in melee distance, and bring restore potions to as they drain your stats. Fire spells are especially effective.", combatGear, restorePotions);
+		killKaramel = new CombatStep(this, NpcID.KARAMEL, new WorldPoint(1900, 5355, 2), "Kill Karamel. Stand in melee distance, and bring restore potions to as they drain your stats. Fire spells are especially effective.", "Karamel (level 136)", combatGear, restorePotions);
 		killKaramel.addSubSteps(enterPortalKaramel);
 
 		enterPortalDessourt = new ObjectStep(this, NullObjectID.NULL_12354, new WorldPoint(3209, 3218, 0), "Enter the portal in Lumbridge Castle, ready to fight Dessourt.", combatGear);
-		killDessourt = new NpcStep(this, NpcID.DESSOURT, new WorldPoint(1900, 5355, 2), "Kill Dessourt.");
+		killDessourt = new CombatStep(this, NpcID.DESSOURT, new WorldPoint(1900, 5355, 2), "Kill Dessourt.", "Dessourt (level 121)");
 		killDessourt.addSubSteps(enterPortalDessourt);
 
 		enterPortalMother = new ObjectStep(this, NullObjectID.NULL_12354, new WorldPoint(3209, 3218, 0), "Enter the portal in Lumbridge Castle, ready to fight the Gelatinnoth mother. You'll need to use air spells when she's white, earth when brown, fire when red and water when blue.", combatGear);
-		killMother = new NpcStep(this, NpcID.GELATINNOTH_MOTHER, new WorldPoint(1900, 5355, 2), "Kill the Gelatinnoth mother. You'll need to use air spells when she's white, earth when brown, fire when red and water when blue, melee when orange and ranged when green.");
+		killMother = new CombatStep(this, NpcID.GELATINNOTH_MOTHER, new WorldPoint(1900, 5355, 2), "Kill the Gelatinnoth mother. You'll need to use air spells when she's white, earth when brown, fire when red and water when blue, melee when orange and ranged when green.", "Gelatinnoth Mother (level 130)");
 		((NpcStep)(killMother)).addAlternateNpcs(NpcID.GELATINNOTH_MOTHER_4885, NpcID.GELATINNOTH_MOTHER_4886, NpcID.GELATINNOTH_MOTHER_4887, NpcID.GELATINNOTH_MOTHER_4888, NpcID.GELATINNOTH_MOTHER_4889);
 		killMother.addSubSteps(enterPortalMother);
 
 		enterPortalCulinaromancer = new ObjectStep(this, NullObjectID.NULL_12354, new WorldPoint(3209, 3218, 0), "Enter the portal in Lumbridge Castle, ready to fight the Culinaromancer. Try to keep your distance.", combatGear);
-		killCulinaromancer = new NpcStep(this, NpcID.CULINAROMANCER_4878,  new WorldPoint(1900, 5355, 2), "Kill the Culinaromancer. Try to keep your distance.");
+		killCulinaromancer = new CombatStep(this, NpcID.CULINAROMANCER_4878,  new WorldPoint(1900, 5355, 2), "Kill the Culinaromancer. Try to keep your distance.", "Culinaromancer (level 75)");
 		killCulinaromancer.addSubSteps(enterPortalCulinaromancer);
 	}
 
@@ -162,9 +159,17 @@ public class RFDFinal extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Agrith-Na-Na (level 146)", "Flambeed (level 149)", "Karamel (level 136)", "Dessourt (level 121)", "Gelatinnoth Mother (level 130)", "Culinaromancer (level 75)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killAgrith);
+		reqs.add(killFlambeed);
+		reqs.add(killKaramel);
+		reqs.add(killDessourt);
+		reqs.add(killMother);
+		reqs.add(killCulinaromancer);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDPiratePete.java
@@ -46,11 +46,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -261,7 +257,7 @@ public class RFDPiratePete extends BasicQuestHelper
 		talkToNung = new NpcStep(this, NpcID.NUNG, new WorldPoint(2971, 9513, 1), "Talk to Nung in the north of the area.");
 		pickUpRocks = new DetailedQuestStep(this, new WorldPoint(2950, 9511, 1), "Pick up 5 rocks in the west of the area.", rocks5);
 		enterCave = new ObjectStep(this, ObjectID.UNDERWATER_CAVERN_ENTRANCE_12461, new WorldPoint(2950, 9516, 1), "Enter the underwater cave entrance.");
-		killMudksippers5 = new NpcStep(this, NpcID.MUDSKIPPER, new WorldPoint(2951, 9526, 1), "Kill mudskippers for 5 hides.", true, mudskipperHide5);
+		killMudksippers5 = new CombatStep(this, NpcID.MUDSKIPPER, new WorldPoint(2951, 9526, 1), "Kill mudskippers for 5 hides.", "5 Mudskippers (level 30/31)", true, mudskipperHide5);
 		((NpcStep) (killMudksippers5)).addAlternateNpcs(NpcID.MUDSKIPPER_4821);
 		returnToNung = new NpcStep(this, NpcID.NUNG, new WorldPoint(2971, 9513, 1), "Bring the hides to Nung.", mudskipperHide5);
 		talkToNungAgain = new NpcStep(this, NpcID.NUNG, new WorldPoint(2971, 9513, 1), "Talk to Nung again.");
@@ -271,7 +267,7 @@ public class RFDPiratePete extends BasicQuestHelper
 		goDivingAgain = new NpcStep(this, NpcID.MURPHY, new WorldPoint(2664, 3160, 0), "Talk to Murphy again to go diving.", divingAparatus, divingHelmet, canSwim);
 		goDiving.addDialogSteps("Talk about Recipe for Disaster.", "Yes, Let's go diving.");
 		pickUpRocksAgain = new DetailedQuestStep(this, new WorldPoint(2950, 9511, 1), "Pick up 5 rocks so you can kill the crabs.", rocks5);
-		killCrab = new NpcStep(this, NpcID.CRAB_4819, new WorldPoint(2977, 9518, 1), "Kill the crabs for some crab meat. Get 2-3 to be safe.", true, crabMeat);
+		killCrab = new CombatStep(this, NpcID.CRAB_4819, new WorldPoint(2977, 9518, 1), "Kill the crabs for some crab meat. Get 2-3 to be safe.", "Crab (level 21/23)", true, crabMeat);
 		killCrab.addSubSteps(pickUpRocksAgain);
 		grindKelp = new DetailedQuestStep(this, "Use a pestle and mortar on the kelp.", pestleHighlighted, kelpHighlighted);
 		grindCrab = new DetailedQuestStep(this, "Use a pestle and mortar on the crab.", pestleHighlighted, crabMeatHighlighted);
@@ -305,9 +301,13 @@ public class RFDPiratePete extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("5 Mudskippers (level 30/31)", "Crab (level 21/23)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killMudksippers5);
+		reqs.add(killCrab);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
@@ -45,12 +45,7 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
 import java.util.ArrayList;
@@ -254,10 +249,10 @@ public class RFDSirAmikVarze extends BasicQuestHelper
 		useChickenOnShrine = new ObjectStep(this, ObjectID.CHICKEN_SHRINE, new WorldPoint(2453, 4477, 0),
 			"Use a raw chicken on the Chicken Shrine in the north east of Zanaris.", rawChicken, combatGear);
 		useChickenOnShrine.addIcon(ItemID.RAW_CHICKEN);
-		killEvilChicken = new NpcStep(this, NpcID.EVIL_CHICKEN, new WorldPoint(2455, 4399, 0), "Kill the Evil Chicken in the north of the range. Pray protect from magic against it.");
+		killEvilChicken = new CombatStep(this, NpcID.EVIL_CHICKEN, new WorldPoint(2455, 4399, 0), "Kill the Evil Chicken in the north of the range. Pray protect from magic against it.", "Evil Chicken (level " + evilChickenLevel + ")");
 		pickUpEgg = new ItemStep(this, "Pick up the evil chicken egg.", evilEgg);
 		useEggOnBrulee = new DetailedQuestStep(this, "Use the evil chickens egg on the brulee.", evilEgg, baseBrulee, pestleAndMortar);
-		killBlackDragon = new NpcStep(this, NpcID.BLACK_DRAGON, new WorldPoint(2461, 4367, 0), "Kill a black dragon.", combatGear, antidragonShield);
+		killBlackDragon = new CombatStep(this, NpcID.BLACK_DRAGON, new WorldPoint(2461, 4367, 0), "Kill a black dragon.", "Black dragon (level 227) (Can be safespotted)", combatGear, antidragonShield);
 		pickUpToken = new ItemStep(this, "Pick up the dragon token.", token);
 		grindBranch = new DetailedQuestStep(this, "Use a pestle and mortar on the dramen branch.", pestleAndMortarHighlighted, dramenBranch);
 		useCinnamonOnBrulee = new DetailedQuestStep(this, "Use the cinnamon on the brulee.", cinnamon, bruleeWithEgg);
@@ -319,9 +314,13 @@ public class RFDSirAmikVarze extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Evil Chicken (level " + evilChickenLevel + ")", "Black dragon (level 227) (Can be safespotted)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBlackDragon);
+		reqs.add(killEvilChicken);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSkrachUglogwee.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSkrachUglogwee.java
@@ -43,12 +43,8 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -216,7 +212,7 @@ public class RFDSkrachUglogwee extends BasicQuestHelper
 		getRock = new ObjectStep(this, ObjectID.PILE_OF_ROCK_12564, new WorldPoint(2567, 2960, 0), "Mine a pile of rocks near the Feldip Hills Fairy Ring for a rock.", pickaxe);
 		useBellowOnToadInInv = new DetailedQuestStep(this, "Use the bellows on your toad with a ball of wool in your inventory.", ogreBellowsFilled, toad, ballOfWool);
 		dropBalloonToad = new DetailedQuestStep(this, new WorldPoint(2593, 2964, 0), "Drop the balloon toad near a swamp and wait for a Jubbly to arrive.", toadReady, ogreBowAndArrows);
-		killJubbly = new NpcStep(this, NpcID.JUBBLY_BIRD, "Kill then pluck jubbly.", ogreBowAndArrows);
+		killJubbly = new CombatStep(this, NpcID.JUBBLY_BIRD, "Kill then pluck jubbly.", "Jubbly (level 9)", ogreBowAndArrows);
 		pickUpRawJubbly = new ItemStep(this, "Pick up the raw jubbly.", rawJubbly);
 		lootJubbly = new NpcStep(this, NpcID.JUBBLY_BIRD_4864, "Pluck the jubbly's carcass.");
 		cookJubbly = new ObjectStep(this, NullObjectID.NULL_6895, new WorldPoint(2631, 2990, 0), "Cook the raw jubbly on Rantz's spit.", rawJubbly);
@@ -235,9 +231,12 @@ public class RFDSkrachUglogwee extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Jubbly (level 9)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killJubbly);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/recruitmentdrive/RecruitmentDrive.java
+++ b/src/main/java/com/questhelper/quests/recruitmentdrive/RecruitmentDrive.java
@@ -46,11 +46,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -201,8 +198,8 @@ public class RecruitmentDrive extends BasicQuestHelper
 		VarbitRequirement finishedRoom = new VarbitRequirement(661, 1);
 
 		talkToSirKuam = new NpcStep(this, NpcID.SIR_KUAM_FERENTSE, "Talk to Sir Kuam Ferentse to have him spawn Sir Leye");
-		killSirLeye = new NpcStep(this, NpcID.SIR_LEYE,
-			"Kill Sir Leye to win this challenge. You must be a female character or you can't kill him.", true,
+		killSirLeye = new CombatStep(this, NpcID.SIR_LEYE,
+			"Kill Sir Leye to win this challenge. You must be a female character or you can't kill him.", "Sir Leye (level 20) with no items", true,
 			femaleReq);
 
 		leaveSirKuamRoom = new ObjectStep(this, 7317, "Leave through the portal to continue.");
@@ -372,9 +369,12 @@ public class RecruitmentDrive extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Sir Leye (level 20) with no items");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSirLeye);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/regicide/Regicide.java
+++ b/src/main/java/com/questhelper/quests/regicide/Regicide.java
@@ -44,11 +44,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -625,7 +622,7 @@ public class Regicide extends BasicQuestHelper
 			"");
 		climbThroughForest = new ObjectStep(this, ObjectID.DENSE_FOREST_3939, new WorldPoint(2239, 3149, 0),
 			"");
-		killGuard = new NpcStep(this, NpcID.TYRAS_GUARD, "Kill the guard.");
+		killGuard = new CombatStep(this, NpcID.TYRAS_GUARD, "Kill the guard.", "Tyras guard (level 110)");
 		crossTripwire = new ObjectStep(this, ObjectID.TRIPWIRE_3921, new WorldPoint(2220, 3154, 0),
 			"Cross the tripwire to the north. It may poison you if you fail it.");
 		goKillGuardAtSecondForest = new NpcStep(this, NpcID.TYRAS_GUARD_3433, new WorldPoint(2188, 3170, 0),
@@ -895,9 +892,12 @@ public class Regicide extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Tyras guard (level 110)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGuard);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/rovingelves/RovingElves.java
+++ b/src/main/java/com/questhelper/quests/rovingelves/RovingElves.java
@@ -40,12 +40,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -180,7 +176,7 @@ public class RovingElves extends BasicQuestHelper
 			glarialsPebble);
 		enterGlarialsTombstone.addIcon(ItemID.GLARIALS_PEBBLE);
 
-		killGuardian = new NpcStep(this, NpcID.MOSS_GUARDIAN, new WorldPoint(2515, 9844, 0), "Kill the Moss Guardian for a Consecration seed.");
+		killGuardian = new CombatStep(this, NpcID.MOSS_GUARDIAN, new WorldPoint(2515, 9844, 0), "Kill the Moss Guardian for a Consecration seed.", "Moss Guardian (level 84) without runes, weapons, or armour");
 
 		pickUpSeed = new ItemStep(this, "Pick up the consecration seed.", seed);
 
@@ -214,9 +210,12 @@ public class RovingElves extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Moss Guardian (level 84) without runes, weapons, or armour");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGuardian);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/royaltrouble/RoyalTrouble.java
+++ b/src/main/java/com/questhelper/quests/royaltrouble/RoyalTrouble.java
@@ -45,12 +45,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -544,7 +539,7 @@ public class RoyalTrouble extends BasicQuestHelper
 		enterSnakesRoom = new ObjectStep(this, ObjectID.CREVICE_15194, new WorldPoint(2585, 10260, 0), "Enter the crevice at the end of the path.");
 		enterBossRoom = new ObjectStep(this, ObjectID.CREVICE_15196, new WorldPoint(2617, 10272, 0), "Prepare to fight the Giant Sea Snake. It will only use ranged attacks if you stand at a distance. It can poison you.");
 
-		killBoss = new NpcStep(this, NpcID.GIANT_SEA_SNAKE, new WorldPoint(2615, 10280, 0), "Kill the Giant Sea Snake.");
+		killBoss = new CombatStep(this, NpcID.GIANT_SEA_SNAKE, new WorldPoint(2615, 10280, 0), "Kill the Giant Sea Snake.", "Giant Sea Snake (level 149)");
 
 		talkToArmod = new NpcStep(this, NpcID.ARMOD, new WorldPoint(2572, 10277, 0), "Talk to Armod.");
 
@@ -572,10 +567,11 @@ public class RoyalTrouble extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Giant Sea Snake (level 149)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBoss);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/rumdeal/RumDeal.java
+++ b/src/main/java/com/questhelper/quests/rumdeal/RumDeal.java
@@ -44,12 +44,7 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -394,14 +389,14 @@ public class RumDeal extends BasicQuestHelper
 		talkToDavey = new NpcStep(this, NpcID.DAVEY, new WorldPoint(2132, 5100, 1), "Talk to Davey south west of Captain Braindeath.", wrench, prayerPoints47);
 		useWrenchOnControl = new ObjectStep(this, NullObjectID.NULL_10104, new WorldPoint(2144, 5101, 1), "Use the holy wrench on the brewing control. Be prepared to fight an evil spirit.", holyWrench);
 		useWrenchOnControl.addIcon(ItemID.HOLY_WRENCH);
-		killSpirit = new NpcStep(this, NpcID.EVIL_SPIRIT, "Kill the Evil Spirit.", prayerPoints47);
+		killSpirit = new CombatStep(this, NpcID.EVIL_SPIRIT, "Kill the Evil Spirit.", "Evil spirit (level 150)", prayerPoints47);
 
 		goUpFromSpiders = new ObjectStep(this, ObjectID.LADDER_10167, new WorldPoint(2139, 5105, 0), "Go up the ladder.");
 
 		talkToBraindeathAfterSpirit = new NpcStep(this, NpcID.CAPTAIN_BRAINDEATH, new WorldPoint(2145, 5108, 1), "Talk to Captain Braindeath.");
 		goDownToSpiders = new ObjectStep(this, ObjectID.LADDER_10168, new WorldPoint(2139, 5105, 1), "Go into the brewery's basement and kill a fever spider. If you're not wearing slayer gloves they'll afflict you with disease.", slayerGloves);
 
-		killSpider = new NpcStep(this, NpcID.FEVER_SPIDER, "Go into the brewery's basement and kill a fever spider. If you're not wearing slayer gloves they'll afflict you with disease.", slayerGloves.equipped());
+		killSpider = new CombatStep(this, NpcID.FEVER_SPIDER, "Go into the brewery's basement and kill a fever spider. If you're not wearing slayer gloves they'll afflict you with disease.", "Fever spider (level 49)", slayerGloves.equipped());
 		pickUpCarcass = new ItemStep(this, "Pick up the fever spider body.", spiderCarcass);
 		goUpFromSpidersWithCorpse = new ObjectStep(this, ObjectID.LADDER_10167, new WorldPoint(2139, 5105, 0), "Add the spider body to the hopper on the top floor.", spiderCarcass);
 		goUpToDropSpider = new ObjectStep(this, ObjectID.LADDER_10167, new WorldPoint(2163, 5092, 1), "Add the spider body to the hopper on the top floor.", spiderCarcass);
@@ -433,9 +428,13 @@ public class RumDeal extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Evil spirit (level 150)", "Fever spider (level 49)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSpirit);
+		reqs.add(killSpider);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/scorpioncatcher/ScorpionCatcher.java
+++ b/src/main/java/com/questhelper/quests/scorpioncatcher/ScorpionCatcher.java
@@ -17,11 +17,7 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -258,9 +254,12 @@ public class ScorpionCatcher extends BasicQuestHelper
 	}
 
 	@Override
-	public ArrayList<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return new ArrayList<>(Collections.singletonList("The ability to run past level 172 black demons and level 64 poison spiders"));
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "The ability to run past level 172 black demons and level 64 poison spiders"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shadesofmortton/ShadesOfMortton.java
+++ b/src/main/java/com/questhelper/quests/shadesofmortton/ShadesOfMortton.java
@@ -38,11 +38,7 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.Operation;
@@ -307,9 +303,12 @@ public class ShadesOfMortton extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("5 Loar Shades (level 40)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.LOAR_SHADE,"5 Loar Shades (level 40)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -42,13 +42,8 @@ import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedOwnerStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -328,9 +323,12 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Agrith-Naar (level 100)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.AGRITH_NAAR, "Agrith-Naar (level 100)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
+++ b/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
@@ -37,11 +37,8 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -145,7 +142,7 @@ public class ShieldOfArravBlackArmGang extends BasicQuestHelper
 
 		goUpToWeaponStore = new ObjectStep(this, ObjectID.LADDER_11794, new WorldPoint(3252, 3384, 0), "Go up the ladder in south east Varrock to the Phoenix Weapon Storeroom.", storeRoomKey);
 
-		killWeaponsMaster = new NpcStep(this, NpcID.WEAPONSMASTER, new WorldPoint(3247, 3384, 1), "Kill the Weaponsmaster, or have someone else kill him.");
+		killWeaponsMaster = new CombatStep(this, NpcID.WEAPONSMASTER, new WorldPoint(3247, 3384, 1), "Kill the Weaponsmaster, or have someone else kill him.", "Weaponsmaster (level 23), or a friend to kill him for you");
 
 		// TODO: Issue with this step, as a crossbow upon killing the weaponsmaster dissappears/appears, the initial despawn doesn't effect the initial area check, so a blue marker remains on the floor
 		pickupTwoCrossbows = new DetailedQuestStep(this, "Pick up TWO phoenix crossbows", twoPhoenixCrossbow);
@@ -196,9 +193,12 @@ public class ShieldOfArravBlackArmGang extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Weaponsmaster (level 23), or a friend to kill him for you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killWeaponsMaster);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
+++ b/src/main/java/com/questhelper/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
@@ -30,10 +30,7 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.conditional.ObjectCondition;
@@ -52,7 +49,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.SHIELD_OF_ARRAV_PHOENIX_GANG
@@ -149,7 +145,7 @@ public class ShieldOfArravPhoenixGang extends BasicQuestHelper
 		talkToStraven.addDialogStep("I'd like to offer you my services.");
 
 		goUpFromPhoenixGang = new ObjectStep(this, ObjectID.LADDER_2405, new WorldPoint(3244, 9783, 0), "Go back up to the surface.");
-		killJonny = new NpcStep(this, NpcID.JONNY_THE_BEARD, new WorldPoint(3222, 3395, 0), "Kill Jonny the Beard in the Blue Moon Inn in Varrock.");
+		killJonny = new CombatStep(this, NpcID.JONNY_THE_BEARD, new WorldPoint(3222, 3395, 0), "Kill Jonny the Beard in the Blue Moon Inn in Varrock.", "Jonny the beard (level 2)");
 		pickupIntelReport = new DetailedQuestStep(this, "Pick up the Intel Report.", intelReport);
 		returnDownLadder = new ObjectStep(this, ObjectID.LADDER_11803, new WorldPoint(3244, 3383, 0), "Return to the Phoenix Gang's base.");
 		talkToStravenAgain = new NpcStep(this, NpcID.STRAVEN, new WorldPoint(3247, 9781, 0), "Talk to Staven again.");
@@ -199,9 +195,12 @@ public class ShieldOfArravPhoenixGang extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Jonny the beard (level 2)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killJonny);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
+++ b/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
@@ -49,12 +49,8 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -356,9 +352,9 @@ public class ShiloVillage extends BasicQuestHelper
 		searchDolmenForFight = new ObjectStep(this, ObjectID.TOMB_DOLMEN_2258, new WorldPoint(2893, 9488, 0),
 			"Search the dolmen, ready to fight.");
 
-		killNazastarool = new NpcStep(this, NpcID.NAZASTAROOL, new WorldPoint(2892, 9488, 0),
+		killNazastarool = new CombatStep(this, NpcID.NAZASTAROOL, new WorldPoint(2892, 9488, 0),
 			"Defeat Nazastrool's 3 forms. You can safe spot them over the dolem, and the Crumble Undead spell is very" +
-				" strong against them.");
+				" strong against them.", "Nazastarool 3 times (levels 68, 91, 93) (safespottable)");
 		((NpcStep) killNazastarool).addAlternateNpcs(NpcID.NAZASTAROOL_5354, NpcID.NAZASTAROOL_5355);
 		((NpcStep)killNazastarool).addSafeSpots(new WorldPoint(2894, 9486, 0), new WorldPoint(2891, 9486, 0));
 		pickupCorpse = new ItemStep(this, "Pickup Rashiliyia's corpse.", rashCorpse);
@@ -385,9 +381,12 @@ public class ShiloVillage extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Nazastarool 3 times (levels 68, 91, 93) (safespottable)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killNazastarool);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
+++ b/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
@@ -43,11 +43,7 @@ import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.conditional.NpcCondition;
@@ -521,8 +517,8 @@ public class SinsOfTheFather extends BasicQuestHelper
 		goDownToKroy = new ObjectStep(this, ObjectID.STAIRS_32637, new WorldPoint(3728, 3301, 0), "Go down the stairs to fight Kroy.");
 		goDownToKroy.addDialogStep("Continue the Sins of the Father quest.");
 
-		killKroy = new NpcStep(this, NpcID.KROY_9560, new WorldPoint(3734, 9763, 1),
-			"Kill Kroy.");
+		killKroy = new CombatStep(this, NpcID.KROY_9560, new WorldPoint(3734, 9763, 1),
+			"Kill Kroy.", "Kroy (level 133)");
 		killKroy.addSubSteps(goDownToKroy);
 
 		destroyLab = new ObjectStep(this, NullObjectID.NULL_39516, new WorldPoint(3730, 9760, 1),
@@ -585,7 +581,7 @@ public class SinsOfTheFather extends BasicQuestHelper
 		leaveBridgeArea.addDialogStep("Yes.");
 
 		/* Vampyre Juvinate section */
-		killJuvinates = new NpcStep(this, NpcID.VAMPYRE_JUVINATE_9615, new WorldPoint(2396, 5011, 0), "Kill the juvinates with the Ivandis Flail. Try to attack the one near Ivan before it can attack him.", true, ivandisFlailEquipped);
+		killJuvinates = new CombatStep(this, NpcID.VAMPYRE_JUVINATE_9615, new WorldPoint(2396, 5011, 0), "Kill the juvinates with the Ivandis Flail. Try to attack the one near Ivan before it can attack him.", "Vampyre juveniles (level 122 and 119)", true, ivandisFlailEquipped);
 		((NpcStep) (killJuvinates)).addAlternateNpcs(NpcID.VAMPYRE_JUVINATE_9614);
 		leaveJuvinateArea = new ObjectStep(this, ObjectID.PATH_38011, new WorldPoint(2397, 5023, 0), "Continue the trek.");
 		leaveJuvinateArea.addDialogStep("Yes.");
@@ -640,8 +636,8 @@ public class SinsOfTheFather extends BasicQuestHelper
 		talkToSafalaanInLab.addDialogStep("Shall we get going then?");
 		talkToSafalaanInLab.addDialogStep("Let's go.");
 		enterDeepLab = new ObjectStep(this, ObjectID.DOOR_17911, new WorldPoint(3629, 9680, 0), "Enter the door to the deeper labs.");
-		killBloodveld = new NpcStep(this, NpcID.MUTATED_BLOODVELD_9611, new WorldPoint(3611, 9737, 0),
-			"Defeat the Mutated Bloodveld (lvl-123).");
+		killBloodveld = new CombatStep(this, NpcID.MUTATED_BLOODVELD_9611, new WorldPoint(3611, 9737, 0),
+			"Defeat the Mutated Bloodveld.", "Mutated bloodveld (level 123)");
 		talkToSafalaanInDeepLab = new NpcStep(this, NpcID.SAFALAAN_HALLOW_9537, new WorldPoint(3611, 9737, 0),
 			"Finish speaking with Safalaan in the Lab.");
 		searchLabBookcase = new ObjectStep(this, ObjectID.BOOKSHELF_38017, new WorldPoint(3589, 9745, 0),
@@ -682,8 +678,8 @@ public class SinsOfTheFather extends BasicQuestHelper
 			unscentedTop, unscentedLegs, unscentedShoes, ivandisFlailEquipped);
 		talkToVeliafForFight.addDialogSteps("Slepe.", "Let's do this.");
 
-		killDamien = new NpcStep(this, NpcID.DAMIEN_LEUCURTE_9564, new WorldPoint(3717, 3358, 1),
-			"Kill Damien Leucurte (lvl-204). He can poison you. Stomp out any of the fires he spawns.",
+		killDamien = new CombatStep(this, NpcID.DAMIEN_LEUCURTE_9564, new WorldPoint(3717, 3358, 1),
+			"Kill Damien Leucurte (lvl-204). He can poison you. Stomp out any of the fires he spawns.", "Damien Leucurte (level 204)",
 			unscentedTop, unscentedLegs, unscentedShoes, ivandisFlailEquipped);
 		killDamien.addDialogSteps("Slepe.", "Let's do this.");
 
@@ -828,9 +824,17 @@ public class SinsOfTheFather extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Kroy (level 133)", "Vampyre juveniles (level 122 and 119)", "Nail beasts (level 143 and 67)", "Mutated bloodveld (level 123)", "Damien Leucurte (level 204)", "Vanstrom Klause (level 413)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killKroy);
+		reqs.add(killJuvinates);
+		reqs.add(new CombatStep(this, NpcID.NAIL_BEAST, "Nail beasts (level 143 and 67)"));
+		reqs.add(killBloodveld);
+		reqs.add(killDamien);
+		reqs.add(new CombatStep(this, NpcID.VANSTROM_KLAUSE, "Vanstrom Klause (level 413)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
+++ b/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
@@ -46,13 +46,7 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.EmoteStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.steps.emote.QuestEmote;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1221,8 +1215,8 @@ public class SongOfTheElves extends BasicQuestHelper
 		goUpLletyaLadder = new ObjectStep(this, ObjectID.LADDER_8744, new WorldPoint(2911, 6168, 0), "Go upstairs.");
 		searchCookingPots = new ObjectStep(this, ObjectID.COOKING_POTS_35875, new WorldPoint(2915, 6164, 1),
 				"Search the nearby cooking pots.");
-		fightArianwyn = new NpcStep(this, NpcID.ARIANWYN_8865, new WorldPoint(2906, 6179, 0),
-			"Defeat Arianwyn. Protect from Ranged. Move when he shoots orange arrows.");
+		fightArianwyn = new CombatStep(this, NpcID.ARIANWYN_8865, new WorldPoint(2906, 6179, 0),
+			"Defeat Arianwyn. Protect from Ranged. Move when he shoots orange arrows.", "Arianwyn (level 182)");
 
 		talkToBaxAfterLletyaFightForIthellClue = new NpcStep(this, NpcID.BAXTORIAN, new WorldPoint(2801, 6116, 0),
 			"Talk to Baxtorian in Lletya about Ithell and Meilyr.");
@@ -1300,12 +1294,12 @@ public class SongOfTheElves extends BasicQuestHelper
 		talkToBaxAfterFillingHoles.addDialogStep("I'm ready.");
 		defendDwarfCamp = new NpcStep(this, NpcID.IORWERTH_ARCHER_8953, "Defend the camp.", true);
 		((NpcStep) defendDwarfCamp).addAlternateNpcs(NpcID.IORWERTH_ARCHER_8954, NpcID.IORWERTH_WARRIOR_8955, NpcID.IORWERTH_WARRIOR_8956);
-		defeatEssyllt = new NpcStep(this, NpcID.ESSYLLT_8950, new WorldPoint(2442, 6094, 0),
-				"Defeat Essyllt. Protect from melee. He can drain your stats, so drink super restores when needed.");
+		defeatEssyllt = new CombatStep(this, NpcID.ESSYLLT_8950, new WorldPoint(2442, 6094, 0),
+				"Defeat Essyllt. Protect from melee. He can drain your stats, so drink super restores when needed.", "Essyllt (level 236)");
 		defeatEssyllt.addText("When he shoves you, flick to Protect from Ranged then back to Protect from Melee.");
 		enterWellCaveForFragmentFight = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_4006, new WorldPoint(2314, 3217, 0),
 			"Enter the Underground Pass from the Elven Lands entrance, and make your way to the dwarven camp. Make sure you're prepared for battle with magic gear.");
-		defeatFragmentOfSeren = new NpcStep(this, NpcID.FRAGMENT_OF_SEREN, "");
+		defeatFragmentOfSeren = new CombatStep(this, NpcID.FRAGMENT_OF_SEREN, "", "Fragment of Seren (level 494)");
 		defeatFragmentOfSeren.addSubSteps(enterWellCaveForFragmentFight);
 
 		defeatFragmentSidebar = new DetailedQuestStep(this, "Defeat the Fragment of Seren. Protect from Ranged, and keep your distance.");
@@ -1383,10 +1377,15 @@ public class SongOfTheElves extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Many Mourners, Paladins and Knights of Ardougne", "Arianwyn" +
-			" (level 182)", "Essyllt (level 236)", "Fragment of Seren (level 494)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Many Mourners, Paladins and Knights of Ardougne"));
+		reqs.add(fightArianwyn);
+		reqs.add(defeatEssyllt);
+		reqs.add(defeatFragmentOfSeren);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/spiritsoftheelid/SpiritsOfTheElid.java
+++ b/src/main/java/com/questhelper/quests/spiritsoftheelid/SpiritsOfTheElid.java
@@ -41,11 +41,7 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -303,10 +299,13 @@ public class SpiritsOfTheElid extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Black Golem, Grey Golem, White Golem (Level 75)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.BLACK_GOLEM, "Black Golem (level 75)"));
+		reqs.add(new CombatStep(this, NpcID.GREY_GOLEM, "Grey Golem (level 75)"));
+		reqs.add(new CombatStep(this, NpcID.WHITE_GOLEM, "White Golem (level 75)"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/swansong/SwanSong.java
+++ b/src/main/java/com/questhelper/quests/swansong/SwanSong.java
@@ -46,11 +46,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -238,7 +234,7 @@ public class SwanSong extends BasicQuestHelper
 		talkToWomAtColony.addDialogStep("I'm ready to fight.");
 		enterColony = new ObjectStep(this, ObjectID.HOLE_12656, new WorldPoint(2344, 3651, 0), "Enter the Fishing Colony, prepared to fight trolls.", combatGear, log, tinderbox, ironBar5, hammer);
 		talkToWomAtColony.addSubSteps(enterColony);
-		kill79Trolls = new NpcStep(this, NpcID.SEA_TROLL, new WorldPoint(2343, 3657, 0), "Kill the sea trolls.", true);
+		kill79Trolls = new CombatStep(this, NpcID.SEA_TROLL, new WorldPoint(2343, 3657, 0), "Kill the sea trolls.", "11 Sea trolls (levels 65/79/87/101)", true);
 		talkToHermanInBuilding = new NpcStep(this, NpcID.HERMAN_CARANOS, new WorldPoint(2354, 3683, 0), "Talk to Herman in the east of the Fishing Colony.");
 		talkToFranklin = new NpcStep(this, NpcID.FRANKLIN_CARANOS, new WorldPoint(2341, 3667, 0), "Talk to Franklin in the middle of the Fishing Colony.");
 		useLog = new ObjectStep(this, NullObjectID.NULL_13702, new WorldPoint(2344, 3676, 0), "Add some logs to the firebox in the building with a furnace.", logHiglight);
@@ -274,7 +270,7 @@ public class SwanSong extends BasicQuestHelper
 		talkToHermanForFinalFight.addDialogStep("I'm ready. Let's fight!");
 		talkToHermanForFinalFight.addSubSteps(talkToHermanWithPot);
 
-		killQueen = new NpcStep(this, NpcID.SEA_TROLL_QUEEN, new WorldPoint(2347, 3704, 0), "Kill the Sea Troll Queen.", combatGearRanged);
+		killQueen = new CombatStep(this, NpcID.SEA_TROLL_QUEEN, new WorldPoint(2347, 3704, 0), "Kill the Sea Troll Queen.", "Sea troll queen (level 170)", combatGearRanged);
 		killQueen.addDialogStep("No, I'm ready to move on with the quest.");
 		talkToHermanToFinish = new NpcStep(this, NpcID.HERMAN_CARANOS, new WorldPoint(2354, 3683, 0), "Talk to the Herman to finish the quest.");
 	}
@@ -287,11 +283,12 @@ public class SwanSong extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("11 Sea trolls (levels 65/79/87/101)");
-		reqs.add("Sea troll queen (level 170)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(kill79Trolls);
+		reqs.add(killQueen);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/taleoftherighteous/TaleOfTheRighteous.java
+++ b/src/main/java/com/questhelper/quests/taleoftherighteous/TaleOfTheRighteous.java
@@ -35,7 +35,7 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.DetailedQuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
@@ -57,10 +57,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.TALE_OF_THE_RIGHTEOUS
@@ -260,8 +256,8 @@ public class TaleOfTheRighteous extends BasicQuestHelper
 
 		tryToEnterBarrier = new ObjectStep(this, ObjectID.MAGIC_GATE, new WorldPoint(1172, 9947, 0),
 			"Attempt to enter the magic gate to the south room. You will need to kill the corrupted lizardman who appears.");
-		killLizardman = new NpcStep(this, NpcID.CORRUPT_LIZARDMAN_8000, new WorldPoint(1172, 9947, 0),
-			"Kill the corrupt lizardman.");
+		killLizardman = new CombatStep(this, NpcID.CORRUPT_LIZARDMAN_8000, new WorldPoint(1172, 9947, 0),
+			"Kill the corrupt lizardman.", "Corrupt Lizardman (level 46)");
 		tryToEnterBarrier.addSubSteps(killLizardman);
 
 		inspectUnstableAltar = new ObjectStep(this, ObjectID.UNSTABLE_ALTAR, new WorldPoint(1172, 9929, 0),
@@ -323,10 +319,11 @@ public class TaleOfTheRighteous extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Corrupt Lizardman (level 46)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killLizardman);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/templeofikov/TempleOfIkov.java
+++ b/src/main/java/com/questhelper/quests/templeofikov/TempleOfIkov.java
@@ -46,12 +46,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -312,8 +308,8 @@ public class TempleOfIkov extends BasicQuestHelper
 		tryToEnterWitchRoom = new ObjectStep(this, ObjectID.DOOR_93, new WorldPoint(2646, 9870, 0),
 			"Try to enter the far north door. Be prepared to fight Lesarkus, who can only be hurt by ice arrows.", yewOrBetterBow, iceArrowsEquipped);
 
-		fightLes = new NpcStep(this, NpcID.FIRE_WARRIOR_OF_LESARKUS, new WorldPoint(2646, 9866, 0),
-			"Kill the Fire Warrior of Lesarkus. He can only be hurt by the ice arrows.", yewOrBetterBow, iceArrowsEquipped);
+		fightLes = new CombatStep(this, NpcID.FIRE_WARRIOR_OF_LESARKUS, new WorldPoint(2646, 9866, 0),
+			"Kill the Fire Warrior of Lesarkus. He can only be hurt by the ice arrows.", "Fire Warrior of Lesarkus (level 84) with ranged", yewOrBetterBow, iceArrowsEquipped);
 
 		enterDungeonKilledLes = new ObjectStep(this, ObjectID.LADDER_17384, new WorldPoint(2677, 3405, 0),
 			"Enter the Temple of Ikov north of East Ardougne.", pendantOfLucienEquipped, limpwurt20);
@@ -366,12 +362,14 @@ public class TempleOfIkov extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Able to survive multiple aggressive spiders (level 61) and demons (level 82)");
-		reqs.add("Fire Warrior of Lesarkus (level 84) with ranged");
-		reqs.add("If siding with Lucien, Guardian of Armadyl (level 43)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Able to survive multiple aggressive spiders (level 61) and demons (level 82)"));
+		reqs.add(fightLes);
+		reqs.add(new CombatStep(this, NpcID.GUARDIAN_OF_ARMADYL, "If siding with Lucien, Guardian of Armadyl (level 43)"));
+		reqs.add(new CombatStep(this, NpcID.LUCIEN, "If opposing him, Lucien (level 14)"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/theascentofarceuus/TheAscentOfArceuus.java
+++ b/src/main/java/com/questhelper/quests/theascentofarceuus/TheAscentOfArceuus.java
@@ -43,10 +43,7 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.player.InInstanceRequirement;
 import java.util.ArrayList;
@@ -199,8 +196,8 @@ public class TheAscentOfArceuus extends BasicQuestHelper
 			" of Magic in Arceuus, ready to fight some level 16 Tormented Souls.", combatGear);
 		enterTowerOfMagic.addDialogStep("Yes.");
 
-		killTormentedSouls = new NpcStep(this, NpcID.TORMENTED_SOUL, new WorldPoint(1585, 3821, 0),
-			"Defeat the tormented souls.", true, combatGear);
+		killTormentedSouls = new CombatStep(this, NpcID.TORMENTED_SOUL, new WorldPoint(1585, 3821, 0),
+			"Defeat the tormented souls.", "5 Tormented Souls (level 16)", true, combatGear);
 		((NpcStep) killTormentedSouls).addAlternateNpcs(NpcID.TORMENTED_SOUL_8513);
 
 		goUpstairsTowerOfMagic = new ObjectStep(this, ObjectID.STAIRS_33575, new WorldPoint(1585, 3821, 0),
@@ -237,8 +234,8 @@ public class TheAscentOfArceuus extends BasicQuestHelper
 
 		inspectTrack6 = new ObjectStep(this, NullObjectID.NULL_34625, new WorldPoint(1282, 3726, 0),
 			"Inspect the final plant and kill the Trapped Soul (level 30) which appears.", combatGear);
-		killTrappedSoul = new NpcStep(this, NpcID.TRAPPED_SOUL, new WorldPoint(1281, 3724, 0),
-			"Kill the Trapped Soul.");
+		killTrappedSoul = new CombatStep(this, NpcID.TRAPPED_SOUL, new WorldPoint(1281, 3724, 0),
+			"Kill the Trapped Soul.", "Trapped Soul (level 30)");
 		inspectTrack6.addSubSteps(killTrappedSoul);
 
 		enterKaruulmAgain = new ObjectStep(this, ObjectID.ELEVATOR, new WorldPoint(1311, 3807, 0),
@@ -266,9 +263,13 @@ public class TheAscentOfArceuus extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("5 Tormented Souls (level 16)", "Trapped Soul (level 30)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killTormentedSouls);
+		reqs.add(killTrappedSoul);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thecorsaircurse/TheCorsairCurse.java
+++ b/src/main/java/com/questhelper/quests/thecorsaircurse/TheCorsairCurse.java
@@ -38,12 +38,7 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.DigStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -335,7 +330,7 @@ public class TheCorsairCurse extends BasicQuestHelper
 
 		goUpToIthoiToKill = new ObjectStep(this, ObjectID.STAIRS_31735, new WorldPoint(2531, 2833, 0), "Go kill Ithoi (level 35) in his hut.");
 		goUpToIthoiToKill.addDialogStep("I'll be back.");
-		killIthoi = new NpcStep(this, NpcID.ITHOI_THE_NAVIGATOR_7964, new WorldPoint(2529, 2840, 1), "Kill Ithoi (level 35).");
+		killIthoi = new CombatStep(this, NpcID.ITHOI_THE_NAVIGATOR_7964, new WorldPoint(2529, 2840, 1), "Kill Ithoi (level 35).", "Ithoi the Navigator (level 34)");
 		killIthoi.addSubSteps(goUpToIthoiToKill);
 
 		goOntoShip4 = new ObjectStep(this, ObjectID.GANGPLANK_31756, new WorldPoint(2578, 2839, 0), "Talk to Captain Tock on the ship to finish the quest.");
@@ -353,10 +348,11 @@ public class TheCorsairCurse extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Ithoi the Navigator (level 34)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killIthoi);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/thedepthsofdespair/TheDepthsOfDespair.java
+++ b/src/main/java/com/questhelper/quests/thedepthsofdespair/TheDepthsOfDespair.java
@@ -43,12 +43,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -210,7 +206,7 @@ public class TheDepthsOfDespair extends BasicQuestHelper
 
 		talkToArturHosidius = new NpcStep(this, NpcID.ARTUR_HOSIDIUS_7899, "Speak to Artur Hosidius.");
 
-		killSandSnake = new NpcStep(this, NpcID.SAND_SNAKE_7903, "Kill the Sand Snake.");
+		killSandSnake = new CombatStep(this, NpcID.SAND_SNAKE_7903, "Kill the Sand Snake.", "Sand Snake (level 36)");
 
 		searchChest = new ObjectStep(this, ObjectID.CHEST_31703, "Search the chest.");
 
@@ -225,9 +221,12 @@ public class TheDepthsOfDespair extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Sand Snake (level 36)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSandSnake);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
+++ b/src/main/java/com/questhelper/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
@@ -40,11 +40,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -303,9 +300,12 @@ public class TheEyesOfGlouphrie extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Evil creature (x6)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.EVIL_CREATURE, "Evil creature x6"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thefeud/TheFeud.java
+++ b/src/main/java/com/questhelper/quests/thefeud/TheFeud.java
@@ -47,11 +47,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -490,9 +486,13 @@ public class TheFeud extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Bandit Champion (level 70) - Safespottable", "Tough Guy (level 75) - Safespottable");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.BANDIT_CHAMPION, "Bandit Champion (level 70) - Safespottable"));
+		reqs.add(new CombatStep(this, NpcID.TOUGH_GUY, "Tough Guy (level 75) - Safespottable"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikexiles/TheFremennikExiles.java
@@ -46,10 +46,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,8 +67,6 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.QuestStep;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.THE_FREMENNIK_EXILES
@@ -344,8 +340,8 @@ public class TheFremennikExiles extends BasicQuestHelper
 			"Search the sand pit near Freygerd, ready to fight a basilisk youngling.", combatGear, mirrorShield.equipped());
 		searchSandpitForLetter = new ObjectStep(this, NullObjectID.NULL_4373, new WorldPoint(2668, 3708, 0),
 			"Search the sand pit near Freygerd for a letter.", letter.highlighted());
-		killYoungling = new NpcStep(this, NpcID.BASILISK_YOUNGLING, new WorldPoint(2666, 3708, 0),
-			"Defeat the Basilisk Youngling.", combatGear, mirrorShield.equipped());
+		killYoungling = new CombatStep(this, NpcID.BASILISK_YOUNGLING, new WorldPoint(2666, 3708, 0),
+			"Defeat the Basilisk Youngling.", "Basilisk Youngling (level 53)", combatGear, mirrorShield.equipped());
 		pickupLetter = new ItemStep(this, "Pick up the letter.", letter);
 		pickupLetter.addSubSteps(searchSandpitForLetter);
 		readLetter = new DetailedQuestStep(this, "Read the letter.", letter.highlighted());
@@ -428,8 +424,8 @@ public class TheFremennikExiles extends BasicQuestHelper
 			"Waterbirth Dungeon or Bardur in Waterbirth " +
 			"Dungeon for 150k, or for free with the Ring of Charos(a). You'll need a friend to get there, or a rune " +
 			"thrownaxe and a pet rock.", coins150kOrCharos);
-		killBasilisks = new NpcStep(this, NpcID.BASILISK_9283, new WorldPoint(2644, 3677, 0),
-			"Kill basilisks until you're told to stop.", true, vShield.equipped(), combatGear, food);
+		killBasilisks = new CombatStep(this, NpcID.BASILISK_9283, new WorldPoint(2644, 3677, 0),
+			"Kill basilisks until you're told to stop.", "Several Basilisk (level 61)", true, vShield.equipped(), combatGear, food);
 		((NpcStep) killBasilisks).addAlternateNpcs(NpcID.BASILISK_9284, NpcID.BASILISK_9285, NpcID.BASILISK_9286,
 			NpcID.MONSTROUS_BASILISK_9287, NpcID.MONSTROUS_BASILISK_9288);
 		travelToIsleOfStone = new ObjectStep(this, NullObjectID.NULL_37432, new WorldPoint(2623, 3693, 0),
@@ -445,13 +441,13 @@ public class TheFremennikExiles extends BasicQuestHelper
 		enterCaveToFight = new ObjectStep(this, NullObjectID.NULL_37433, new WorldPoint(2465, 4012, 0),
 			"Enter the door, ready to fight.", combatGear, vShield.equipped());
 		enterCaveToFight.addDialogStep("Yes.");
-		fightTyphor = new NpcStep(this, NpcID.TYPHOR, new WorldPoint(2457, 10384, 0), "Fight Typhor, who attacks " +
-			"with both Melee and Magic", vShield.equipped());
+		fightTyphor = new CombatStep(this, NpcID.TYPHOR, new WorldPoint(2457, 10384, 0), "Fight Typhor, who attacks " +
+			"with both Melee and Magic", "Typhor (level 218)", vShield.equipped());
 		((NpcStep) fightTyphor).addAlternateNpcs(NpcID.TYPHOR_9296);
 
 		PrayerRequirement protectFromMagic = new PrayerRequirement("Protect from Magic", Prayer.PROTECT_FROM_MAGIC);
-		fightJormungand = new NpcStep(this, NpcID.THE_JORMUNGAND, new WorldPoint(2457, 10384, 0), "Defeat the " +
-			"Jormungand.", vShield.equipped(), protectFromMagic);
+		fightJormungand = new CombatStep(this, NpcID.THE_JORMUNGAND, new WorldPoint(2457, 10384, 0), "Defeat the " +
+			"Jormungand.", "The Jormungand (level 363)", vShield.equipped(), protectFromMagic);
 		fightJormungand.addText("When the screen turns red, have your character face away from him.");
 		fightJormungand.addText("When frozen in rock, click repeatedly to break out.");
 		((NpcStep) fightJormungand).addAlternateNpcs(NpcID.THE_JORMUNGAND_9290, NpcID.THE_JORMUNGAND_9291, NpcID.THE_JORMUNGAND_9292);
@@ -476,15 +472,16 @@ public class TheFremennikExiles extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList(
-			"Basilisk Youngling (level 53)",
-			"Basilisk (level 61)",
-			"Monstrous Basilisk (level 135)",
-			"Typhor (level 218)",
-			"The Jormungand (level 363)"
-		);
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killYoungling);
+		reqs.add(killBasilisks);
+		reqs.add(new CombatStep(this, NpcID.MONSTROUS_BASILISK_9287, "Monstrous Basilisk (level 135)"));
+		reqs.add(fightTyphor);
+		reqs.add(fightJormungand);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -39,10 +39,7 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
 import java.util.ArrayList;
@@ -55,7 +52,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -542,7 +538,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 		killTrolls = new KillTrolls(this);
 		enterKingRoom = new ObjectStep(this, ObjectID.ROPE_BRIDGE_21316, new WorldPoint(2385, 10263, 1), "Cross the rope bridge. Be prepared to fight the Ice Troll King. Use the Protect from Magic prayer for the fight.");
-		killKing = new NpcStep(this, NpcID.ICE_TROLL_KING, new WorldPoint(2386, 10249, 1), "Kill the king. Use the Protect from Magic prayer for the fight.");
+		killKing = new CombatStep(this, NpcID.ICE_TROLL_KING, new WorldPoint(2386, 10249, 1), "Kill the king. Use the Protect from Magic prayer for the fight.", "Ice Troll King (level 122)");
 		decapitateKing = new ObjectStep(this, ObjectID.ICE_TROLL_KING, "Decapitate the king's head.");
 		finishQuest = new NpcStep(this, NpcID.MAWNIS_BUROWGAR, new WorldPoint(2335, 3800, 0), "Talk to Mawnis with the Ice Troll King's head to complete the quest.", head);
 		finishQuestGivenHead = new NpcStep(this, NpcID.MAWNIS_BUROWGAR, new WorldPoint(2335, 3800, 0), "Talk to Mawnis to complete the quest.");
@@ -573,9 +569,13 @@ public class TheFremennikIsles extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("10 Ice Trolls (level 74-82)", "Ice Troll King (level 122)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.ICE_TROLL_MALE_5824, "10x Ice Trolls (level 74-82)"));
+		reqs.add(killKing);
+
+		return reqs;
 	}
 
 

--- a/src/main/java/com/questhelper/quests/thefremenniktrials/TheFremennikTrials.java
+++ b/src/main/java/com/questhelper/quests/thefremenniktrials/TheFremennikTrials.java
@@ -47,12 +47,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.QuestSyncStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -808,7 +804,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 		bringChampionsTokenToThorvald.addDialogStep("Yes");
 		goDownLadderToKoschei = new ObjectStep(this, ObjectID.LADDER_4187, new WorldPoint(2667, 3694, 0), "When you're ready to fight Koschei, go down the ladder.", koscheiGear, optionalKoscheiGear);
 		waitForKoschei = new DetailedQuestStep(this, "Wait for Koschei the Deathless to spawn. If you brought a dramen branch you should now fletch it and equip the staff.");
-		killKoschei1 = new NpcStep(this, NpcID.KOSCHEI_THE_DEATHLESS, new WorldPoint(2660, 10080, 2), "Fight Koschei the Deathless and 'kill' him at least 3 times. Dying to his fourth phase is a SAFE death.");
+		killKoschei1 = new CombatStep(this, NpcID.KOSCHEI_THE_DEATHLESS, new WorldPoint(2660, 10080, 2), "Fight Koschei the Deathless and 'kill' him at least 3 times. Dying to his fourth phase is a SAFE death.", "Koschei the deathless");
 		killKoschei2 = new NpcStep(this, NpcID.KOSCHEI_THE_DEATHLESS, new WorldPoint(2660, 10080, 2), "Fight Koschei the Deathless and 'kill' him at least 3 times. Dying to his fourth phase is a SAFE death.");
 		killKoschei3 = new NpcStep(this, NpcID.KOSCHEI_THE_DEATHLESS, new WorldPoint(2660, 10080, 2), "Fight Koschei the Deathless and 'kill' him at least 3 times. Dying to his fourth phase is a SAFE death.");
 		killKoschei4 = new NpcStep(this, NpcID.KOSCHEI_THE_DEATHLESS, new WorldPoint(2660, 10080, 2), "You must now either die (SAFE DEATH), or defeat Koschei once more. Do not leave or you'll have to fight him again.");
@@ -956,11 +952,12 @@ public class TheFremennikTrials extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Koschei the deathless");
-		reqs.add("Draugen (level 69)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killKoschei1);
+		reqs.add(new CombatStep(this, NpcID.THE_DRAUGEN, "Draugen (level 69)"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/thegeneralsshadow/TheGeneralsShadow.java
+++ b/src/main/java/com/questhelper/quests/thegeneralsshadow/TheGeneralsShadow.java
@@ -41,10 +41,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -211,8 +209,8 @@ public class TheGeneralsShadow extends BasicQuestHelper
 			"the north east of the caves.", combatGear, serveredLeg);
 		enterCrack.addDialogStep("Yes");
 
-		killBouncer = new NpcStep(this, NpcID.BOUNCER_3509, new WorldPoint(8969, 2184, 0), "Kill Bouncer. You cannot " +
-			"use prayers.", combatGear, serveredLeg);
+		killBouncer = new CombatStep(this, NpcID.BOUNCER_3509, new WorldPoint(8969, 2184, 0), "Kill Bouncer. You cannot " +
+			"use prayers.", "Bouncer (level 160, can't use prayer)", combatGear, serveredLeg);
 	}
 
 	@Override
@@ -230,9 +228,12 @@ public class TheGeneralsShadow extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Bouncer (level 160, can't use prayer)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBouncer);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thegrandtree/TheGrandTree.java
+++ b/src/main/java/com/questhelper/quests/thegrandtree/TheGrandTree.java
@@ -42,11 +42,8 @@ import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -398,7 +395,7 @@ public class TheGrandTree extends BasicQuestHelper
 		// The black demon
 		climbDownTrapDoor = new ObjectStep(this, ObjectID.TRAPDOOR_26243, "Go down the trap door. Be prepared for the fight against a Black Demon (level 172).");
 		talkToGloughBeforeFight = new NpcStep(this, NpcID.GLOUGH, "Talk to Glough. You can safespot the Demon from where he stands.");
-		killBlackDemon = new NpcStep(this, NpcID.BLACK_DEMON_1432, "Kill the black Demon. You can safespot from where Glough stands.");
+		killBlackDemon = new CombatStep(this, NpcID.BLACK_DEMON_1432, "Kill the black Demon. You can safespot from where Glough stands.", "Black demon (level 172) (can be safespotted)");
 		((NpcStep) killBlackDemon).addSafeSpots(new WorldPoint(2492, 9865, 0));
 		climbDownTrapDoorAfterFight = new ObjectStep(this, ObjectID.TRAPDOOR_26243, "Go down the trap door again.");
 		talkToKingAfterFight = new NpcStep(this, NpcID.KING_NARNODE_SHAREEN, new WorldPoint(2465, 9895, 0), "Talk to King Narnode deeper in the cave.");
@@ -431,9 +428,12 @@ public class TheGrandTree extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Black demon (level 172) (can be safespotted)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBlackDemon);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -47,12 +47,8 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -499,8 +495,8 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		lightFuse = new ObjectStep(this, NullObjectID.NULL_22492, new WorldPoint(3803, 2844, 0),
 			"Light the fuse.", tinderbox.highlighted());
 		lightFuse.addIcon(ItemID.TINDERBOX);
-		killSorebones = new NpcStep(this, NpcID.SOREBONES, new WorldPoint(3815, 2843, 0),
-			"Kill sorebones in the church for items.", true,
+		killSorebones = new CombatStep(this, NpcID.SOREBONES, new WorldPoint(3815, 2843, 0),
+			"Kill sorebones in the church for items.", "4x Sorebones (level 57)", true,
 			cranialClamp.hideConditioned(givenClamp), brainTongs.hideConditioned(givenTongs),
 			neededJars.hideConditioned(givenBells), neededStaples.hideConditioned(givenStaples));
 		((NpcStep) killSorebones).addAlternateNpcs(NpcID.SOREBONES_562);
@@ -526,8 +522,8 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			divingApparatus.equipped(), combatGearForSafespotting);
 		confrontMigor = new NpcStep(this, NpcID.MIGOR, new WorldPoint(3815, 2844, 0),
 			"Confront Migor.");
-		defeatBarrelchest = new NpcStep(this, NpcID.BARRELCHEST, new WorldPoint(3815, 2844, 0),
-			"Defeat the barrelchest. You can safespot it from the door if you leave and re-enter the instance.");
+		defeatBarrelchest = new CombatStep(this, NpcID.BARRELCHEST, new WorldPoint(3815, 2844, 0),
+			"Defeat the barrelchest. You can safespot it from the door if you leave and re-enter the instance.", "Barrelchest (level 190, safespottable)");
 		((NpcStep) defeatBarrelchest).addSafeSpots(new WorldPoint(3806, 2844, 0));
 
 		pickupAnchor = new ItemStep(this, "Pickup the anchor.", anchor);
@@ -567,9 +563,13 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Barrelchest (level 190, safespottable)", "4 Sorebones (level 57)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(defeatBarrelchest);
+		reqs.add(killSorebones);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
+++ b/src/main/java/com/questhelper/quests/theknightssword/TheKnightsSword.java
@@ -41,10 +41,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -192,10 +190,11 @@ public class TheKnightsSword extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Able to survive attacks from Ice Warriors (level 57) and Ice Giants (level 53)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Able to survive attacks from Ice Warriors (level 57) and Ice Giants (level 53)"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/themagearenai/TheMageArenaI.java
+++ b/src/main/java/com/questhelper/quests/themagearenai/TheMageArenaI.java
@@ -37,11 +37,8 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -132,8 +129,8 @@ public class TheMageArenaI extends BasicQuestHelper
 			"for fighting him in the Mage Arena.", runesForCasts);
 		talkToKolodion.addDialogSteps("Can I fight here?", "Yes indeedy.", "Okay, let's fight.");
 
-		fightKolodion = new NpcStep(this, NpcID.KOLODION_1604, new WorldPoint(3105, 3934, 0), "Defeat Kolodion's " +
-			"various forms.");
+		fightKolodion = new CombatStep(this, NpcID.KOLODION_1604, new WorldPoint(3105, 3934, 0), "Defeat Kolodion's " +
+			"various forms.", "Kolodion in 5 forms, up to level 112");
 		((NpcStep) fightKolodion).addAlternateNpcs(NpcID.KOLODION_1605, NpcID.KOLODION_1606, NpcID.KOLODION_1607,
 			NpcID.KOLODION_1608, NpcID.KOLODION_1609);
 
@@ -159,9 +156,12 @@ public class TheMageArenaI extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Kolodion in 5 forms, up to level 112");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(fightKolodion);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/themagearenaii/MA2Locator.java
+++ b/src/main/java/com/questhelper/quests/themagearenaii/MA2Locator.java
@@ -35,12 +35,14 @@ import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.steps.CombatStep;
 import com.questhelper.steps.QuestStep;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import net.runelite.api.ItemID;
+import net.runelite.api.NpcID;
 import net.runelite.api.QuestState;
 import net.runelite.api.coords.WorldPoint;
 
@@ -122,10 +124,14 @@ public class MA2Locator extends ComplexStateQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Porazdir (level 235)", "Justiciar Zachariah (level 348)", "Derwen " +
-			"(level 235)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.PORAZDIR, "Porazdir (level 235)"));
+		reqs.add(new CombatStep(this, NpcID.JUSTICIAR_ZACHARIAH, "Justiciar Zachariah (level 348)"));
+		reqs.add(new CombatStep(this, NpcID.DERWEN, "Derwen (level 235)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/themagearenaii/TheMageArenaII.java
+++ b/src/main/java/com/questhelper/quests/themagearenaii/TheMageArenaII.java
@@ -39,11 +39,7 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -227,10 +223,14 @@ public class TheMageArenaII extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Porazdir (level 235)", "Justiciar Zachariah (level 348)", "Derwen " +
-			"(level 235)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.PORAZDIR, "Porazdir (level 235)"));
+		reqs.add(new CombatStep(this, NpcID.JUSTICIAR_ZACHARIAH, "Justiciar Zachariah (level 348)"));
+		reqs.add(new CombatStep(this, NpcID.DERWEN, "Derwen (level 235)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/therestlessghost/TheRestlessGhost.java
+++ b/src/main/java/com/questhelper/quests/therestlessghost/TheRestlessGhost.java
@@ -39,10 +39,8 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -202,8 +200,11 @@ public class TheRestlessGhost extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("A skeleton (level 13) you can run away from");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.SKELETON, "A skeleton (level 13) you can run away from"));
+
+		return reqs;
 	}
 }

--- a/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
@@ -44,12 +44,8 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -360,7 +356,7 @@ public class TheSlugMenace extends BasicQuestHelper
 
 		enterWallAgain = new ObjectStep(this, NullObjectID.NULL_19124, new WorldPoint(2701, 9688, 0), "Enter the wall just east of where you come down.");
 		useEmptyRunesOnDoor = new ObjectStep(this, ObjectID.IMPOSING_DOORS, new WorldPoint(2351, 5093, 0), "Use the runes on the imposing doors at the end of the path.", airRune, waterRune, earthRune, fireRune, mindRune);
-		killSlugPrince = new NpcStep(this, NpcID.SLUG_PRINCE, new WorldPoint(2351, 5093, 0), "Kill the Slug Prince. Only melee can hurt it.");
+		killSlugPrince = new CombatStep(this, NpcID.SLUG_PRINCE, new WorldPoint(2351, 5093, 0), "Kill the Slug Prince. Only melee can hurt it.", "Slug Prince (level 62) (can only be hurt by melee)");
 
 		reportBackToTiffy = new NpcStep(this, NpcID.SIR_TIFFY_CASHIEN, new WorldPoint(2996, 3373, 0), "Report back to Sir Tiffy Cashien in Falador Park.");
 		reportBackToTiffy.addDialogStep("Slug Menace.");
@@ -390,10 +386,11 @@ public class TheSlugMenace extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Slug Prince (level 62) (can only be hurt by melee)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killSlugPrince);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/thetouristtrap/TheTouristTrap.java
+++ b/src/main/java/com/questhelper/quests/thetouristtrap/TheTouristTrap.java
@@ -37,10 +37,7 @@ import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.Operation;
 import java.util.ArrayList;
@@ -60,7 +57,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.widgets.WidgetInfo;
 
 @QuestDescriptor(
@@ -302,7 +298,7 @@ public class TheTouristTrap extends BasicQuestHelper
 		talkToIrena.addDialogSteps("What's the matter?", "Is there a reward if I get her back?", "I'll look for your daughter.", "Okay Irena, calm down. I'll get your daughter back for you.", "Yes, I'll go on this quest!");
 		talkToCaptain = new NpcStep(this, NpcID.MERCENARY_CAPTAIN, new WorldPoint(3271, 3029, 0), "Talk the Mercenary Captain outside the Desert Mining Camp. When he attacks you, kill him for a key.", combatGear);
 		talkToCaptain.addDialogSteps("Wow! A real captain!", "I'd love to work for a tough guy like you!", "Can't I do something for a strong Captain like you?", "Sorry Sir, I don't think I can do that.", "It's a funny captain who can't fight his own battles!");
-		killCaptain = new NpcStep(this, NpcID.MERCENARY_CAPTAIN, new WorldPoint(3271, 3029, 0), "Kill the Mercenary Captain outside the Desert Mining Camp.", combatGear);
+		killCaptain = new CombatStep(this, NpcID.MERCENARY_CAPTAIN, new WorldPoint(3271, 3029, 0), "Kill the Mercenary Captain outside the Desert Mining Camp.", "Mercenary Captain (level 47)", combatGear);
 
 		escapeJail = new ObjectStep(this, NullObjectID.NULL_2679, new WorldPoint(3283, 3034, 0), "Bend the cell window and escape through it.");
 		climbSlope = new ObjectStep(this, ObjectID.ROCK_18871, new WorldPoint(3281, 3037, 0), "Climb the rocks to escape.");
@@ -395,9 +391,12 @@ public class TheTouristTrap extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Mercenary Captain (level 47)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killCaptain);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/treegnomevillage/TreeGnomeVillage.java
+++ b/src/main/java/com/questhelper/quests/treegnomevillage/TreeGnomeVillage.java
@@ -45,12 +45,8 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -148,8 +144,8 @@ public class TreeGnomeVillage extends BasicQuestHelper
 	{
 		NpcHintArrowRequirement fightingWarlord = new NpcHintArrowRequirement(NpcID.KHAZARD_WARLORD_7622);
 
-		fightTheWarlord = new NpcStep(this, NpcID.KHAZARD_WARLORD_7622, new WorldPoint(2456, 3301, 0),
-			"Defeat the warlord and retrieve orbs.");
+		fightTheWarlord = new CombatStep(this, NpcID.KHAZARD_WARLORD_7622, new WorldPoint(2456, 3301, 0),
+			"Defeat the warlord and retrieve orbs.", "Khazard Warlord (level 112)");
 		talkToTheWarlord = new NpcStep(this, NpcID.KHAZARD_WARLORD_7621, new WorldPoint(2456, 3301, 0),
 			"Talk to the Warlord south west of West Ardougne, ready to fight him.");
 
@@ -329,9 +325,12 @@ public class TreeGnomeVillage extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Khazard Warlord (level 112)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(fightTheWarlord);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/trollromance/TrollRomance.java
+++ b/src/main/java/com/questhelper/quests/trollromance/TrollRomance.java
@@ -42,11 +42,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -256,7 +252,7 @@ public class TrollRomance extends BasicQuestHelper
 		challengeArrg.setWorldMapPoint(new WorldPoint(2892, 10127, 0));
 		challengeArrg.addSubSteps(enterStrongholdForFight, goUpToUgForFight, goDownToUgForFight);
 
-		killArrg = new NpcStep(this, NpcID.ARRG_643, "Kill Arrg.");
+		killArrg = new CombatStep(this, NpcID.ARRG_643, "Kill Arrg.", "Arrg (level 113) can be safe spotted");
 		returnToUg = new NpcStep(this, NpcID.UG, new WorldPoint(2827, 10064, 1), "Talk to Ug in the south west room to finish the quest.");
 		returnToUg.setWorldMapPoint(new WorldPoint(2891, 10097, 0));
 		returnToUg.addSubSteps(goDownToUgForEnd, goUpToUgForEnd, enterStrongholdForEnd);
@@ -275,10 +271,11 @@ public class TrollRomance extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Arrg (level 113) can be safe spotted");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killArrg);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/trollstronghold/TrollStronghold.java
+++ b/src/main/java/com/questhelper/quests/trollstronghold/TrollStronghold.java
@@ -46,12 +46,8 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -206,7 +202,7 @@ public class TrollStronghold extends BasicQuestHelper
 		climbOverStile = new ObjectStep(this, ObjectID.STILE_3730, new WorldPoint(2817, 3563, 0), "Climb over the stile north of Tenzing.");
 		climbOverRocks = new ObjectStep(this, ObjectID.ROCKS_3748, new WorldPoint(2856, 3612, 0), "Follow the path until you reach some rocks. Climb over them.", climbingBootsEquipped);
 		enterArena = new ObjectStep(this, ObjectID.ARENA_ENTRANCE_3783, new WorldPoint(2897, 3619, 0), "Follow the path from here east until you enter the arena.");
-		fightDad = new NpcStep(this, NpcID.DAD, new WorldPoint(2913, 3617, 0), "Fight Dad until he gives up. You can safe spot him from the gate you entered through.");
+		fightDad = new CombatStep(this, NpcID.DAD, new WorldPoint(2913, 3617, 0), "Fight Dad until he gives up. You can safe spot him from the gate you entered through.", "Dad (level 101) (safespottable)");
 		fightDad.addDialogStep("I accept your challenge!");
 		((NpcStep) fightDad).addSafeSpots(new WorldPoint(2897, 3619, 0));
 
@@ -220,7 +216,7 @@ public class TrollStronghold extends BasicQuestHelper
 			enterStronghold.getText().add("They can be avoided by taking the agility shortcuts across the mountain.");
 		}
 
-		killGeneral = new NpcStep(this, NpcID.TROLL_GENERAL, new WorldPoint(2830, 10086, 2), "Enter the west rooms and kill any of the Troll Generals for a prison key.");
+		killGeneral = new CombatStep(this, NpcID.TROLL_GENERAL, new WorldPoint(2830, 10086, 2), "Enter the west rooms and kill any of the Troll Generals for a prison key.", "Troll Generall (level 113) (safespottable)");
 		pickupPrisonKey = new ItemStep(this, "Pick up the prison key.", prisonKey);
 
 		goDownInStronghold = new ObjectStep(this, ObjectID.STONE_STAIRCASE_3789, new WorldPoint(2844, 10109, 2), "Climb down the north staircase.");
@@ -260,11 +256,12 @@ public class TrollStronghold extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Dad (level 101) (safespottable)");
-		reqs.add("Troll Generall (level 113) (safespottable)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(fightDad);
+		reqs.add(killGeneral);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/undergroundpass/UndergroundPass.java
+++ b/src/main/java/com/questhelper/quests/undergroundpass/UndergroundPass.java
@@ -45,12 +45,7 @@ import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
-import com.questhelper.steps.TileStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -490,7 +485,7 @@ public class UndergroundPass extends BasicQuestHelper
 		useCatOnDoor.addIcon(ItemID.WITCHS_CAT);
 		searchWitchsChest = new ObjectStep(this, ObjectID.CHEST_3272, new WorldPoint(2157, 4564, 1), "Search the chest in the witch's house. You'll need 4 empty inventory slots.");
 
-		killHolthion = new NpcStep(this, NpcID.HOLTHION, new WorldPoint(2133, 4555, 1), "From the south east corner of the area, head west then south along the pathways. Kill Holthion and pick up his amulet.", amuletHolthion);
+		killHolthion = new CombatStep(this, NpcID.HOLTHION, new WorldPoint(2133, 4555, 1), "From the south east corner of the area, head west then south along the pathways. Kill Holthion and pick up his amulet.", "Holthion (level 91, safespottable)", amuletHolthion);
 		killHolthion.setLinePoints(Arrays.asList(
 			new WorldPoint(2169, 4582, 1),
 			new WorldPoint(2152, 4582, 1),
@@ -500,8 +495,8 @@ public class UndergroundPass extends BasicQuestHelper
 			new WorldPoint(2137, 4556, 1)
 		));
 
-		killDoomion = new NpcStep(this, NpcID.DOOMION, new WorldPoint(2135, 4566, 1), "Kill Doomion and pick up his amulet.", amuletDoomion);
-		killOthanian = new NpcStep(this, NpcID.OTHAINIAN, new WorldPoint(2123, 4563, 1), "Kill Othanian and pick up his amulet.", amuletOthanian);
+		killDoomion = new CombatStep(this, NpcID.DOOMION, new WorldPoint(2135, 4566, 1), "Kill Doomion and pick up his amulet.", "Doomion (level 91, safespottable)", amuletDoomion);
+		killOthanian = new CombatStep(this, NpcID.OTHAINIAN, new WorldPoint(2123, 4563, 1), "Kill Othanian and pick up his amulet.", "Othanian (level 91, safespottable)", amuletOthanian);
 		useShadowOnDoll = new DetailedQuestStep(this, "Use the shadow on the doll.", ibansShadow, dollOfIbanHighlighted);
 		searchDoomionsChest = new ObjectStep(this, ObjectID.CHEST_3274, new WorldPoint(2136, 4578, 1), "Search the chest north of Doomion.");
 		searchDoomionsChest.addSubSteps(useShadowOnDoll);
@@ -515,7 +510,7 @@ public class UndergroundPass extends BasicQuestHelper
 		useTinderboxOnTomb = new ObjectStep(this, ObjectID.TOMB, new WorldPoint(2357, 9802, 0), "Light the tomb with a tinderbox.", tinderboxHighlight);
 		useTinderboxOnTomb.addSubSteps(useAshOnDoll);
 		useTinderboxOnTomb.addIcon(ItemID.TINDERBOX);
-		killKalrag = new NpcStep(this, NpcID.KALRAG, new WorldPoint(2356, 9913, 0), "Kill Kalrag the spider. Protect From Melee can keep you safe in this fight.", dollOfIban);
+		killKalrag = new CombatStep(this, NpcID.KALRAG, new WorldPoint(2356, 9913, 0), "Kill Kalrag the spider. Protect From Melee can keep you safe in this fight.", "Kalrag (level 89)", dollOfIban);
 		ascendToHalfSouless = new ObjectStep(this, ObjectID.CAVE_3223, new WorldPoint(2304, 9915, 0), "Ascend to the upper level of the cave again via the north west exit.");
 		searchCage = new ObjectStep(this, ObjectID.CAGE_3351, new WorldPoint(2135, 4703, 1), "Search the marked cage in the north west of the area while wearing Klank's gauntlets.", klanksGauntletsEquipped);
 		searchCage.setLinePoints(Arrays.asList(
@@ -533,7 +528,7 @@ public class UndergroundPass extends BasicQuestHelper
 		));
 		searchCage.addSubSteps(ascendToHalfSouless, useDoveOnDoll);
 
-		killDisciple = new NpcStep(this, NpcID.DISCIPLE_OF_IBAN, new WorldPoint(2163, 4648, 1), "Travel along the pathways from the north west corner of the area to the middle. Kill a disciple of Iban and take their robes.", true, dollOfIban);
+		killDisciple = new CombatStep(this, NpcID.DISCIPLE_OF_IBAN, new WorldPoint(2163, 4648, 1), "Travel along the pathways from the north west corner of the area to the middle. Kill a disciple of Iban and take their robes.", "Disciple of Iban (level 13)", true, dollOfIban);
 		killDisciple.setLinePoints(Arrays.asList(
 			new WorldPoint(2117, 4686, 1),
 			new WorldPoint(2128, 4686, 1),
@@ -751,13 +746,17 @@ public class UndergroundPass extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("3 Demons (level 91, safespottable)");
-		reqs.add("3 Paladins (level 62, safespottable)");
-		reqs.add("Kalrag (level 89)");
-		reqs.add("Disciple of Iban (level 13)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+
+		reqs.add(killOthanian);
+		reqs.add(killDoomion);
+		reqs.add(killHolthion);
+		reqs.add(new CombatStep(this, NpcID.PALADIN, "3 Paladins (level 62, safespottable)"));
+		reqs.add(killKalrag);
+		reqs.add(killDisciple);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/vampyreslayer/VampyreSlayer.java
+++ b/src/main/java/com/questhelper/quests/vampyreslayer/VampyreSlayer.java
@@ -37,11 +37,7 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -144,7 +140,7 @@ public class VampyreSlayer extends BasicQuestHelper
 		enterDraynorManor = new ObjectStep(this, ObjectID.LARGE_DOOR_134, new WorldPoint(3108, 3353, 0), "Prepare to fight Count Draynor (level 34), and enter Draynor Manor.", combatGear, stake, hammer, garlic);
 		goDownToBasement = new ObjectStep(this, ObjectID.STAIRS_2616, new WorldPoint(3116, 3358, 0), "Enter Draynor Manor's basement.", combatGear, stake, hammer, garlic);
 		openCoffin = new ObjectStep(this, ObjectID.COFFIN_2614, new WorldPoint(3078, 9776, 0), "Open the coffin and kill Count Draynor.", combatGear, stake, hammer, garlic);
-		killDraynor = new NpcStep(this, NpcID.COUNT_DRAYNOR, new WorldPoint(3077, 9769, 0), "Kill Count Draynor.", combatGear, stake, hammer, garlic);
+		killDraynor = new CombatStep(this, NpcID.COUNT_DRAYNOR, new WorldPoint(3077, 9769, 0), "Kill Count Draynor.", "Count Draynor (level 34)", combatGear, stake, hammer, garlic);
 		openCoffin.addSubSteps(killDraynor);
 	}
 
@@ -169,10 +165,11 @@ public class VampyreSlayer extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Count Draynor (level 34)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killDraynor);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/wanted/Wanted.java
+++ b/src/main/java/com/questhelper/quests/wanted/Wanted.java
@@ -49,11 +49,7 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 
 import java.util.*;
 
@@ -437,8 +433,8 @@ public class Wanted extends BasicQuestHelper
 		talkToLordDaquarius.addSubSteps(enterTaverleyDungeon);
 
 		goToBlackKnightsBase = new DetailedQuestStep(this, new WorldPoint(2896, 9681, 0), "Go to the Black Knights' Base in Taverley Dungeon.");
-		killBlackKnight = new NpcStep(this, NpcID.BLACK_KNIGHT, new WorldPoint(2891, 9681, 0),
-			"Kill a Black Knight near Daquarius.", true, combatGear);
+		killBlackKnight = new CombatStep(this, NpcID.BLACK_KNIGHT, new WorldPoint(2891, 9681, 0),
+			"Kill a Black Knight near Daquarius.", "Black Knight (level 33)", true, combatGear);
 		talkToIntimidatedLordDaquarius = new NpcStep(this, NpcID.LORD_DAQUARIUS, new WorldPoint(2891, 9681, 0), "Talk to Lord Daquarius in Taverley Dungeon again.");
 
 		talkToMageOfZamorakInWilderness = new NpcStep(this, NpcID.MAGE_OF_ZAMORAK, new WorldPoint(3106, 3558, 0), "Talk to the Mage of Zamorak in the wilderness just north of Edgeville.", commorb);
@@ -497,7 +493,7 @@ public class Wanted extends BasicQuestHelper
 
 		// Final battle
 		goToEssenceMine = new NpcStep(this, NpcID.AUBURY, new WorldPoint(3253, 3402, 0), "Go to the Rune Essence mine by talking to any of the NPC's that can teleport you there.", commorb, combatGear);
-		killSolus = new NpcStep(this, NpcID.SOLUS_DELLAGAR_4962, "Kill Solus Dellagar.", combatGear);
+		killSolus = new CombatStep(this, NpcID.SOLUS_DELLAGAR_4962, "Kill Solus Dellagar.", "Solus Dellagar (similar strength)", combatGear);
 
 		// Wrapping up
 		QuestStep talkToSirAmikAfterSolusFight = new NpcStep(this, NpcID.SIR_AMIK_VARZE_4771, "Talk to Sir Amik Varze at the White Knights' Castle in Falador.");
@@ -536,9 +532,13 @@ public class Wanted extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Arrays.asList("Black Knight (level 33)", "Solus Dellagar (similar strength)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killBlackKnight);
+		reqs.add(killSolus);
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/watchtower/Watchtower.java
+++ b/src/main/java/com/questhelper/quests/watchtower/Watchtower.java
@@ -43,11 +43,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -460,7 +457,7 @@ public class Watchtower extends BasicQuestHelper
 
 		enterHoleSouthOfGuTanoth = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2811, new WorldPoint(2500, 2990, 0), "Enter the hole south of Gu'Tanoth.");
 
-		killGorad = new NpcStep(this, NpcID.GORAD, new WorldPoint(2578, 3022, 0), "Kill Gorad and pick up his tooth.");
+		killGorad = new CombatStep(this, NpcID.GORAD, new WorldPoint(2578, 3022, 0), "Kill Gorad and pick up his tooth.", "Gorad (level 68)");
 		talkToToban = new NpcStep(this, NpcID.TOBAN, new WorldPoint(2574, 3027, 0), "Talk to Toban on the island east of Gu'Tanoth.");
 		talkToToban.addDialogStep("I seek entrance to the city of ogres.");
 		talkToToban.addDialogStep("I could do something for you...");
@@ -622,11 +619,12 @@ public class Watchtower extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Gorad (level 68)");
-		reqs.add("Able to survive blue dragons, ogres, and greater demons attacking you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killGorad);
+		reqs.add(new CombatStep(this, -1, "Able to survive blue dragons, ogres, and greater demons attacking you"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/waterfallquest/WaterfallQuest.java
+++ b/src/main/java/com/questhelper/quests/waterfallquest/WaterfallQuest.java
@@ -38,11 +38,8 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -263,10 +260,11 @@ public class WaterfallQuest extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Able to survive enemies up to level 86 attacking you");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, -1, "Able to survive enemies up to level 86 attacking you"));
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/whatliesbelow/WhatLiesBelow.java
+++ b/src/main/java/com/questhelper/quests/whatliesbelow/WhatLiesBelow.java
@@ -39,11 +39,8 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,8 +182,8 @@ public class WhatLiesBelow extends BasicQuestHelper
 		talkToRat = new NpcStep(this, NpcID.RAT_BURGISS, new WorldPoint(3266, 3333, 0), "Talk to Rat Burgiss south of Varrock.");
 		talkToRat.addDialogStep("Shall I get them back for you?");
 		talkToRat.addDialogStep("Of course! Tell me what you need me to do.");
-		killOutlaws = new NpcStep(this, NpcID.OUTLAW, new WorldPoint(3118, 3472, 0),
-			"Go to the Bandits west of the Grand Exchange and kill 5 for intel. Put the intel into the folder Rat gave you.", true, folder, intel5);
+		killOutlaws = new CombatStep(this, NpcID.OUTLAW, new WorldPoint(3118, 3472, 0),
+			"Go to the Bandits west of the Grand Exchange and kill 5 for intel. Put the intel into the folder Rat gave you.", "5 outlaws (level 32)", true, folder, intel5);
 		killOutlaws.addAlternateNpcs(NpcID.OUTLAW_4168, NpcID.OUTLAW_4169, NpcID.OUTLAW_4170, NpcID.OUTLAW_4171, NpcID.OUTLAW_4172, NpcID.OUTLAW_4173, NpcID.OUTLAW_4174, NpcID.OUTLAW_4175, NpcID.OUTLAW_4176);
 		bringFolderToRat = new NpcStep(this, NpcID.RAT_BURGISS, new WorldPoint(3266, 3333, 0), "Return to Rat Burgiss south of Varrock.", fullFolder);
 		talkToRatAfterFolder = new NpcStep(this, NpcID.RAT_BURGISS, new WorldPoint(3266, 3333, 0), "Return to Rat Burgiss south of Varrock.");
@@ -213,7 +210,7 @@ public class WhatLiesBelow extends BasicQuestHelper
 		talkToZaff.addDialogStep("Rat Burgiss sent me!");
 		talkToSurokToFight = new NpcStep(this, NpcID.SUROK_MAGIS_4160, new WorldPoint(3211, 3493, 0), "Prepare to fight King Roald (level 47), then go talk to Surok Magis in the Varrock Library.", beaconRing);
 		talkToSurokToFight.addDialogStep("Bring it on!");
-		fightRoald = new NpcStep(this, NpcID.KING_ROALD_4163, new WorldPoint(3211, 3493, 0), "Fight King Roald. When he's at 1hp, right-click operate the beacon ring.", beaconRing);
+		fightRoald = new CombatStep(this, NpcID.KING_ROALD_4163, new WorldPoint(3211, 3493, 0), "Fight King Roald. When he's at 1hp, right-click operate the beacon ring.", "King Roald (level 47)", beaconRing);
 		talkToRatToFinish = new NpcStep(this, NpcID.RAT_BURGISS, new WorldPoint(3266, 3333, 0), "Return to Rat Burgiss south of Varrock to finish the quest.");
 	}
 
@@ -236,11 +233,12 @@ public class WhatLiesBelow extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("5 outlaws (level 32)");
-		reqs.add("King Roald (level 47)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(killOutlaws);
+		reqs.add(fightRoald);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/quests/witchshouse/WitchsHouse.java
+++ b/src/main/java/com/questhelper/quests/witchshouse/WitchsHouse.java
@@ -41,11 +41,8 @@ import com.questhelper.requirements.conditional.ObjectCondition;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -224,9 +221,12 @@ public class WitchsHouse extends BasicQuestHelper
 	}
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		return Collections.singletonList("Witch's experiment (level 19, 30, 42 and 53)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.WITCHS_EXPERIMENT, "Witch's experiment (level 19, 30, 42 and 53)"));
+
+		return reqs;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/quests/zogreflesheaters/ZogreFleshEaters.java
+++ b/src/main/java/com/questhelper/quests/zogreflesheaters/ZogreFleshEaters.java
@@ -36,10 +36,7 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ItemStep;
-import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.*;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.util.LogicType;
@@ -64,8 +61,6 @@ import com.questhelper.QuestDescriptor;
 import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.QuestStep;
 import net.runelite.api.widgets.WidgetInfo;
 
 @QuestDescriptor(
@@ -259,7 +254,7 @@ public class ZogreFleshEaters extends BasicQuestHelper
 
 		goDownStairs = new ObjectStep(this, ObjectID.STAIRS_6841, new WorldPoint(2486, 3043, 0), "Climb down the stairs to the east.");
 		searchSkeleton = new ObjectStep(this, ObjectID.SKELETON_6893, new WorldPoint(2442, 9459, 2), "Search the skeleton in the north west corner of this area.");
-		killZombie = new NpcStep(this, NpcID.ZOMBIE_880, new WorldPoint(2442, 9459, 2), "Kill the zombie which appeared, and pick up the ruined backpack that appeared.");
+		killZombie = new CombatStep(this, NpcID.ZOMBIE_880, new WorldPoint(2442, 9459, 2), "Kill the zombie which appeared, and pick up the ruined backpack that appeared.", "Zombie (level 39)");
 		openBackpack = new DetailedQuestStep(this, "Open the backpack for a knife and a dragon inn tankard.", backpack);
 
 		searchLectern = new ObjectStep(this, ObjectID.BROKEN_LECTURN, new WorldPoint(2443, 9459, 2), "Search the broken lecturn in the north west corner of the tombs.");
@@ -345,11 +340,12 @@ public class ZogreFleshEaters extends BasicQuestHelper
 
 
 	@Override
-	public List<String> getCombatRequirements()
+	public List<QuestStep> getCombatRequirements()
 	{
-		ArrayList<String> reqs = new ArrayList<>();
-		reqs.add("Slash Bash (level 111)");
-		reqs.add("Zombie (level 39)");
+		ArrayList<QuestStep> reqs = new ArrayList<>();
+		reqs.add(new CombatStep(this, NpcID.SLASH_BASH, "Slash Bash (level 111)"));
+		reqs.add(killZombie);
+
 		return reqs;
 	}
 

--- a/src/main/java/com/questhelper/steps/CombatStep.java
+++ b/src/main/java/com/questhelper/steps/CombatStep.java
@@ -1,0 +1,47 @@
+package com.questhelper.steps;
+
+import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.requirements.Requirement;
+import net.runelite.api.coords.WorldPoint;
+
+public class CombatStep extends NpcStep
+{
+    private final String combatText;
+
+    public CombatStep(QuestHelper questHelper, int npcID, String text, String combatText, Requirement... requirements)
+    {
+        super(questHelper, npcID, text, requirements);
+        this.combatText = combatText;
+    }
+
+    public CombatStep(QuestHelper questHelper, int npcID, WorldPoint worldPoint, String text, String combatText, Requirement... requirements)
+    {
+        super(questHelper, npcID,worldPoint, text, requirements);
+        this.combatText = combatText;
+    }
+
+    public CombatStep(QuestHelper questHelper, int npcID, WorldPoint worldPoint, String text, String combatText, boolean allowMultipleHighlights, Requirement... requirements) {
+        super(questHelper, npcID, null, text, allowMultipleHighlights, requirements);
+        this.combatText = combatText;
+    }
+
+    public CombatStep(QuestHelper questHelper, int npcID, String combatText) {
+        super(questHelper, npcID, null);
+        this.combatText = combatText;
+    }
+
+    public CombatStep(QuestHelper questHelper, int npcID, String text, String combatText, boolean allowMultipleHighlights)
+    {
+        super(questHelper, npcID, text, allowMultipleHighlights);
+        this.combatText = combatText;
+    }
+
+    public CombatStep(QuestHelper questHelper, int npcID, String text, String combatText, boolean allowMultipleHighlights, Requirement... requirements) {
+        super(questHelper, npcID, text, allowMultipleHighlights, requirements);
+        this.combatText = combatText;
+    }
+
+    public String getCombatText(){
+        return combatText;
+    }
+}

--- a/src/main/java/com/questhelper/steps/NpcStep.java
+++ b/src/main/java/com/questhelper/steps/NpcStep.java
@@ -40,6 +40,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+
+import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -58,6 +60,7 @@ public class NpcStep extends DetailedQuestStep
 	@Inject
 	protected Client client;
 
+	@Getter
 	private final int npcID;
 	private final List<Integer> alternateNpcIDs = new ArrayList<>();
 


### PR DESCRIPTION
Added 'right-click'-> 'go to wiki..' functionality (similar to the ItemRequirement 'go to wiki..') to the `'Enemies to Defeat'`panel. 

- added `CombatStep,` this extends `NpcStep` and are added to the  `getCombatRequirements()` list
- there are several constructors to handle any case. Most constructors are similar to the `NpcStep` except that there is a String argument for the `combatText ` to be displayed. Others allow you to simply provide the text with an ID to allow for a link or text and -1 as an ID to have no link.

The constructor in action:
<img width="880" alt="Screen Shot 2022-08-10 at 5 42 23 PM" src="https://user-images.githubusercontent.com/96400383/184043123-ae73ee68-00ce-4542-b13b-1c754fa74435.png">

The objects being added to the list:
<img width="408" alt="1" src="https://user-images.githubusercontent.com/96400383/184042969-0f21c66a-ffcc-42c6-8468-c4d0847650b5.png">

Additionally,  the `CombatStep` can be added on its own if another method was used (such as `DetailedQuestSte`) for the step:
<img width="809" alt="Screen Shot 2022-08-10 at 5 45 27 PM" src="https://user-images.githubusercontent.com/96400383/184043355-0e64cf57-0c0f-46f4-8b59-dd8518760735.png">

Example of a constructor used just for displaying text with no link (`NpcID` of -1 will result in no link):
<img width="827" alt="Screen Shot 2022-08-10 at 6 22 30 PM" src="https://user-images.githubusercontent.com/96400383/184043699-6be6eaa1-1cc5-4bee-b9be-b722dee94b8c.png">


There is an error that occured rarely(shown below) that I can't pin down. I have been unable to recreate it but I think it is one of the quests. Everything continued to run just fine but the error did occur. I am unsure where this occurred.
<img width="894" alt="Screen Shot 2022-08-10 at 6 19 20 PM" src="https://user-images.githubusercontent.com/96400383/184043906-340968b3-a663-4136-9372-a7df820caa89.png">

All feedback/criticism welcome, thank you. 

