### PR TITLE
Fix missing General's Shadow recommendations

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/thegeneralsshadow/TheGeneralsShadow.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/thegeneralsshadow/TheGeneralsShadow.java
@@ -232,7 +232,8 @@ public class TheGeneralsShadow extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRecommended()
 	{
-		return Arrays.asList(rellekkaTeleport, gnomeTeleport, kharidTeleport, karamjaTeleport, draynorTeleport);
+		return Arrays.asList(rellekkaTeleport, gnomeTeleport, kharidTeleport, karamjaTeleport, draynorTeleport,
+			camelotTeleport, skillsNecklace);
 	}
 
 


### PR DESCRIPTION
When adding in the additional recommended teleport items previously, I forgot to include the Camelot and Skills teleports into the recommended items panel.

Continues from PR #1244 
