### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -333,6 +333,7 @@ ij_properties_spaces_around_key_value_delimiter = false
 
 [{*.yaml,*.yml}]
 indent_size = 2
+indent_style = space
 ij_yaml_align_values_properties = do_not_align
 ij_yaml_autoinsert_sequence_marker = true
 ij_yaml_block_mapping_on_new_line = false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,32 @@
+name: Build with Gradle
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.4 # https://github.com/runelite/plugin-hub/blob/master/package/gradle/wrapper/gradle-wrapper.properties
+
+      - name: Execute Gradle build
+        run: gradle build


### PR DESCRIPTION
This PR adds a simple "gradle build" workflow that will run on commits pushed to the main branch, and to all future PRs

You can see this in action what this looks like on my fork: https://github.com/pajlada/quest-helper/pull/1
the CI job won't automatically run on this PR since the main branch does not have workflow defined, and this PR comes from a fork

If you want to protect your main branch (which would make sure the CI job has to complete before you can merge in PRs), you can:

1. go [here](https://github.com/zoinkwiz/quest-helper/settings/branch_protection_rules/new)
2. set the "Branch name pattern" to `master`
3. enable "Require status checks to pass before merging"
4. type `gradle` in the text box and selecting the job that shows up. if no job has shown up, you might need to have the CI job run in master once first
5. press "Create" at the bottom of the screen

With these settings, you'll always be able to bypass CI if it's ever flaky
