### PR TITLE
fix: avoid varbit lookup in quest setup when not logged in

### DIFF
--- a/src/main/java/com/questhelper/quests/bonevoyage/BoneVoyage.java
+++ b/src/main/java/com/questhelper/quests/bonevoyage/BoneVoyage.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -171,7 +173,7 @@ public class BoneVoyage extends BasicQuestHelper
 		sawmillProposal = new ItemRequirement("Sawmill proposal", ItemID.SAWMILL_PROPOSAL);
 		sawmillProposal.setTooltip("You can get another from the sawmill operator near Varrock");
 		sawmillAgreement = new ItemRequirement("Sawmill agreement", ItemID.SAWMILL_AGREEMENT);
-		if (canEnterGuild.check(client))
+		if (client.getGameState() == GameState.LOGGED_IN && canEnterGuild.check(client))
 		{
 			sawmillAgreement.setTooltip("You can get another from the sawmill operator in the Woodcutting Guild");
 		}

--- a/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
+++ b/src/main/java/com/questhelper/quests/recipefordisaster/RFDSirAmikVarze.java
@@ -149,7 +149,7 @@ public class RFDSirAmikVarze extends BasicQuestHelper
 		machete = new ItemRequirement("Any machete", ItemCollections.MACHETE).isNotConsumed();
 		radimusNotes = new ItemRequirement("Radimus notes", ItemID.RADIMUS_NOTES).isNotConsumed();
 		radimusNotes.addAlternates(ItemID.RADIMUS_NOTES_715);
-		if (QuestHelperQuest.LEGENDS_QUEST.getState(client) == QuestState.FINISHED)
+		if (client.getGameState() == GameState.LOGGED_IN && QuestHelperQuest.LEGENDS_QUEST.getState(client) == QuestState.FINISHED)
 		{
 			macheteAndRadimus = machete;
 		}

--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -335,28 +335,38 @@ public class TheFremennikIsles extends BasicQuestHelper
 		yakBottom = new ItemRequirement("Yak-hide armour (bottom)", ItemID.YAKHIDE_ARMOUR_10824).isNotConsumed();
 		roundShield = new ItemRequirement("Neitiznot shield", ItemID.NEITIZNOT_SHIELD).isNotConsumed();
 
