### PR TITLE
Fix for RuneLite 1.10.9-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.8-SNAPSHOT'
+def runeLiteVersion = '1.10.9-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
RuneLite was updated today, adding support for new client version.

closes #1198