### PR TITLE
Add dialog step about tinderbox warning

### DIFF
--- a/src/main/java/com/questhelper/quests/watchtower/Watchtower.java
+++ b/src/main/java/com/questhelper/quests/watchtower/Watchtower.java
@@ -501,9 +501,16 @@ public class Watchtower extends BasicQuestHelper
 		leaveScaredSkavidRoom = new ObjectStep(this, ObjectID.CAVE_EXIT_2821, new WorldPoint(2504, 9442, 0), "Talk to four other skavids in their caves.");
 
 		enterSkavid1Cave = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2808, new WorldPoint(2554, 3053, 0), "Talk to four other skavids in their caves.", skavidMap, lightSource);
+		enterSkavid1Cave.addDialogStep("I'll be fine without a tinderbox.");
+
 		enterSkavid2Cave = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2807, new WorldPoint(2541, 3053, 0), "Talk to four other skavids in their caves.", skavidMap, lightSource);
+		enterSkavid2Cave.addDialogStep("I'll be fine without a tinderbox.");
+
 		enterSkavid3Cave = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2806, new WorldPoint(2524, 3069, 0), "Talk to four other skavids in their caves.", skavidMap, lightSource);
+		enterSkavid3Cave.addDialogStep("I'll be fine without a tinderbox.");
+
 		enterSkavid4Cave = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2805, new WorldPoint(2561, 3024, 0), "Talk to four other skavids in their caves.", skavidMap, lightSource);
+		enterSkavid4Cave.addDialogStep("I'll be fine without a tinderbox.");
 
 		talkToSkavid1 = new NpcStep(this, NpcID.SKAVID_4378, new WorldPoint(2503, 9449, 0), "Talk to the skavid.");
 		talkToSkavid1.addDialogStep("Cur.");
@@ -528,6 +535,7 @@ public class Watchtower extends BasicQuestHelper
 			"Try to go through the gate to the south east cave of Gu'Tanoth. Give the guard a gold bar and go through.", goldBar);
 
 		enterInsaneSkavidCave = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2810, new WorldPoint(2528, 3013, 0), "Enter the mad skavid's cave.");
+		enterInsaneSkavidCave.addDialogStep("I'll be fine without a tinderbox.");
 
 		talkToInsaneSkavid = new SkavidChoice(this);
 


### PR DESCRIPTION
When entering the cave with a lit light source, there will be a warning message about bringing a tinderbox in case the light source goes out. Because this won't happen during the quest I've added dialog steps to help the player make a decision.