### PR TITLE
Update lumbridge elite diary quest point requirement

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -139,7 +139,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		notQCEmote = new VarplayerRequirement(1195, false, 9);
 
 		// todo find better way to check for all quests completed
-		allQuests = new QuestPointRequirement(290, Operation.EQUAL);
+		allQuests = new QuestPointRequirement(291, Operation.EQUAL);
 
 		lockpick = new ItemRequirement("Lockpick", ItemID.LOCKPICK).showConditioned(notRichChest).isNotConsumed();
 		crossbow = new ItemRequirement("Crossbow", ItemCollections.CROSSBOWS).showConditioned(notMovario).isNotConsumed();


### PR DESCRIPTION
Updated the required amount of QP for the lumbridge elite diary since after the release of "The Garden of Death" the maximum amount of quest points increased to 291 from 290.



![image](https://user-images.githubusercontent.com/72727555/208125050-ddf7e184-f3ec-4fd9-a3d6-63ddda9988fb.png)

**Before**
![image](https://user-images.githubusercontent.com/72727555/208125080-9059e994-9e8e-428b-935e-5fbfa256d8c2.png)
**After**
![image](https://user-images.githubusercontent.com/72727555/208125408-0165cc07-d668-43e4-9b0b-e17e34e4bb25.png)

