### PR TITLE
Rename Secrets of the North to match external quest resources enum

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperQuest.java
+++ b/src/main/java/com/questhelper/QuestHelperQuest.java
@@ -443,7 +443,7 @@ public enum QuestHelperQuest
 	A_KINGDOM_DIVIDED(new AKingdomDivided(), Quest.A_KINGDOM_DIVIDED, QuestVarbits.QUEST_A_KINGDOM_DIVIDED, QuestDetails.Type.P2P, QuestDetails.Difficulty.EXPERIENCED),
 	A_NIGHT_AT_THE_THEATRE(new ANightAtTheTheatre(), Quest.A_NIGHT_AT_THE_THEATRE, QuestVarbits.QUEST_A_NIGHT_AT_THE_THEATRE, QuestDetails.Type.P2P, QuestDetails.Difficulty.MASTER),
 	THE_GARDEN_OF_DEATH(new TheGardenOfDeath(), Quest.THE_GARDEN_OF_DEATH, QuestVarbits.QUEST_THE_GARDEN_OF_DEATH, QuestDetails.Type.P2P, QuestDetails.Difficulty.INTERMEDIATE),
-	THE_SECRETS_OF_THE_NORTH(new SecretsOfTheNorth(), Quest.SECRETS_OF_THE_NORTH, QuestVarbits.QUEST_SECRETS_OF_THE_NORTH, QuestDetails.Type.P2P, QuestDetails.Difficulty.MASTER),
+	SECRETS_OF_THE_NORTH(new SecretsOfTheNorth(), Quest.SECRETS_OF_THE_NORTH, QuestVarbits.QUEST_SECRETS_OF_THE_NORTH, QuestDetails.Type.P2P, QuestDetails.Difficulty.MASTER),
 
 	//Miniquests
 	ENTER_THE_ABYSS(new EnterTheAbyss(), Quest.ENTER_THE_ABYSS, QuestVarPlayer.QUEST_ENTER_THE_ABYSS, QuestDetails.Type.MINIQUEST, QuestDetails.Difficulty.MINIQUEST),

--- a/src/main/java/com/questhelper/panel/questorders/QuestOrders.java
+++ b/src/main/java/com/questhelper/panel/questorders/QuestOrders.java
@@ -241,7 +241,7 @@ public class QuestOrders
 		//QuestHelperQuest.INTO_THE_TOMBS, - Placeholder for later addition. (Miniquest)
 		QuestHelperQuest.A_NIGHT_AT_THE_THEATRE,
 		QuestHelperQuest.DRAGON_SLAYER_II,
-		QuestHelperQuest.THE_SECRETS_OF_THE_NORTH,
+		QuestHelperQuest.SECRETS_OF_THE_NORTH,
 		//QuestHelperQuest.SECRETS_OF_THE_NORTH, - Placeholder for later addition.
 		QuestHelperQuest.SONG_OF_THE_ELVES,
 		QuestHelperQuest.CLOCK_TOWER,
@@ -475,7 +475,7 @@ public class QuestOrders
 		QuestHelperQuest.FREMENNIK_MEDIUM,
 		QuestHelperQuest.A_NIGHT_AT_THE_THEATRE,
 		QuestHelperQuest.DRAGON_SLAYER_II,
-		QuestHelperQuest.THE_SECRETS_OF_THE_NORTH,
+		QuestHelperQuest.SECRETS_OF_THE_NORTH,
 		QuestHelperQuest.SONG_OF_THE_ELVES,
 		QuestHelperQuest.THE_CORSAIR_CURSE,
 
@@ -712,7 +712,7 @@ public class QuestOrders
 		//QuestHelperQuest.THE_FROZEN_DOOR, - Placeholder for future addition.
 		QuestHelperQuest.HOPESPEARS_WILL,
 		//QuestHelperQuest.INTO_THE_TOMBS, - Placeholder for future addition.
-		QuestHelperQuest.THE_SECRETS_OF_THE_NORTH
+		QuestHelperQuest.SECRETS_OF_THE_NORTH
 	);
 
 	public static String normalizeQuestName(String questName)

--- a/src/main/java/com/questhelper/quests/secretsofthenorth/SecretsOfTheNorth.java
+++ b/src/main/java/com/questhelper/quests/secretsofthenorth/SecretsOfTheNorth.java
@@ -61,7 +61,7 @@ import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
 @QuestDescriptor(
-	quest = QuestHelperQuest.THE_SECRETS_OF_THE_NORTH
+	quest = QuestHelperQuest.SECRETS_OF_THE_NORTH
 )
 public class SecretsOfTheNorth extends BasicQuestHelper
 {


### PR DESCRIPTION
Fixes: https://github.com/Zoinkwiz/quest-helper/issues/1080, https://github.com/Zoinkwiz/quest-helper/issues/1117 by matching external quest resources enum: https://github.com/Zoinkwiz/quest-helper/blob/86cd794df5a4d402e8a46aea50c68b545a37808a/src/main/java/com/questhelper/ExternalQuestResources.java#L178

Tested locally:
![image](https://user-images.githubusercontent.com/7159227/232966503-9164fc8c-7989-47cf-9bba-908e3ea7811a.png)
