### PR TITLE
fix: add quest point rewards for SotN

### DIFF
--- a/src/main/java/com/questhelper/quests/secretsofthenorth/SecretsOfTheNorth.java
+++ b/src/main/java/com/questhelper/quests/secretsofthenorth/SecretsOfTheNorth.java
@@ -42,6 +42,7 @@ import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.rewards.ExperienceReward;
+import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
@@ -597,6 +598,12 @@ public class SecretsOfTheNorth extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.THIEVING, 64, false));
 		req.add(new SkillRequirement(Skill.HUNTER, 56, false));
 		return req;
+	}
+
+	@Override
+	public QuestPointReward getQuestPointReward()
+	{
+		return new QuestPointReward(2);
 	}
 
 	@Override


### PR DESCRIPTION
Add missing Quest Point reward.

The [wiki article](https://oldschool.runescape.wiki/w/Secrets_of_the_North#Rewards) says the quest gives 2 Quest Points.

Left a comment at https://github.com/Zoinkwiz/quest-helper/pull/1071, but decided to make a PR.

---

I have not compiled the code, but I assume it works.