### PR TITLE
Removed quantities from item reward names

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/daddyshome/DaddysHome.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/daddyshome/DaddysHome.java
@@ -221,14 +221,14 @@ public class DaddysHome extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("25 x Planks", ItemID.PLANK, 25),
-				new ItemReward("10 x Oak Planks", ItemID.OAK_PLANK, 10),
-				new ItemReward("50 x Mithril Nails", ItemID.MITHRIL_NAILS, 50),
-				new ItemReward("5 x Steel Bars", ItemID.STEEL_BAR, 5),
-				new ItemReward("8 x Bolt of Cloth", ItemID.BOLT_OF_CLOTH, 8),
-				new ItemReward("5 x House Teleport Tablets", ItemID.TELEPORT_TO_HOUSE, 5),
-				new ItemReward("1 x Falador Teleport Tablet", ItemID.FALADOR_TELEPORT, 1),
-				new ItemReward("POH in Rimmington or 1,000 Coins", ItemID.COINS_995, 1000));
+			new ItemReward("Planks", ItemID.PLANK, 25),
+			new ItemReward("Oak Planks", ItemID.OAK_PLANK, 10),
+			new ItemReward("Mithril Nails", ItemID.MITHRIL_NAILS, 50),
+			new ItemReward("Steel Bars", ItemID.STEEL_BAR, 5),
+			new ItemReward("Bolt of Cloth", ItemID.BOLT_OF_CLOTH, 8),
+			new ItemReward("House Teleport Tablets", ItemID.TELEPORT_TO_HOUSE, 5),
+			new ItemReward("Falador Teleport Tablet", ItemID.FALADOR_TELEPORT, 1),
+			new ItemReward("POH in Rimmington or 1,000 Coins", ItemID.COINS_995, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/atailoftwocats/ATailOfTwoCats.java
+++ b/src/main/java/com/questhelper/helpers/quests/atailoftwocats/ATailOfTwoCats.java
@@ -243,7 +243,7 @@ public class ATailOfTwoCats extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("2 x 2,500 Experience Lamps (Any skill over level 30).", ItemID.ANTIQUE_LAMP, 2),
+				new ItemReward("2,500 Experience Lamps (Any skill over level 30).", ItemID.ANTIQUE_LAMP, 2),
 				new ItemReward("A Doctors hat", ItemID.DOCTORS_HAT, 1),
 				new ItemReward("A Nurse hat", ItemID.NURSE_HAT, 1),
 				new ItemReward("A Mouse Toy", ItemID.MOUSE_TOY, 1)); //4447 Is Placeholder.

--- a/src/main/java/com/questhelper/helpers/quests/atasteofhope/ATasteOfHope.java
+++ b/src/main/java/com/questhelper/helpers/quests/atasteofhope/ATasteOfHope.java
@@ -569,7 +569,7 @@ public class ATasteOfHope extends BasicQuestHelper
 		return Arrays.asList(
 				new ItemReward("Ivandis Flail", ItemID.IVANDIS_FLAIL, 1),
 				new ItemReward("Drakan's Medallion", ItemID.DRAKANS_MEDALLION, 1),
-				new ItemReward("3 x 2,500 Experience Tomes (Any skill over level 35).", ItemID.TOME_OF_EXPERIENCE, 3) //22415 is placeholder
+				new ItemReward("2,500 Experience Tomes (Any skill over level 35).", ItemID.TOME_OF_EXPERIENCE, 3) //22415 is placeholder
 		);
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/cabinfever/CabinFever.java
+++ b/src/main/java/com/questhelper/helpers/quests/cabinfever/CabinFever.java
@@ -662,7 +662,7 @@ public class CabinFever extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("10,000 Coins", ItemID.COINS_995, 10000),
+				new ItemReward("Coins", ItemID.COINS_995, 10000),
 				new ItemReward("The Book o' Piracy", ItemID.BOOK_O_PIRACY, 1));
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/clientofkourend/ClientOfKourend.java
+++ b/src/main/java/com/questhelper/helpers/quests/clientofkourend/ClientOfKourend.java
@@ -196,7 +196,7 @@ public class ClientOfKourend extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("2 x 500 Experience Lamps (Any Skill)", ItemID.ANTIQUE_LAMP, 2), //4447 Placeholder until confirmed.
+				new ItemReward("500 Experience Lamps (Any Skill)", ItemID.ANTIQUE_LAMP, 2), //4447 Placeholder until confirmed.
 				new ItemReward("20% Kourend Favour Certificate", ItemID.KOUREND_FAVOUR_CERTIFICATE, 1),
 				new ItemReward("Kharedst's Memoirs", ItemID.KHAREDSTS_MEMOIRS, 1));
 	}

