### PR TITLE
Revamped Boostable Skill Requirements and Minor Fixes

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -200,6 +200,16 @@ public interface QuestHelperConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+		keyName = "stewBoostsPanel",
+		name = "Use Spicy stew for boosts",
+		description = "Raises the boost maximum boost for certain skills to 5"
+	)
+	default boolean stewBoosts()
+	{
+		return false;
+	}
+
 	@ConfigSection(
 		position = 1,
 		name = "Quest Hints",
@@ -311,6 +321,17 @@ public interface QuestHelperConfig extends Config
 	default Color failColour()
 	{
 		return Color.RED;
+	}
+
+	@ConfigItem(
+		keyName = "boostColour",
+		name = "Colour of boostable skill",
+		description = "Change the colour that will indicate a skill level check has passed",
+		section = colorSection
+	)
+	default Color boostColour()
+	{
+		return Color.ORANGE;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikMedium.java
+++ b/src/main/java/com/questhelper/achievementdiaries/fremennik/FremennikMedium.java
@@ -110,7 +110,7 @@ public class FremennikMedium extends ComplexStateQuestHelper
 		setupSteps();
 
 		ConditionalStep doMedium = new ConditionalStep(this, claimReward);
-		slayBrineRatTask = new ConditionalStep(this, moveToCave);
+		slayBrineRatTask = new ConditionalStep(this, enterBrineCave);
 		slayBrineRatTask.addStep(inBrineRatCave, slayBrineRat);
 		doMedium.addStep(notSlayBrineRat, slayBrineRatTask);
 		doMedium.addStep(inBrineRatCave, rollBoulderExit);

--- a/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
+++ b/src/main/java/com/questhelper/achievementdiaries/kourend/KourendHard.java
@@ -336,7 +336,7 @@ public class KourendHard extends ComplexStateQuestHelper
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new CombatLevelRequirement(85));
-		req.add(new SkillRequirement(Skill.FARMING, 74));
+		req.add(new SkillRequirement(Skill.FARMING, 74, true));
 		req.add(new SkillRequirement(Skill.MAGIC, 66, true));
 		req.add(new SkillRequirement(Skill.MINING, 65, true));
 		req.add(new SkillRequirement(Skill.SLAYER, 62, true));

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -437,7 +437,7 @@ public class QuestOverviewPanel extends JPanel
 	private void updateRewardsPanels(List<Reward> rewards)
 	{
 		Reward lastReward = null;
-		if (rewards != null)
+		if (!rewards.isEmpty())
 		{
 			for (Reward reward : rewards)
 			{

--- a/src/main/java/com/questhelper/quests/beneathcursedsands/BeneathCursedSands.java
+++ b/src/main/java/com/questhelper/quests/beneathcursedsands/BeneathCursedSands.java
@@ -276,7 +276,7 @@ public class BeneathCursedSands extends BasicQuestHelper
 		spade = new ItemRequirement("Spade", ItemID.SPADE);
 		spade.setTooltip("Obtainable during quest");
 		meat = new ItemRequirement("Any cooked or raw meat", ItemID.COOKED_MEAT);
-		meat.addAlternates(ItemID.RAW_BEEF, ItemID.RAW_BEAR_MEAT, ItemID.RAW_BOAR_MEAT, ItemID.RAW_RAT_MEAT, ItemID.RAW_YAK_MEAT);
+		meat.addAlternates(ItemID.RAW_BEEF, ItemID.RAW_BEAR_MEAT, ItemID.RAW_BOAR_MEAT, ItemID.RAW_RAT_MEAT);
 		meat.setTooltip("Purchasable from a shop during the quest. Fish will NOT work");
 		waterskins = new ItemRequirement("Waterskin(s)", ItemID.WATERSKIN4);
 		waterskins.addAlternates(ItemID.WATERSKIN3, ItemID.WATERSKIN2, ItemID.WATERSKIN1);

--- a/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/quests/dragonslayerii/DragonSlayerII.java
@@ -1221,8 +1221,8 @@ public class DragonSlayerII extends BasicQuestHelper
 		allSteps.add(karamjaKeyPanel);
 
 		allSteps.add(new PanelDetails("Unlocking the door", Arrays.asList(goEnterMithDoorFirstTime, castFireOnHead, goSmithKey,
-			goOpenDoorWithKey, openDoorWithoutKey, goTalkToBobAfterRelease),
-			ancientKey, runesForFireWaveOrSurge3, fremennikKeyPiece, karamjaKeyPiece, varrocKeyPiece, kourendKeyPiece, hammer));
+			goOpenDoorWithKey, openDoorWithoutKey, goTalkToBobAfterRelease), ancientKey, runesForFireWaveOrSurge3, fremennikKeyPiece,
+			karamjaKeyPiece, varrocKeyPiece, kourendKeyPiece, hammer, antifireShield));
 
 		allSteps.add(new PanelDetails("Creating an army", Arrays.asList(talkToRoald, talkToBrundtAboutThreat, talkToAmik, talkToLathasOrThoros, enterVarrockDiningRoom, talkToBobAfterDiningRoom)));
 

--- a/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
+++ b/src/main/java/com/questhelper/quests/icthlarinslittlehelper/IcthlarinsLittleHelper.java
@@ -453,9 +453,9 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 	public List<ExperienceReward> getExperienceRewards()
 	{
 		return Arrays.asList(
-				new ExperienceReward(Skill.THIEVING, 4500),
-				new ExperienceReward(Skill.AGILITY, 4000),
-				new ExperienceReward(Skill.WOODCUTTING, 4000));
+			new ExperienceReward(Skill.THIEVING, 4500),
+			new ExperienceReward(Skill.AGILITY, 4000),
+			new ExperienceReward(Skill.WOODCUTTING, 4000));
 	}
 
 	@Override
