### PR TITLE
Contact!: Fix the trap path break & reward typo

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/contact/Contact.java
+++ b/src/main/java/com/questhelper/helpers/quests/contact/Contact.java
@@ -222,7 +222,7 @@ public class Contact extends BasicQuestHelper
 			new WorldPoint(2149, 4374, 2),
 			new WorldPoint(2151, 4374, 2),
 
-			new WorldPoint(3304, 9238, 3),
+			new WorldPoint(0, 0, 0),
 
 			new WorldPoint(2154, 4374, 2),
 			new WorldPoint(2157, 4374, 2),

--- a/src/main/java/com/questhelper/helpers/quests/contact/Contact.java
+++ b/src/main/java/com/questhelper/helpers/quests/contact/Contact.java
@@ -319,7 +319,7 @@ public class Contact extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("2 x 7,000 Experience Lamps (Combat Skills)", ItemID.ANTIQUE_LAMP, 2),
+				new ItemReward("7,000 Experience Lamps (Combat Skills)", ItemID.ANTIQUE_LAMP, 2),
 				new ItemReward("Keris", ItemID.KERIS, 1)
 		);
 	}


### PR DESCRIPTION
What it looks like in the main version:
![2023-09-09-094826_1278x708_scrot](https://github.com/Zoinkwiz/quest-helper/assets/962989/9e5d45d4-924b-4b2c-a64a-537d49b2824e)

What it looks like after my fix:
![2023-09-09-095017_1278x708_scrot](https://github.com/Zoinkwiz/quest-helper/assets/962989/fca353e6-215b-4663-8394-27b88af25219)

I also snuck in a reward typo fix that was showing the reward as `2x 2x Experience Lamps`