--- a/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
@@ -358,7 +358,7 @@ public class ClockTower extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("500 Coins", ItemID.COINS_995, 500));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 500));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/contact/Contact.java
+++ b/src/main/java/com/questhelper/helpers/quests/contact/Contact.java
@@ -319,7 +319,7 @@ public class Contact extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("2 x 7,000 Experience Lamps (Combat Skills)", ItemID.ANTIQUE_LAMP, 2),
+				new ItemReward("7,000 Experience Lamps (Combat Skills)", ItemID.ANTIQUE_LAMP, 2),
 				new ItemReward("Keris", ItemID.KERIS, 1)
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/quests/doricsquest/DoricsQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/doricsquest/DoricsQuest.java
@@ -119,7 +119,7 @@ public class DoricsQuest extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("180 Coins", ItemID.COINS_995, 180));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 180));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/fairytaleii/FairytaleII.java
+++ b/src/main/java/com/questhelper/helpers/quests/fairytaleii/FairytaleII.java
@@ -401,7 +401,7 @@ public class FairytaleII extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("2 x 2,500 Experience Lamps (Any skill over level 30.)", ItemID.ANTIQUE_LAMP, 2)); //4447 Is placeholder for filter.
+		return Collections.singletonList(new ItemReward("2,500 Experience Lamps (Any skill over level 30.)", ItemID.ANTIQUE_LAMP, 2)); //4447 Is placeholder for filter.
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/fightarena/FightArena.java
+++ b/src/main/java/com/questhelper/helpers/quests/fightarena/FightArena.java
@@ -243,7 +243,7 @@ public class FightArena extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("1,000 Coins", ItemID.COINS_995, 1000),
+				new ItemReward("Coins", ItemID.COINS_995, 1000),
 				new ItemReward("Khazard Armor", ItemID.KHAZARD_ARMOUR, 1));
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/gettingahead/GettingAhead.java
+++ b/src/main/java/com/questhelper/helpers/quests/gettingahead/GettingAhead.java
@@ -344,7 +344,7 @@ public class GettingAhead extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("3,000 Coins", ItemID.COINS_995, 3000));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 3000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/hazeelcult/HazeelCult.java
+++ b/src/main/java/com/questhelper/helpers/quests/hazeelcult/HazeelCult.java
@@ -361,7 +361,7 @@ public class HazeelCult extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-			new ItemReward("2,000 (2,005 if siding with Ceril) Coins", ItemID.COINS_995, 2000),
+			new ItemReward("(2,005 if siding with Ceril) Coins", ItemID.COINS_995, 2000),
 			new ItemReward("Hazeel's mark (if you sided with Hazeel)", ItemID.HAZEELS_MARK),
 			new ItemReward("Carnillean armour (if you sided with Ceril)", ItemID.CARNILLEAN_ARMOUR)
 		);

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
@@ -914,7 +914,7 @@ public class LunarDiplomacy extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("50 x Astral Runes", ItemID.ASTRAL_RUNE, 50),
+				new ItemReward("Astral Runes", ItemID.ASTRAL_RUNE, 50),
 				new ItemReward("A Seal of Passage", ItemID.SEAL_OF_PASSAGE, 1),
 				new ItemReward("A set of Lunar Equipment", -1, 1));
 	}

