### PR TITLE
Added alt & tooltip for hammer in Sleeping Giants

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/sleepinggiants/SleepingGiants.java
+++ b/src/main/java/com/questhelper/helpers/quests/sleepinggiants/SleepingGiants.java
@@ -190,7 +190,9 @@ public class SleepingGiants extends BasicQuestHelper
 		nails.setQuantity(10);
 
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER);
+		hammer.addAlternates(ItemID.IMCANDO_HAMMER);
 		hammer.canBeObtainedDuringQuest();
+		hammer.setTooltip("Imcando hammer also works");
 
 		chisel = new ItemRequirement("Chisel", ItemID.CHISEL);
 


### PR DESCRIPTION
Sleeping Giants did not recognize Imcando Hammer as an alternate for hammer.
Added Imcando hammer as an alt and included a tooltip that mentions it can be used instead. 

closes #1187 