### PR TITLE
Changing the Tai Bwo favour requirement on My Arm's Big Adventure to be optional

### DIFF
--- a/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
+++ b/src/main/java/com/questhelper/quests/myarmsbigadventure/MyArmsBigAdventure.java
@@ -465,7 +465,7 @@ public class MyArmsBigAdventure extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 10));
 		req.add(new SkillRequirement(Skill.FARMING, 29, true));
 		// 907 is the Varbit for tai bwo wannai cleanup favour
-		req.add(new VarbitRequirement(907, Operation.GREATER_EQUAL, 60, "At least 60% favor in the Tai Bwo Wannai Cleanup minigame"));
+		req.add(new VarbitRequirement(907, Operation.GREATER_EQUAL, 60, "At least 60% favor in the Tai Bwo Wannai Cleanup minigame", false));
 		return req;
 	}
 

--- a/src/main/java/com/questhelper/requirements/var/VarbitRequirement.java
+++ b/src/main/java/com/questhelper/requirements/var/VarbitRequirement.java
@@ -70,6 +70,25 @@ public class VarbitRequirement extends AbstractRequirement
 	}
 
 	/**
+	 * Check if the player's varbit value meets the required level using the given
+	 * {@link Operation}.
+	 *
+	 * @param varbitID             the {@link Varbits} id to use
+	 * @param operation            the {@link Operation} to check with
+	 * @param requiredValue        the required varbit value to pass this requirement
+	 * @param displayText          the display text
+	 * @param shouldCountForFilter if the requirement should count for quest filtering
+	 */
+	public VarbitRequirement(int varbitID, Operation operation, int requiredValue, String displayText, boolean shouldCountForFilter)
+	{
+		this.varbitID = varbitID;
+		this.operation = operation;
+		this.requiredValue = requiredValue;
+		this.displayText = displayText;
+		this.shouldCountForFilter = shouldCountForFilter;
+	}
+
+	/**
 	 * Check if a specified varbit value is exactly the supplied value.
 	 *
 	 * @param varbitID the varbit id


### PR DESCRIPTION
Fix for issue #1055

The Tai Bwo Favour tracker only recognizes you have the favour requirement if you've checked your status since restarting RuneLite. This hides the quest when it shouldn't if "show meets reqs" is selected, as I imagine people rarely check their favour outside of doing the Karamja diary.