### PR TITLE
Heroes' Quest: Various fixes

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -203,6 +203,7 @@ public class HeroesQuest extends BasicQuestHelper
 	public void setupRequirements()
 	{
 		iceGloves = new ItemRequirement("Ice gloves (obtainable in quest)", ItemID.ICE_GLOVES).isNotConsumed();
+		iceGloves.canBeObtainedDuringQuest();
 		equippedIceGloves = new ItemRequirement("Ice gloves", ItemID.ICE_GLOVES, 1, true).isNotConsumed();
 		fishingRod = new ItemRequirement("Fishing rod", ItemID.FISHING_ROD).isNotConsumed();
 		fishingRod.addAlternates(ItemID.OILY_FISHING_ROD);

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -418,7 +418,7 @@ public class HeroesQuest extends BasicQuestHelper
 		talkToCharlie.addDialogStep("I'm looking for a gherkin...");
 		talkToCharlie.addDialogStep("I want to steal Scarface Pete's candlesticks.");
 		pushWall = new ObjectStep(this, ObjectID.WALL_2629, new WorldPoint(2787, 3190, 0), "Push the wall to enter Pete's garden.");
-		useKeyOnDoor = new ObjectStep(this, ObjectID.DOOR_2622, new WorldPoint(2781, 3197, 0), "Use the misc key on the door to the north west.", miscKey);
+		useKeyOnDoor = new ObjectStep(this, ObjectID.DOOR_2622, new WorldPoint(2781, 3197, 0), "Use the misc key on the door to the north west.", miscKey.highlighted());
 		useKeyOnDoor.addIcon(ItemID.MISCELLANEOUS_KEY);
 		killGrip = new NpcStep(this, NpcID.GRIP, new WorldPoint(2775, 3192, 0), "Wait for your partner to lure Grip into the room next to yours, and kill him with magic/ranged. Afterwards, trade your partner for a candlestick.");
 		getCandlestick = new DetailedQuestStep(this, "Get your candlestick from your partner.");

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -349,7 +349,7 @@ public class HeroesQuest extends BasicQuestHelper
 		talkToGerrant = new NpcStep(this, NpcID.GERRANT_2891, new WorldPoint(3013, 3224, 0), "You need to get an oily rod. Talk to Gerrant in Port Sarim to get some slime.");
 		talkToGerrant.addDialogStep("I want to find out how to catch a lava eel.");
 		talkToGerrant.addTeleport(portSarimTeleport);
-		makeBlamishOil = new DetailedQuestStep(this, "Combine the harralander potion (unf) with the blamish snail slime.", harralanderUnf, blamishSlime);
+		makeBlamishOil = new ItemStep(this, "Combine the harralander potion (unf) with the blamish snail slime.", harralanderUnf.highlighted(), blamishSlime.highlighted());
 		useOilOnRod = new DetailedQuestStep(this, "Use the Blamish oil on your fishing rod.", blamishOil, fishingRod);
 
 		if (client.getRealSkillLevel(Skill.AGILITY) >= 70)

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -421,7 +421,8 @@ public class HeroesQuest extends BasicQuestHelper
 		useKeyOnDoor = new ObjectStep(this, ObjectID.DOOR_2622, new WorldPoint(2781, 3197, 0), "Use the misc key on the door to the north west.", miscKey.highlighted());
 		useKeyOnDoor.addIcon(ItemID.MISCELLANEOUS_KEY);
 		killGrip = new NpcStep(this, NpcID.GRIP, new WorldPoint(2775, 3192, 0), "Wait for your partner to lure Grip into the room next to yours, and kill him with magic/ranged. Afterwards, trade your partner for a candlestick.");
-		getCandlestick = new DetailedQuestStep(this, "Get your candlestick from your partner.");
+		getCandlestick = new ItemStep(this, "Get your candlestick from your partner.", candlestick);
+		getCandlestick.hideRequirements = true;
 		killGrip.addSubSteps(getCandlestick);
 		enterPhoenixBaseAgain = new ObjectStep(this, ObjectID.LADDER_11803, new WorldPoint(3244, 3383, 0), "Bring the candlestick back to Straven.");
 		enterPhoenixBaseAgain.addTeleport(varrockTeleport);

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -412,7 +412,8 @@ public class HeroesQuest extends BasicQuestHelper
 		talkToAlfonse = new NpcStep(this, NpcID.ALFONSE_THE_WAITER, new WorldPoint(2792, 3186, 0), "Talk to Alfonse the Waiter in the restaurant in Brimhaven.", rangedMage);
 		talkToAlfonse.addTeleport(brimhavenTeleport);
 		talkToAlfonse.addDialogStep("Do you sell Gherkins?");
-		getKeyFromPartner = new DetailedQuestStep(this, "You'll need your partner to give you a miscellaneous key.");
+		getKeyFromPartner = new ItemStep(this, "You'll need your partner to give you a miscellaneous key.", miscKey);
+		getKeyFromPartner.hideRequirements = true;
 		talkToCharlie = new NpcStep(this, NpcID.CHARLIE_THE_COOK, new WorldPoint(2790, 3191, 0), "Talk to Charlie the Cook in the back of the restaurant.");
 		talkToCharlie.addDialogStep("I'm looking for a gherkin...");
 		talkToCharlie.addDialogStep("I want to steal Scarface Pete's candlesticks.");

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -350,7 +350,7 @@ public class HeroesQuest extends BasicQuestHelper
 		talkToGerrant.addDialogStep("I want to find out how to catch a lava eel.");
 		talkToGerrant.addTeleport(portSarimTeleport);
 		makeBlamishOil = new ItemStep(this, "Combine the harralander potion (unf) with the blamish snail slime.", harralanderUnf.highlighted(), blamishSlime.highlighted());
-		useOilOnRod = new DetailedQuestStep(this, "Use the Blamish oil on your fishing rod.", blamishOil, fishingRod);
+		useOilOnRod = new ItemStep(this, "Use the Blamish oil on your fishing rod.", blamishOil.highlighted(), fishingRod.highlighted());
 
 		if (client.getRealSkillLevel(Skill.AGILITY) >= 70)
 		{

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -202,9 +202,11 @@ public class HeroesQuest extends BasicQuestHelper
 	@Override
 	public void setupRequirements()
 	{
-		iceGloves = new ItemRequirement("Ice gloves (obtainable in quest)", ItemID.ICE_GLOVES).isNotConsumed();
+		iceGloves = new ItemRequirement("Ice gloves/Smiths gloves (i)", ItemID.ICE_GLOVES).isNotConsumed();
 		iceGloves.canBeObtainedDuringQuest();
-		equippedIceGloves = new ItemRequirement("Ice gloves", ItemID.ICE_GLOVES, 1, true).isNotConsumed();
+		iceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
+		equippedIceGloves = new ItemRequirement("Ice gloves/Smiths gloves (i)", ItemID.ICE_GLOVES, 1, true).isNotConsumed();
+		equippedIceGloves.addAlternates(ItemID.SMITHS_GLOVES_I);
 		fishingRod = new ItemRequirement("Fishing rod", ItemID.FISHING_ROD).isNotConsumed();
 		fishingRod.addAlternates(ItemID.OILY_FISHING_ROD);
 		fishingBait = new ItemRequirement("Fishing bait", ItemID.FISHING_BAIT);

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -409,8 +409,8 @@ public class HeroesQuest extends BasicQuestHelper
 		enterPhoenixBase = new ObjectStep(this, ObjectID.LADDER_11803, new WorldPoint(3244, 3383, 0), "Head into the Phoenix Gang's base in south Varrock.");
 		enterPhoenixBase.addTeleport(varrockTeleport);
 		talkToStraven = new NpcStep(this, NpcID.STRAVEN, new WorldPoint(3247, 9781, 0), "Talk to Straven.");
-		talkToStraven.addTeleport(brimhavenTeleport);
 		talkToAlfonse = new NpcStep(this, NpcID.ALFONSE_THE_WAITER, new WorldPoint(2792, 3186, 0), "Talk to Alfonse the Waiter in the restaurant in Brimhaven.", rangedMage);
+		talkToAlfonse.addTeleport(brimhavenTeleport);
 		talkToAlfonse.addDialogStep("Do you sell Gherkins?");
 		getKeyFromPartner = new DetailedQuestStep(this, "You'll need your partner to give you a miscellaneous key.");
 		talkToCharlie = new NpcStep(this, NpcID.CHARLIE_THE_COOK, new WorldPoint(2790, 3191, 0), "Talk to Charlie the Cook in the back of the restaurant.");


### PR DESCRIPTION
<details>
<summary>Add Smiths gloves (i) as an alternative to Ice gloves (+ use `canBeObtainedDuringQuest()`)</summary>

_In the general quest requirements_
![heroes-quest-smiths-gloves-alternative](https://github.com/Zoinkwiz/quest-helper/assets/962989/f5673459-7133-4f1d-8b88-067d556a7948)

_When prompted to travel to Entrana_
![heroes-quest-smiths-gloves-equipped](https://github.com/Zoinkwiz/quest-helper/assets/962989/f32a8eba-0ab4-427c-af98-77893c37c484)


</details>

<details>
<summary>Highlight relevant items for the "Make an oily rod" step</summary>

![heroes-quest-highlight-oily-rod-combine](https://github.com/Zoinkwiz/quest-helper/assets/962989/da363ed3-d9a1-4815-8cb0-3ce5b112367e)

</details>


<details>
<summary>Highlight the relevant items for the "Use the Blamish oil on your rod" step</summary>

![heroes-quest-oily-rod-combine](https://github.com/Zoinkwiz/quest-helper/assets/962989/f600cea8-3156-440e-abf5-1876f015ce9f)

</details>

<details>
<summary>Highlight the misc key on the ground after your partner dropped it</summary>

![heroes-quest-highlight-misc-key](https://github.com/Zoinkwiz/quest-helper/assets/962989/adc55f62-e327-4b70-8df0-1c02dcb89599)

</details>

<details>
<summary>Highlight the misc key in your inventory when prompted to unlock the door</summary>

![heroes-quest-highlight-misc-key-in-inventory](https://github.com/Zoinkwiz/quest-helper/assets/962989/97a2d37f-87db-4c94-b04b-eee4ded6077c)

</details>

<details>
<summary>Highlight the candlestick on the ground</summary>

![heroes-quest-highlight-candlestick](https://github.com/Zoinkwiz/quest-helper/assets/962989/ccd6ac01-a2c5-4a13-a9bc-f662ddc620ee)

</details>
