### PR TITLE
Remove Lumberyard Teleport From Slug Menace

### DIFF
--- a/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
+++ b/src/main/java/com/questhelper/quests/shilovillage/ShiloVillage.java
@@ -358,7 +358,7 @@ public class ShiloVillage extends BasicQuestHelper
 			"Search the dolmen, ready to fight.");
 
 		killNazastarool = new NpcStep(this, NpcID.NAZASTAROOL, new WorldPoint(2892, 9488, 0),
-			"Defeat Nazastrool's 3 forms. You can safe spot them over the dolem, and the Crumble Undead spell is very" +
+			"Defeat Nazastrool's 3 forms. You can safe spot them over the dolmen, and the Crumble Undead spell is very" +
 				" strong against them.");
 		((NpcStep) killNazastarool).addAlternateNpcs(NpcID.NAZASTAROOL_5354, NpcID.NAZASTAROOL_5355);
 		((NpcStep)killNazastarool).addSafeSpots(new WorldPoint(2894, 9486, 0), new WorldPoint(2891, 9486, 0));

--- a/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/quests/theslugmenace/TheSlugMenace.java
@@ -233,6 +233,7 @@ public class TheSlugMenace extends BasicQuestHelper
 		airAltarTeleport.addAlternates(ItemID.FALADOR_TELEPORT, ItemID.RIMMINGTON_TELEPORT);
 		airAltarTeleport.setDisplayMatchedItemName(true);
 		airAltarTeleport.setTooltip("The best items for this are (in order):");
+		airAltarTeleport.appendToTooltip("Ring Of The Elements");
 		airAltarTeleport.appendToTooltip("Skills Necklace (to Crafting Guild)");
 		airAltarTeleport.appendToTooltip("Falador Teleport");
 		airAltarTeleport.appendToTooltip("Rimmington/House Teleport");
@@ -241,6 +242,7 @@ public class TheSlugMenace extends BasicQuestHelper
 		earthAltarTeleport.addAlternates(ItemID.VARROCK_TELEPORT, ItemID.LUMBERYARD_TELEPORT, ItemID.DIGSITE_TELEPORT);
 		earthAltarTeleport.setDisplayMatchedItemName(true);
 		earthAltarTeleport.setTooltip("The best items for this are (in order):");
+		earthAltarTeleport.appendToTooltip("Ring Of The Elements");
 		earthAltarTeleport.appendToTooltip("Lumberyard Teleport");
 		earthAltarTeleport.appendToTooltip("Digsite Pendant(s)");
 		earthAltarTeleport.appendToTooltip("Digsite Teleport");
@@ -249,12 +251,13 @@ public class TheSlugMenace extends BasicQuestHelper
 		fireAltarTeleport = new ItemRequirement("Teleport near Fire Altar", ItemCollections.RING_OF_DUELINGS);
 		fireAltarTeleport.addAlternates(ItemCollections.AMULET_OF_GLORIES);
 		fireAltarTeleport.setTooltip("The best items for this are (in order):");
+		fireAltarTeleport.appendToTooltip("Ring Of The Elements");
 		fireAltarTeleport.appendToTooltip("Ring of Dueling");
 		fireAltarTeleport.appendToTooltip("Amulet of Glory (to Al Kharid)");
 
 		waterAltarTeleport = new ItemRequirement("Teleport near Water Altar", ItemID.LUMBRIDGE_TELEPORT);
 		waterAltarTeleport.setTooltip("The best items for this are (in order):");
-		waterAltarTeleport.appendToTooltip("Lumbridge Graveyard Teleport");
+		waterAltarTeleport.appendToTooltip("Ring Of The Elements");
 		waterAltarTeleport.appendToTooltip("Lumbridge Teleport");
 
 		mindAltarTeleport = new ItemRequirement("Teleport near Mind Altar", ItemID.MIND_ALTAR_TELEPORT);


### PR DESCRIPTION
Issue #1015  Remove lumberyard tele from slug menace tooltip as it was removed from game. Added Ring Of The Elements as a tooltip. 