-		if (client.getGameState() == GameState.LOGGED_IN) {
-			if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman()) {
+		if (client.getGameState() == GameState.LOGGED_IN)
+		{
+			if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
+			{
 				splitLogs8.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 				splitLogs4.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 				yakTop.setTooltip("Kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
 				yakBottom.setTooltip("Kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
 				roundShield.setTooltip("Get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
-			} else {
-				if (client.getRealSkillLevel(Skill.WOODCUTTING) >= 56) {
+			}
+			else
+			{
+				if (client.getRealSkillLevel(Skill.WOODCUTTING) >= 56)
+				{
 					splitLogs8.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 					splitLogs4.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 					roundShield.setTooltip("Buy from the GE, or get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
-				} else {
+				}
+				else
+				{
 					splitLogs8.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
 					splitLogs4.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
 					roundShield.setTooltip("Buy from the GE, or get level 56 Woodcutting");
 				}
 
-				if (client.getRealSkillLevel(Skill.CRAFTING) >= 46) {
+				if (client.getRealSkillLevel(Skill.CRAFTING) >= 46)
+				{
 					yakTop.setTooltip("Buy from the GE, or kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
 					yakBottom.setTooltip("Buy from the GE, or kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
-				} else {
+				}
+				else
+				{
 					yakBottom.setTooltip("Buy from the GE, or get 46 crafting");
 					yakTop.setTooltip("Buy from the GE, or get 46 crafting");
 				}

--- a/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/quests/thefremennikisles/TheFremennikIsles.java
@@ -56,6 +56,7 @@ import com.questhelper.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
+import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -334,38 +335,31 @@ public class TheFremennikIsles extends BasicQuestHelper
 		yakBottom = new ItemRequirement("Yak-hide armour (bottom)", ItemID.YAKHIDE_ARMOUR_10824).isNotConsumed();
 		roundShield = new ItemRequirement("Neitiznot shield", ItemID.NEITIZNOT_SHIELD).isNotConsumed();
 
-		if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
-		{
-			splitLogs8.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
-			splitLogs4.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
-			yakTop.setTooltip("Kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
-			yakBottom.setTooltip("Kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
-			roundShield.setTooltip("Get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
-		}
-		else
-		{
-			if (client.getRealSkillLevel(Skill.WOODCUTTING) >= 56)
-			{
-				splitLogs8.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
-				splitLogs4.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
-				roundShield.setTooltip("Buy from the GE, or get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
-			}
-			else
-			{
-				splitLogs8.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
-				splitLogs4.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
-				roundShield.setTooltip("Buy from the GE, or get level 56 Woodcutting");
-			}
+		if (client.getGameState() == GameState.LOGGED_IN) {
+			if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman()) {
+				splitLogs8.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
+				splitLogs4.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
+				yakTop.setTooltip("Kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
+				yakBottom.setTooltip("Kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
+				roundShield.setTooltip("Get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
+			} else {
+				if (client.getRealSkillLevel(Skill.WOODCUTTING) >= 56) {
+					splitLogs8.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
+					splitLogs4.setTooltip("Buy some from the GE, or cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
+					roundShield.setTooltip("Buy from the GE, or get 2 arctic pine logs, a bronze nail, a hammer, and a rope, and make the shield on the woodcutting stump in central Neitiznot");
+				} else {
+					splitLogs8.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
+					splitLogs4.setTooltip("Buy some from the GE, or get level 56 Woodcutting");
+					roundShield.setTooltip("Buy from the GE, or get level 56 Woodcutting");
+				}
 
-			if (client.getRealSkillLevel(Skill.CRAFTING) >= 46)
-			{
-				yakTop.setTooltip("Buy from the GE, or kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
-				yakBottom.setTooltip("Buy from the GE, or kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
-			}
-			else
-			{
-				yakBottom.setTooltip("Buy from the GE, or get 46 crafting");
-				yakTop.setTooltip("Buy from the GE, or get 46 crafting");
+				if (client.getRealSkillLevel(Skill.CRAFTING) >= 46) {
+					yakTop.setTooltip("Buy from the GE, or kill yaks for 2 hides, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
+					yakBottom.setTooltip("Buy from the GE, or kill yaks for a hide, have Thakkrad next to Mawnis cure them, and use a thread + needle to craft");
+				} else {
+					yakBottom.setTooltip("Buy from the GE, or get 46 crafting");
+					yakTop.setTooltip("Buy from the GE, or get 46 crafting");
+				}
 			}
 		}
 		knife = new ItemRequirement("Knife", ItemID.KNIFE).isNotConsumed();

--- a/src/main/java/com/questhelper/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -58,6 +58,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntUnaryOperator;
+
+import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -269,8 +272,9 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		skullStaples = new ItemRequirement("Skull staple", ItemID.SKULL_STAPLE);
 		anchor = new ItemRequirement("Barrelchest anchor", ItemID.BARRELCHEST_ANCHOR_10888);
 
-		neededJars = bellJars.quantity(3 - client.getVarbitValue(3399));
-		neededStaples = skullStaples.quantity(30 - client.getVarbitValue(3400));
+		IntUnaryOperator varbit = id -> client.getGameState() == GameState.LOGGED_IN ? client.getVarbitValue(id) : 0;
+		neededJars = bellJars.quantity(3 - varbit.applyAsInt(3399));
+		neededStaples = skullStaples.quantity(30 - varbit.applyAsInt(3400));
 	}
 
 	public void setupZones()


### PR DESCRIPTION
<details>
<summary>Fixed TheGreatBrainRobbery NPE</summary>

```
[Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
java.lang.NullPointerException: null
	at client.getVarbitValue(client.java:9184)
	at client.getVarbitValue(client.java:58466)
	at com.questhelper.quests.thegreatbrainrobbery.TheGreatBrainRobbery.lambda$setupRequirements$0(TheGreatBrainRobbery.java:275)
	at com.questhelper.quests.thegreatbrainrobbery.TheGreatBrainRobbery.setupRequirements(TheGreatBrainRobbery.java:276)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$0(QuestHelperPlugin.java:318)
	at java.base/java.util.HashMap.forEach(HashMap.java:1425)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$1(QuestHelperPlugin.java:316)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:80)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:213)
	at client.ac(client.java:31956)
	at client.an(client.java)
	at an.ao(an.java:390)
	at an.run(an.java:369)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
</details>

<details>
<summary>Fixed TheFremennikIsles NPE</summary>

```
[Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
java.lang.NullPointerException: null
	at client.getVarbitValue(client.java:9184)
	at client.getVarbitValue(client.java:58466)
	at client.getAccountType(client.java:32690)
	at com.questhelper.quests.thefremennikisles.TheFremennikIsles.setupRequirements(TheFremennikIsles.java:337)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$0(QuestHelperPlugin.java:318)
	at java.base/java.util.HashMap.forEach(HashMap.java:1425)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$1(QuestHelperPlugin.java:316)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:80)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:213)
	at client.ac(client.java:31956)
	at client.an(client.java)
	at an.ao(an.java:390)
	at an.run(an.java:369)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
</details>

<details>
<summary>Fixed BoneVoyage NPE</summary>

```
[Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
java.lang.NullPointerException: null
	at client.getVarbitValue(client.java:9184)
	at client.getVarbitValue(client.java:58466)
	at com.questhelper.requirements.player.FavourRequirement.check(FavourRequirement.java:55)
	at com.questhelper.requirements.conditional.Conditions.lambda$check$0(Conditions.java:126)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.ReduceOps$5.evaluateSequential(ReduceOps.java:257)
	at java.base/java.util.stream.ReduceOps$5.evaluateSequential(ReduceOps.java:248)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.count(ReferencePipeline.java:605)
	at com.questhelper.requirements.conditional.Conditions.check(Conditions.java:127)
	at com.questhelper.quests.bonevoyage.BoneVoyage.setupRequirements(BoneVoyage.java:174)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$0(QuestHelperPlugin.java:318)
	at java.base/java.util.HashMap.forEach(HashMap.java:1425)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$1(QuestHelperPlugin.java:316)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:80)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:213)
	at client.ac(client.java:31956)
	at client.an(client.java)
	at an.ao(an.java:390)
	at an.run(an.java:369)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
</details>

<details>
<summary>Fixed RFDSirAmikVarze NPE (technically this one is `runScript` rather than varbit)</summary>

```
[Client] ERROR client-patch - Client error: 6152 4029 7505
java.lang.NullPointerException: null
	at cu.e(cu.java:26)
	at pv.ac(pv.java:5042)
	at bb.v(bb.java:436)
	at du.e(du.java:34232)
	at client.wm(client.java)
	at client.tg(client.java:28960)
	at client.runScript(client.java:17753)
	at com.questhelper.QuestHelperQuest.getState(QuestHelperQuest.java:522)
	at com.questhelper.quests.recipefordisaster.RFDSirAmikVarze.setupRequirements(RFDSirAmikVarze.java:152)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$0(QuestHelperPlugin.java:318)
	at java.base/java.util.HashMap.forEach(HashMap.java:1425)
	at com.questhelper.QuestHelperPlugin.lambda$startUp$1(QuestHelperPlugin.java:316)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:80)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:213)
	at client.ac(client.java:31956)
	at client.an(client.java)
	at an.ao(an.java:390)
	at an.run(an.java:369)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
</details>
