### PR TITLE
Fix issue #1041 added hammer requirement

### DIFF
--- a/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessElite.java
+++ b/src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessElite.java
@@ -281,7 +281,7 @@ public class WildernessElite extends ComplexStateQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(combatGear, lawRune.quantity(2), waterRune.quantity(8), coins.quantity(3750), axe,
+		return Arrays.asList(combatGear, hammer, lawRune.quantity(2), waterRune.quantity(8), coins.quantity(3750), axe,
 			tinderbox, pickaxe, coal.quantity(16), lobsterPot, darkFishingBait, godEquip);
 	}
 


### PR DESCRIPTION
Fixes issue https://github.com/Zoinkwiz/quest-helper/issues/1041 Wildy Elite doesnt recommend hammere - added hammer to requirements at src/main/java/com/questhelper/achievementdiaries/wilderness/WildernessElite line 284