@@ -468,8 +468,8 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-				new UnlockReward("Access to the city of Sophanem."),
-				new UnlockReward("Ability to take carpet rides from Pollnivneah to Sophanem and Menaphos."));
+			new UnlockReward("Access to the city of Sophanem."),
+			new UnlockReward("Ability to take carpet rides from Pollnivneah to Sophanem and Menaphos."));
 	}
 
 	@Override
@@ -484,7 +484,8 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 
 		allSteps.add(new PanelDetails("Returning the jar",
 			Arrays.asList(talkToSphinx, talkToHighPriest, openPyramidDoor, jumpPitAgain, pickUpAnyJar,
-				pickUpAnyJarAgain, returnOverPit, jumpOverPitAgain, solvePuzzleAgain, dropJar, leavePyramid), cat));
+				pickUpAnyJarAgain, returnOverPit, jumpOverPitAgain, solvePuzzleAgain, dropJar, leavePyramid),
+			combatGear, food, cat));
 
 		allSteps.add(new PanelDetails("Prepare the ritual",
 			Arrays.asList(talkToEmbalmer, buyLinen, talkToEmbalmerAgain, talkToCarpenter), bucketOfSap, bagOfSaltOrBucket, coinsOrLinen, willowLog));
@@ -492,7 +493,7 @@ public class IcthlarinsLittleHelper extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Save the ritual",
 			Arrays.asList(openPyramidDoorWithSymbol, jumpPitWithSymbol, enterEastRoom, useSymbolOnSarcopagus,
 				leaveEastRoom, jumpPitWithSymbolAgain, enterEastRoomAgain, killPriest, talkToHighPriestInPyramid,
-				leavePyramidToFinish, talkToHighPriestToFinish), cat));
+				leavePyramidToFinish, talkToHighPriestToFinish), combatGear, food, cat));
 
 		return allSteps;
 	}

--- a/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
+++ b/src/main/java/com/questhelper/quests/mourningsendparti/MourningsEndPartI.java
@@ -476,8 +476,8 @@ public class MourningsEndPartI extends BasicQuestHelper
 	public List<ExperienceReward> getExperienceRewards()
 	{
 		return Arrays.asList(
-				new ExperienceReward(Skill.THIEVING, 25000),
-				new ExperienceReward(Skill.HITPOINTS, 25000));
+			new ExperienceReward(Skill.THIEVING, 25000),
+			new ExperienceReward(Skill.HITPOINTS, 25000));
 	}
 
 	@Override
@@ -516,16 +516,20 @@ public class MourningsEndPartI extends BasicQuestHelper
 		allSteps.add(cleanPanel);
 		allSteps.add(repairPanel);
 
