### PR TITLE
Set The Tourist Trap feather requirement to 50

### DIFF
--- a/src/main/java/com/questhelper/quests/thetouristtrap/TheTouristTrap.java
+++ b/src/main/java/com/questhelper/quests/thetouristtrap/TheTouristTrap.java
@@ -71,7 +71,7 @@ import net.runelite.api.widgets.WidgetInfo;
 public class TheTouristTrap extends BasicQuestHelper
 {
 	//Items Required
-	ItemRequirement desertTop, desertBottom, desertBoot, desertTopWorn, desertBottomWorn, desertBootWorn, bronzeBar3, hammer, feather10,
+	ItemRequirement desertTop, desertBottom, desertBoot, desertTopWorn, desertBottomWorn, desertBootWorn, bronzeBar3, hammer, feather50,
 		metalKey, slaveTop, slaveRobe, slaveBoot, slaveTopWorn, slaveRobeWorn, slaveBootWorn, bedabinKey, technicalPlans, prototypeDart, prototypeDartTip,
 		bronzeBar, tentiPineapple, bronzeBarHighlighted, barrel, anaInABarrel, anaInABarrelHighlighted, barrelHighlighted;
 


### PR DESCRIPTION
Strictly only 10 feathers is needed, but the player can lose feathers if creating a dart fails. The wiki recommends 30-50 feathers, so the required amount is set to 50.