### PR TITLE
Use the correct item name in the Beneath Cursed Sands quest

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/beneathcursedsands/BeneathCursedSands.java
+++ b/src/main/java/com/questhelper/helpers/quests/beneathcursedsands/BeneathCursedSands.java
@@ -53,7 +53,7 @@ public class BeneathCursedSands extends BasicQuestHelper
 	ItemRequirement coal, tinderbox, ironBar, spade, meat, prayerPotions, fiveCoins;
 
 	// Items Recommended
-	ItemRequirement waterskins, antipoison, accessToFairyRings, pharaosSceptre, food, meleeCombatGear,
+	ItemRequirement waterskins, antipoison, accessToFairyRings, pharaohSceptre, food, meleeCombatGear,
 		rangedCombatGear, staminaPotions, nardahTeleport;
 
 	// Quest Items


### PR DESCRIPTION
The old item links to https://oldschool.runescape.wiki/w/Pharaoh%27s_sceptre_(discontinued)#(3). The new item links to https://oldschool.runescape.wiki/w/Pharaoh%27s_sceptre.