-		PanelDetails enterWestArdougnePanel = new PanelDetails("Infiltrate the Mourners", Arrays.asList(enterMournerBase, enterBasement, talkToEssyllt, talkToGnome, useFeatherOnGnome, talkToGnomeWithItems, releaseGnome, giveGnomeItems),
+		PanelDetails enterWestArdougnePanel = new PanelDetails("Infiltrate the Mourners", Arrays.asList(enterMournerBase,
+			enterBasement, talkToEssyllt, talkToGnome, useFeatherOnGnome, talkToGnomeWithItems, releaseGnome, giveGnomeItems),
 			fullMourners, mournerLetter, feather, toadCrunchies, magicLogs, leather);
 
 		allSteps.add(enterWestArdougnePanel);
 
-		allSteps.add(new PanelDetails("Dye the sheep", Arrays.asList(getToads, dyeSheep, enterBaseAfterSheep, enterBasementAfterSheep, talkToEssylltAfterSheep), fixedDevice, ogreBellows, redDye, yellowDye, greenDye, blueDye));
+		allSteps.add(new PanelDetails("Dye the sheep", Arrays.asList(getToads, dyeSheep, enterBaseAfterSheep,
+			enterBasementAfterSheep, talkToEssylltAfterSheep), fixedDevice, ogreBellows, redDye, yellowDye, greenDye, blueDye));
 
 
 		allSteps.add(new PanelDetails("Poison the citizens",
-			Arrays.asList(pickUpRottenApple, talkToElena, pickUpBarrel, useBarrelOnPile, useApplesOnPress, getNaphtha, useNaphthaOnBarrel, useSieveOnBarrel, cookNaphtha, usePowderOnFood1, usePowderOnFood2, talkToEssylltAfterPoison), coal20OrNaphtha));
+			Arrays.asList(pickUpRottenApple, talkToElena, pickUpBarrel, useBarrelOnPile, useApplesOnPress, getNaphtha,
+				useNaphthaOnBarrel, useSieveOnBarrel, cookNaphtha, usePowderOnFood1, usePowderOnFood2,
+				talkToEssylltAfterPoison), coal20OrNaphtha, fullMourners));
 
 		allSteps.add(new PanelDetails("Report back to Arianwyn",
 			Collections.singletonList(returnToArianwyn)));

--- a/src/main/java/com/questhelper/quests/trollromance/TrollRomance.java
+++ b/src/main/java/com/questhelper/quests/trollromance/TrollRomance.java
@@ -325,7 +325,7 @@ public class TrollRomance extends BasicQuestHelper
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
-		allSteps.add(new PanelDetails("Starting off", Arrays.asList(talkToUg, talkToAga)));
+		allSteps.add(new PanelDetails("Starting off", Arrays.asList(talkToUg, talkToAga), climbingBoots));
 		allSteps.add(new PanelDetails("Make a sled", Arrays.asList(talkToTenzing, talkToDunstan, talkToDunstanAgain, useTarOnWax, useWaxOnSled), mapleLog, ironBar, rope, swampTar, bucketOfWax, cakeTin));
 		allSteps.add(new PanelDetails("Get flowers", Arrays.asList(enterTrollCave, leaveTrollCave, equipSled, sledSouth, pickFlowers), waxedSled));
 		allSteps.add(new PanelDetails("Fighting for Aga", Arrays.asList(talkToUgWithFlowers, challengeArrg, killArrg, returnToUg), trollweissFlowers, combatGear));

