### PR TITLE
Update skill rewards in SotN

### DIFF
--- a/src/main/java/com/questhelper/quests/secretsofthenorth/SecretsOfTheNorth.java
+++ b/src/main/java/com/questhelper/quests/secretsofthenorth/SecretsOfTheNorth.java
@@ -604,8 +604,8 @@ public class SecretsOfTheNorth extends BasicQuestHelper
 	{
 		return Arrays.asList(
 			new ExperienceReward(Skill.AGILITY, 60000),
-			new ExperienceReward(Skill.FARMING, 50000),
-			new ExperienceReward(Skill.FARMING, 40000)
+			new ExperienceReward(Skill.THIEVING, 50000),
+			new ExperienceReward(Skill.HUNTER, 40000)
 		);
 	}
 


### PR DESCRIPTION
Hey,

Love the plugin really useful.

Just noticed Secrets of the North was added. Where it had the 50k exp reward and 40k exp reward as farming experience.

RSWiki reckons it's 50k thieving and 40k hunter https://oldschool.runescape.wiki/w/Secrets_of_the_North 