### PR TITLE
Fix mentions of Runite bars being Rune bars in elite diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneElite.java
@@ -171,7 +171,7 @@ public class ArdougneElite extends ComplexStateQuestHelper
 		spade = new ItemRequirement("Spade", ItemID.SPADE).showConditioned(notPickTorstol).isNotConsumed();
 
 		yewLog = new ItemRequirement("Yew logs", ItemID.YEW_LOGS).showConditioned(notRuneCrossbow);
-		runeBar = new ItemRequirement("Rune bar", ItemID.RUNITE_BAR).showConditioned(notRuneCrossbow);
+		runeBar = new ItemRequirement("Runite bar", ItemID.RUNITE_BAR).showConditioned(notRuneCrossbow);
 		sinew = new ItemRequirement("Sinew", ItemID.SINEW).showConditioned(notRuneCrossbow);
 		root = new ItemRequirement("Root", ItemCollections.NON_MAGIC_TREE_ROOT).showConditioned(notRuneCrossbow);
 		sinewOrRoot = new ItemRequirements(LogicType.OR, "Sinew or non-magic tree root", root, sinew)

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
@@ -141,7 +141,7 @@ public class VarrockElite extends ComplexStateQuestHelper
 		cookingGuild = new ItemRequirement("Access to cooking guild", ItemCollections.COOKING_GUILD).showConditioned(notSummerPie).isNotConsumed();
 		cookingGuild.setTooltip("A chef's hat, Varrock Armour 3, or Cooking Cape");
 		rawPie = new ItemRequirement("Raw summer pie", ItemID.RAW_SUMMER_PIE).showConditioned(notSummerPie);
-		runeBar = new ItemRequirement("Rune bar", ItemID.RUNITE_BAR).showConditioned(notRuneDart);
+		runeBar = new ItemRequirement("Runite bar", ItemID.RUNITE_BAR).showConditioned(notRuneDart);
 		feather = new ItemRequirement("Feather", ItemID.FEATHER).showConditioned(notRuneDart);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notRuneDart).isNotConsumed();
 		runeDartTip = new ItemRequirement("Rune dart tip", ItemID.RUNE_DART_TIP);


### PR DESCRIPTION
Quick glance without processing what I was doing while finishing up Varrock elite ended up with bank search that returned no item, as Rune bar is not an osrs item.
Other Elite diaries and GM quests properly mention this item as Runite bar

I went ahead and ignored the variable and just replaced the user-facing instance, but I can update the variable(s) too if needed