### PR TITLE
Add missing Dialog Step to Silk Merchant in Song of the Elves

### DIFF
--- a/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
+++ b/src/main/java/com/questhelper/quests/songoftheelves/SongOfTheElves.java
@@ -914,6 +914,7 @@ public class SongOfTheElves extends BasicQuestHelper
 		talkToSpiceSeller.addDialogStep("I'm here to tell you about some new taxes.");
 		talkToSilkMerchant = new NpcStep(this, NpcID.SILK_MERCHANT_8728, new WorldPoint(2656, 3301, 0),
 			"Talk to the silk merchant in the East Ardougne Market.", ardyFullHelmEquipped, ardyPlatebodyEquipped, steelPlatelegsEquipped);
+		talkToSilkMerchant.addDialogStep("I'm here to tell you about some new taxes.");
 
 		talkToTownCrier = new NpcStep(this, NpcID.TOWN_CRIER_279, new WorldPoint(2666, 3312, 0),
 			"Talk to the town crier in the East Ardougne Market.", ardyFullHelmEquipped, ardyPlatebodyEquipped, steelPlatelegsEquipped);


### PR DESCRIPTION
During the "Inciting the citizens" step in Song of the Elves, when instructed to talk to the Silk merchant, there is no dialog step to tell you to choose option 2. Believe I added the correct line to add the step, unsure on ways to test steps when quest is already completed.