### PR TITLE
Add antipoison as a suggested/required item for the "Freeing Azzanadra" step

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deserttreasure/DesertTreasure.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasure/DesertTreasure.java
@@ -642,7 +642,7 @@ public class DesertTreasure extends BasicQuestHelper
 		iceDiamondPanel.setLockingStep(getIceDiamond);
 
 		PanelDetails finishingPanel = new PanelDetails("Freeing Azzanadra",
-			Arrays.asList(placeBlood, enterPyramid, goDownFromFirstFloor, enterMiddleOfPyramid, talkToAzz), energyOrStaminas, food, prayerPotions);
+			Arrays.asList(placeBlood, enterPyramid, goDownFromFirstFloor, enterMiddleOfPyramid, talkToAzz), energyOrStaminas, food, prayerPotions, antipoison);
 
 		allSteps.add(smokeDiamondPanel);
 		allSteps.add(shadowDiamondPanel);


### PR DESCRIPTION
Antipoison is mentioned in the big "required items" list, but the player will have banked a few times before coming to this step, so it's good to give the player a gentle reminder