--- a/src/main/java/com/questhelper/helpers/quests/makinghistory/MakingHistory.java
+++ b/src/main/java/com/questhelper/helpers/quests/makinghistory/MakingHistory.java
@@ -293,7 +293,7 @@ public class MakingHistory extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("750 Coins", ItemID.COINS_995, 750),
+				new ItemReward("Coins", ItemID.COINS_995, 750),
 				new ItemReward("An Enchanted Key", ItemID.ENCHANTED_KEY, 1));
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -930,7 +930,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 	{
 		return Arrays.asList(
 				new ItemReward("55,000 Experience Combat Lamp (Over multiple Skills)", ItemID.ANTIQUE_LAMP, 1), //4447 is placeholder for filter
-				new ItemReward("10,000 Coins", ItemID.COINS_995, 10000),
+				new ItemReward("Coins", ItemID.COINS_995, 10000),
 				new ItemReward("3 Diamonds", ItemID.DIAMOND, 3));
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/murdermystery/MurderMystery.java
+++ b/src/main/java/com/questhelper/helpers/quests/murdermystery/MurderMystery.java
@@ -581,7 +581,7 @@ public class MurderMystery extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("2,000 Coins", ItemID.COINS_995, 2000));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 2000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/olafsquest/OlafsQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/olafsquest/OlafsQuest.java
@@ -308,7 +308,7 @@ public class OlafsQuest extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("4 x Rubies", ItemID.RUBY, 4));
+		return Collections.singletonList(new ItemReward("Rubies", ItemID.RUBY, 4));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/onesmallfavour/OneSmallFavour.java
+++ b/src/main/java/com/questhelper/helpers/quests/onesmallfavour/OneSmallFavour.java
@@ -861,7 +861,7 @@ public class OneSmallFavour extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("2 x 10,000 Experience Lamps (Any skill over level 30)", ItemID.ANTIQUE_LAMP, 2), //4447 is placeholder for filter
+				new ItemReward("10,000 Experience Lamps (Any skill over level 30)", ItemID.ANTIQUE_LAMP, 2), //4447 is placeholder for filter
 				new ItemReward("A Steel Keyring", ItemID.STEEL_KEY_RING, 1));
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/sheepherder/SheepHerder.java
+++ b/src/main/java/com/questhelper/helpers/quests/sheepherder/SheepHerder.java
@@ -256,7 +256,7 @@ public class SheepHerder extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("3,100 Coins", ItemID.COINS_995, 3100));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 3100));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/sheepshearer/SheepShearer.java
+++ b/src/main/java/com/questhelper/helpers/quests/sheepshearer/SheepShearer.java
@@ -167,7 +167,7 @@ public class SheepShearer extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("60 Coins", ItemID.COINS_995, 60));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 60));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
+++ b/src/main/java/com/questhelper/helpers/quests/shieldofarrav/ShieldOfArravBlackArmGang.java
@@ -183,7 +183,7 @@ public class ShieldOfArravBlackArmGang extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("600 Coins", ItemID.COINS_995, 600));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 600));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
+++ b/src/main/java/com/questhelper/helpers/quests/shieldofarrav/ShieldOfArravPhoenixGang.java
@@ -205,7 +205,7 @@ public class ShieldOfArravPhoenixGang extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("600 Coins", ItemID.COINS_995, 600));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 600));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/swansong/SwanSong.java
+++ b/src/main/java/com/questhelper/helpers/quests/swansong/SwanSong.java
@@ -346,7 +346,7 @@ public class SwanSong extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("25,000 Coins", ItemID.COINS_995, 25000));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 25000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
+++ b/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
@@ -555,7 +555,7 @@ public class TheDigSite extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("2 x Gold Bars", ItemID.GOLD_BAR, 2));
+		return Collections.singletonList(new ItemReward("Gold Bars", ItemID.GOLD_BAR, 2));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/thefeud/TheFeud.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefeud/TheFeud.java
@@ -512,7 +512,7 @@ public class TheFeud extends BasicQuestHelper
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("500 Coins", ItemID.COINS_995, 500),
+				new ItemReward("Coins", ItemID.COINS_995, 500),
 				new ItemReward("Oak Blackjack", ItemID.OAK_BLACKJACK, 1),
 				new ItemReward("Desert Disguise", ItemID.DESERT_DISGUISE, 1),
 				new ItemReward("Willow Blackjack", ItemID.WILLOW_BLACKJACK, 1),

--- a/src/main/java/com/questhelper/helpers/quests/watchtower/Watchtower.java
+++ b/src/main/java/com/questhelper/helpers/quests/watchtower/Watchtower.java
@@ -666,7 +666,7 @@ public class Watchtower extends BasicQuestHelper
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("5,000 Coins", ItemID.COINS_995, 5000));
+		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS_995, 5000));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/xmarksthespot/XMarksTheSpot.java
+++ b/src/main/java/com/questhelper/helpers/quests/xmarksthespot/XMarksTheSpot.java
@@ -149,7 +149,7 @@ public class XMarksTheSpot extends BasicQuestHelper
 	{
 		return Arrays.asList(
 			new ItemReward("300 Exp. Lamp (Any Skill)", ItemID.ANTIQUE_LAMP, 1),
-			new ItemReward("200 Coins", ItemID.COINS_995, 200),
+			new ItemReward("Coins", ItemID.COINS_995, 200),
 			new ItemReward("A Beginner Clue Scroll", ItemID.CLUE_SCROLL_BEGINNER, 1));
 	}
 


### PR DESCRIPTION

![image](https://github.com/Zoinkwiz/quest-helper/assets/946270/99710159-2738-4f22-89a2-4050a6cd3546)

The display text of some of the item rewards in the rewards panel would show the quantity of the reward twice (see image above). This PR removes any quantities that were hardcoded in the names of the item rewards and should now correctly display.