--- a/src/main/java/com/questhelper/quests/wanted/Wanted.java
+++ b/src/main/java/com/questhelper/quests/wanted/Wanted.java
@@ -529,6 +529,7 @@ public class Wanted extends BasicQuestHelper
 	{
 		return QuestUtil.toArrayList(
 			new QuestPointRequirement(32),
+			new QuestRequirement(QuestHelperQuest.ENTER_THE_ABYSS, QuestState.FINISHED),
 			new QuestRequirement(QuestHelperQuest.RECRUITMENT_DRIVE, QuestState.FINISHED),
 			new QuestRequirement(QuestHelperQuest.THE_LOST_TRIBE, QuestState.FINISHED),
 			new QuestRequirement(QuestHelperQuest.PRIEST_IN_PERIL, QuestState.FINISHED)

--- a/src/main/java/com/questhelper/requirements/player/Boosts.java
+++ b/src/main/java/com/questhelper/requirements/player/Boosts.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Obasill <https://github.com/obasill>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.requirements.player;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Boosts
+{
+	AGILITY("Agility",5),
+	ATTACK("Attack",21),
+	CONSTRUCTION("Construction",6),
+	COOKING("Cooking",6),
+	CRAFTING("Crafting",4),
+	DEFENCE("Defence",21),
+	FARMING("Farming",3),
+	FIREMAKING("Firemaking",0),
+	FISHING("Fishing",5),
+	FLETCHING("Fletching",4),
+	HERBLORE("Herblore",4),
+	HITPOINTS("Hitpoints",22),
+	HUNTER("Hunter",3),
+	MAGIC("Magic",19),
+	MINING("Mining",3),
+	PRAYER("Prayer",0),
+	RANGED("Ranged",19),
+	RUNECRAFT("Runecraft",0),
+	SLAYER("Slayer",5),
+	SMITHING("Smithing",4),
+	STRENGTH("Strength",19),
+	THIEVING("Thieving",3),
+	WOODCUTTING("Woodcutting",3);
+
+	private final String name;
+	private final int highestBoost;
+}

--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -49,6 +49,9 @@ public class SkillRequirement extends AbstractRequirement
 	private String displayText;
 	private Boosts boosts;
 	private QuestHelperPlugin questHelperPlugin;
+	private Boosts selectedSkill;
+	private int currentSkill;
+	private int highestBoost;
 
 	/**
 	 * Check if a player has a certain skill level
@@ -114,7 +117,6 @@ public class SkillRequirement extends AbstractRequirement
 
 	public boolean checkRange(Skill skill, int requiredLevel, Client client, QuestHelperConfig config)
 	{
-		Boosts selectedSkill = null;
 		for (Boosts boostSkills : boosts.values())
 		{
 			if (skill.getName().equals(boostSkills.getName()))
@@ -123,20 +125,15 @@ public class SkillRequirement extends AbstractRequirement
 			}
 		}
 
-		int currentSkill = Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill));
-		int highestBoost = selectedSkill.getHighestBoost();
+		currentSkill = Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill));
+		highestBoost = selectedSkill.getHighestBoost();
 
 		if (config.stewBoosts() && highestBoost < 5)
 		{
 			highestBoost = 5;
 		}
 
-		if (requiredLevel-highestBoost <= currentSkill)
-		{
-			return true;
-		}
-
-		return false;
+		return requiredLevel - highestBoost <= currentSkill;
 	}
 
 	public int checkBoosted(Client client, QuestHelperConfig config)

--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -27,8 +27,11 @@
 
 package com.questhelper.requirements.player;
 
+import com.questhelper.QuestHelperConfig;
+import com.questhelper.QuestHelperPlugin;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Operation;
+import java.awt.Color;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
@@ -44,6 +47,8 @@ public class SkillRequirement extends AbstractRequirement
 	private final Operation operation;
 	private boolean canBeBoosted;
 	private String displayText;
+	private Boosts boosts;
+	private QuestHelperPlugin questHelperPlugin;
 
 	/**
 	 * Check if a player has a certain skill level
@@ -99,13 +104,55 @@ public class SkillRequirement extends AbstractRequirement
 		this.displayText = displayText;
 	}
 
-
 	@Override
 	public boolean check(Client client)
 	{
 		int skillLevel = canBeBoosted ? Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill)) :
 			client.getRealSkillLevel(skill);
 		return skillLevel >= requiredLevel;
+	}
+
+	public boolean checkRange(Skill skill, int requiredLevel, Client client, QuestHelperConfig config)
+	{
+		Boosts selectedSkill = null;
+		for (Boosts boostSkills : boosts.values())
+		{
+			if (skill.getName().equals(boostSkills.getName()))
+			{
+				selectedSkill = boostSkills;
+			}
+		}
+
+		int currentSkill = Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill));
+		int highestBoost = selectedSkill.getHighestBoost();
+
+		if (config.stewBoosts() && highestBoost < 5)
+		{
+			highestBoost = 5;
+		}
+
+		if (requiredLevel-highestBoost <= currentSkill)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	public int checkBoosted(Client client, QuestHelperConfig config)
+	{
+		int skillLevel = canBeBoosted ? Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill)) :
+			client.getRealSkillLevel(skill);
+
+		if (skillLevel >= requiredLevel)
+		{
+			return 1;
+		} else if (canBeBoosted && checkRange(skill, requiredLevel, client, config))
+		{
+			return 2;
+		} else {
+			return 3;
+		}
 	}
 
 	@Override
@@ -127,5 +174,19 @@ public class SkillRequirement extends AbstractRequirement
 		}
 
 		return returnText;
+	}
+
+	@Override
+	public Color getColor(Client client, QuestHelperConfig config)
+	{
+		switch (checkBoosted(client, config)){
+			case 1:
+				return config.passColour();
+			case 2:
+				return config.boostColour();
+			case 3:
+				return config.failColour();
+		}
+		return config.failColour();
 	}
 }


### PR DESCRIPTION
revamped 'boostable' skill requirements, displaying orange if a boost is in range for the player
![image](https://user-images.githubusercontent.com/13607196/186995100-04d2791d-8a3d-488b-8752-bf957061683a.png)
Added option in settings to enable spicy stew boosts

fixed rewards not properly displaying 'none' if null
before:
![image](https://user-images.githubusercontent.com/13607196/186937685-9e8d1baa-1786-4f50-af9c-ac38408edf08.png)
after:
![image](https://user-images.githubusercontent.com/13607196/186937778-2be81db6-4f7e-4fbf-bbee-46603cc8510f.png)

Plus a bunch of other various fixes: #900, #902, #912


