### PR TITLE
Add visibility check for outline highlights of tile objects

### DIFF
--- a/src/main/java/com/questhelper/VisibilityHelper.java
+++ b/src/main/java/com/questhelper/VisibilityHelper.java
@@ -1,0 +1,108 @@
+package com.questhelper;
+
+import java.awt.Shape;
+import java.util.HashMap;
+import java.util.Map;
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.GameObject;
+import net.runelite.api.GroundObject;
+import net.runelite.api.Model;
+import net.runelite.api.Renderable;
+import net.runelite.api.TileObject;
+import net.runelite.api.WallObject;
+
+public class VisibilityHelper
+{
+	private final Map<Integer, Boolean> visibilityCache = new HashMap<>();
+
+	public boolean isObjectVisible(TileObject tileObject)
+	{
+		if (!visibilityCache.containsKey(tileObject.getId()))
+		{
+			visibilityCache.put(tileObject.getId(), isObjectVisibleChecker(tileObject));
+		}
+		return visibilityCache.get(tileObject.getId());
+	}
+
+
+	public Shape getObjectHull(TileObject tileObject)
+	{
+		if (tileObject instanceof GameObject)
+		{
+			return ((GameObject) tileObject).getConvexHull();
+		}
+		else if (tileObject instanceof GroundObject)
+		{
+			return ((GroundObject) tileObject).getConvexHull();
+		}
+		else if (tileObject instanceof DecorativeObject)
+		{
+			return ((DecorativeObject) tileObject).getConvexHull();
+		}
+		else if (tileObject instanceof WallObject)
+		{
+			return ((WallObject) tileObject).getConvexHull();
+		}
+		return null;
+	}
+
+	private boolean isObjectVisibleChecker(TileObject tileObject)
+	{
+		if (tileObject instanceof GameObject)
+		{
+			Model model = extractModel(((GameObject) tileObject).getRenderable());
+			return modelHasVisibleTriangles(model);
+		}
+		else if (tileObject instanceof GroundObject)
+		{
+			Model model = extractModel(((GroundObject) tileObject).getRenderable());
+			return modelHasVisibleTriangles(model);
+		}
+		else if (tileObject instanceof DecorativeObject)
+		{
+			DecorativeObject decoObj = ((DecorativeObject) tileObject);
+			Model model1 = extractModel(decoObj.getRenderable());
+			Model model2 = extractModel(decoObj.getRenderable2());
+			return modelHasVisibleTriangles(model1) || modelHasVisibleTriangles(model2);
+		}
+		else if (tileObject instanceof WallObject)
+		{
+			WallObject wallObj = ((WallObject) tileObject);
+			Model model1 = extractModel(wallObj.getRenderable1());
+			Model model2 = extractModel(wallObj.getRenderable2());
+			return modelHasVisibleTriangles(model1) || modelHasVisibleTriangles(model2);
+		}
+		return false;
+	}
+
+	private Model extractModel(Renderable renderable)
+	{
+		if (renderable == null)
+		{
+			return null;
+		}
+		return renderable instanceof Model ? (Model) renderable : renderable.getModel();
+	}
+
+	private boolean modelHasVisibleTriangles(Model model)
+	{
+		if (model == null)
+		{
+			return false;
+		}
+		byte[] triangleTransparencies = model.getFaceTransparencies();
+		int triangleCount = model.getFaceCount();
+		if (triangleTransparencies == null)
+		{
+			return true;
+		}
+		for (int i = 0; i < triangleCount; i++)
+		{
+			if ((triangleTransparencies[i] & 255) < 254)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -24,6 +24,8 @@
  */
 package com.questhelper.steps;
 
+import com.questhelper.QuestHelperConfig;
+import static com.questhelper.QuestHelperConfig.ObjectHighlightStyle.OUTLINE;
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
@@ -305,20 +307,34 @@ public class ObjectStep extends DetailedQuestStep
 
 				Color configColor = getQuestHelper().getConfig().targetOverlayColor();
 
-				switch (questHelper.getConfig().highlightStyleObjects())
+				QuestHelperConfig.ObjectHighlightStyle highlightStyle = visibilityHelper.isObjectVisible(tileObject)
+					? questHelper.getConfig().highlightStyleObjects()
+					: OUTLINE;
+
+				switch (highlightStyle)
 				{
 					case CLICK_BOX:
 						Color fillColor = new Color(configColor.getRed(), configColor.getGreen(), configColor.getBlue(), 20);
-						OverlayUtil.renderHoverableArea(graphics, tileObject.getClickbox(), mousePosition, fillColor,
+						OverlayUtil.renderHoverableArea(
+							graphics,
+							tileObject.getClickbox(),
+							mousePosition,
+							fillColor,
 							questHelper.getConfig().targetOverlayColor().darker(),
-							questHelper.getConfig().targetOverlayColor());
+							questHelper.getConfig().targetOverlayColor()
+						);
 						break;
 					case OUTLINE:
-						modelOutlineRenderer.drawOutline(tileObject, questHelper.getConfig().outlineThickness(), configColor, questHelper.getConfig().outlineFeathering());
+						modelOutlineRenderer.drawOutline(
+							tileObject,
+							questHelper.getConfig().outlineThickness(),
+							configColor,
+							questHelper.getConfig().
+								outlineFeathering()
+						);
 						break;
 					default:
 				}
-
 			}
 		}
 

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -27,6 +27,7 @@ package com.questhelper.steps;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Module;
+import com.questhelper.VisibilityHelper;
 import static com.questhelper.overlays.QuestHelperOverlay.TITLED_CONTENT_COLOR;
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.QuestVarbits;
@@ -83,6 +84,8 @@ public abstract class QuestStep implements Module
 	@Inject
 	ModelOutlineRenderer modelOutlineRenderer;
 
+	@Inject
+	VisibilityHelper visibilityHelper;
 
 	@Getter
 	protected List<String> text;


### PR DESCRIPTION
This change prevents outlines from being used when there is no object with a visible model (the outline renderer will simply not render anything in that scenario). Instead it falls back on using a clickbox highlight so there is a useful highlight visible.