### PR TITLE
Merlin's Crystal fix Lady of the Lake step

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/merlinscrystal/MerlinsCrystal.java
+++ b/src/main/java/com/questhelper/helpers/quests/merlinscrystal/MerlinsCrystal.java
@@ -36,6 +36,7 @@ import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.conditional.ObjectCondition;
+import com.questhelper.requirements.npc.DialogRequirement;
 import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.rewards.ItemReward;
@@ -200,7 +201,7 @@ public class MerlinsCrystal extends BasicQuestHelper
 		clearedHive = new ObjectCondition(ObjectID.BEEHIVE_305);
 		hasAnyBlackCandle = new Conditions(LogicType.OR, blackCandle, litBlackCandle);
 		beggarNearby = new NpcCondition(NpcID.BEGGAR);
-		talkedToLady = new WidgetTextRequirement(217, 6, "Ok. That seems easy enough.");
+		talkedToLady = new Conditions(true, new DialogRequirement(client.getLocalPlayer().getName(), "Ok. That seems easy enough."));
 		hasReadSpell = new Conditions(true, LogicType.AND, new WidgetTextRequirement(229, 1, "You find a small inscription"));
 		inStar = new ZoneRequirement(star);
 		thrantaxNearby = new NpcCondition(NpcID.THRANTAX_THE_MIGHTY);

--- a/src/main/java/com/questhelper/helpers/quests/merlinscrystal/MerlinsCrystal.java
+++ b/src/main/java/com/questhelper/helpers/quests/merlinscrystal/MerlinsCrystal.java
@@ -200,7 +200,7 @@ public class MerlinsCrystal extends BasicQuestHelper
 		clearedHive = new ObjectCondition(ObjectID.BEEHIVE_305);
 		hasAnyBlackCandle = new Conditions(LogicType.OR, blackCandle, litBlackCandle);
 		beggarNearby = new NpcCondition(NpcID.BEGGAR);
-		talkedToLady = new WidgetTextRequirement(217, 5, "Ok. That seems easy enough.");
+		talkedToLady = new WidgetTextRequirement(217, 6, "Ok. That seems easy enough.");
 		hasReadSpell = new Conditions(true, LogicType.AND, new WidgetTextRequirement(229, 1, "You find a small inscription"));
 		inStar = new ZoneRequirement(star);
 		thrantaxNearby = new NpcCondition(NpcID.THRANTAX_THE_MIGHTY);


### PR DESCRIPTION
Fixes #425

Note that I **have not tested this** because I don't have any available alts atm, but this _should_ fix WidgetTextRequirement not triggering when the dialogue box shows.

Having a look at Runelite's consts [here](https://github.com/runelite/runelite/blob/f029989a291601a6430465494353d4ce7702adcf/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java#L220C25-L220C25) I suspect it's because the child ID is 5 when it's supposed to be 6 for the player's dialogue text.