### PR TITLE
Land of the Goblins: Various fixes

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -543,7 +543,8 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		((NpcStep) talkToAggie).addTeleport(draynorTeleport.quantity(1).named("Amulet of glory (Draynor Village [3])"));
 		talkToAggie.addDialogSteps("Draynor Village", "Can you make dyes for me please?", "Can you make black or white dye?", "Thanks.");
 		goToHemenster = new ObjectStep(this, ObjectID.GATE_48, new WorldPoint(2642, 3441, 0), "Go to Hemenster to catch a whitefish.", fishingRod, rawSlimyEel);
-		goToHemenster.addDialogStep("I need to catch a Hemenster Whitefish.");
+		((ObjectStep) goToHemenster).addTeleport(combatBracelet.named("Combat bracelet (Ranging Guild [4])"));
+		goToHemenster.addDialogSteps("Ranging Guild", "I need to catch a Hemenster Whitefish.");
 		catchWhitefish = new NpcStep(this, NpcID.FISHING_SPOT_4080, new WorldPoint(2637, 3444, 0), "Catch a Hemenster whitefish.", fishingRod, rawSlimyEel);
 		talkToAggieWithFish = new NpcStep(this, NpcID.AGGIE, new WorldPoint(3086, 3258, 0), "Bring the whitefish and black goblin mail to Aggie.", coins, hemensterWhitefish, blackGoblinMail);
 		((NpcStep) talkToAggieWithFish).addTeleport(draynorTeleport.quantity(1).named("Amulet of glory (Draynor Village [3])"));

--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -446,7 +446,8 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		dramenStaff = new ItemRequirement("Dramen staff", ItemID.DRAMEN_STAFF);
 		dramenStaff.addAlternates(ItemID.LUNAR_STAFF);
 		dramenStaff.setTooltip("For transportation via fairy rings");
-		skillsNecklace = new ItemRequirement("Skills necklace", ItemCollections.SKILLS_NECKLACES);
+		skillsNecklace = new ItemRequirement("Skills necklace", ItemCollections.SKILLS_NECKLACES, 3);
+		skillsNecklace.setChargedItem(true);
 		combatBracelet = new ItemRequirement("Combat bracelet", ItemCollections.COMBAT_BRACELETS);
 		lumbridgeTeleport = new ItemRequirement("Lumbridge teleport", -1, 2);
 		draynorTeleport = new ItemRequirement("Draynor Village teleport", -1, 2);
@@ -478,11 +479,13 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		talkToGuard = new NpcStep(this, NpcID.GOBLIN_GUARD_11314, new WorldPoint(2580, 9852, 0), "Talk to the goblin guard in the northwest of the cave.");
 		talkToMakeoverMage = new NpcStep(this, new int[]{NpcID.MAKEOVER_MAGE, NpcID.MAKEOVER_MAGE_1307}, new WorldPoint(2917, 3322, 0),
 			"Talk to the Makeover Mage southwest of Falador.", toadflaxPotionUnf);
+		((NpcStep) talkToMakeoverMage).addTeleport(skillsNecklace.quantity(1).named("Skills necklace (Crafting Guild [3])"));
 		talkToMakeoverMage.addDialogSteps("Can you turn me into a goblin?", "I need to slip past some goblin guards.", "Can you turn me into a goblin or not?");
 		pickPharmakosBerry = new ObjectStep(this, ObjectID.PHARMAKOS_BUSH, "Pick some Pharmakos berries from the bushes outside.", toadflaxPotionUnf);
 		mixGoblinPotion = new DetailedQuestStep(this, "Use the pharmakos berries on the unfinished toadflax potion.", pharmakosBerryHighlight, toadflaxUnfHighlight);
 		goBackToGoblinCave = new ObjectStep(this, ObjectID.CAVE_ENTRANCE, new WorldPoint(2624, 3393, 0), "Go back to the Goblin Cave outside the Fishing Guild.",
 			goblinPotion, vial, pestleAndMortar, noEquippedItems);
+		((ObjectStep) goBackToGoblinCave).addTeleport(skillsNecklace.quantity(1).named("Skills necklace (Fishing Guild [1])"));
 		pickBlackMushrooms = new ObjectStep(this, ObjectID.BLACK_MUSHROOMS, new WorldPoint(2577, 9845, 0), "Pick some black mushrooms and use it on a vial to make black dye.",
 			goblinPotion, vial, pestleAndMortar, noEquippedItems);
 		makeBlackDye = new DetailedQuestStep(this, "Make black dye by using the blackmushrooms on a vial.", blackMushroom.highlighted(), vial.highlighted(), pestleAndMortar);
@@ -543,6 +546,7 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		talkToAggieWithFish.addDialogSteps("Can you make dyes for me please?", "Could you remove the dye from this goblin mail?");
 		goToTempleWithDyes = new ObjectStep(this, ObjectID.CAVE_ENTRANCE, new WorldPoint(2624, 3393, 0),
 			"", whiteGoblinMail, goblinPotion, huzamogaarbKey, yellowDye, blueDye, orangeDye, purpleDye, noEquippedItems, combatGear);
+		((ObjectStep) goToTempleWithDyes).addTeleport(skillsNecklace.quantity(1).named("Skills necklace (Fishing Guild [1])"));
 
 		enterTempleDoorForThieving = new ObjectStep(this, ObjectID.STAIRS_43261, new WorldPoint(2581, 9853, 0), "Enter the temple.");
 
@@ -728,13 +732,13 @@ public class LandOfTheGoblins extends BasicQuestHelper
 			Arrays.asList(goBackToGoblinCave, goToGuards, pickBlackMushrooms, makeBlackDye, drinkGoblinPotion, talkToGuardAsGoblin, dyeGoblinMail, enterNorthEastRoom, searchCrateForSphere, talkToZanikInCell,
 				leaveNorthEastRoom, talkToPriestInTemple, enterNorthEastRoomForKey, pickpocketPriest),
 			Arrays.asList(noPet, goblinPotion, vial, pestleAndMortar, goblinMail),
-			Arrays.asList(invSpaceToUnequip, dorgeshKaanSphereRec)));
+			Arrays.asList(skillsNecklace.quantity(1), invSpaceToUnequip, dorgeshKaanSphereRec)));
 		panels.add(new PanelDetails("Keys to the Crypt",
 			Arrays.asList(talkToAggie, goToHemenster, catchWhitefish, talkToAggieWithFish, goToTempleWithDyes, pickpocketWhitePriest, dyeGoblinMailYellow,
 				pickpocketYellowPriest, dyeGoblinMailBlue, pickpocketBluePriest, dyeGoblinMailOrange, pickpocketOrangePriest,
 				dyeGoblinMailPurple, pickpocketPurplePriest, unlockCrypt),
 			Arrays.asList(fishingRod, rawSlimyEel, coins, yellowDye, blueDye, orangeDye, purpleDye, blackGoblinMail, goblinPotion, huzamogaarbKey, combatGear),
-			Arrays.asList(draynorTeleport, combatBracelet)));
+			Arrays.asList(draynorTeleport, combatBracelet, skillsNecklace.quantity(1))));
 		panels.add(new PanelDetails("High Priests of Ages Past",
 			Arrays.asList(enterCrypt, sayNameSnothead, defeatSnothead, sayNameSnailfeet, defeatSnailfeet, sayNameMosschin, defeatMosschin, sayNameRedeyes, defeatRedeyes, sayNameStrongbones, defeatStrongbones, learnYubiusk),
 			combatGear));

--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -450,7 +450,8 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		skillsNecklace.setChargedItem(true);
 		combatBracelet = new ItemRequirement("Combat bracelet", ItemCollections.COMBAT_BRACELETS);
 		lumbridgeTeleport = new ItemRequirement("Lumbridge teleport", -1, 2);
-		draynorTeleport = new ItemRequirement("Draynor Village teleport", -1, 2);
+		draynorTeleport = new ItemRequirement("Draynor Village teleport", ItemCollections.AMULET_OF_GLORIES, 2);
+		draynorTeleport.setChargedItem(true);
 		explorersRing = new ItemRequirement("Explorer's ring 3 or 4", Arrays.asList(ItemID.EXPLORERS_RING_3, ItemID.EXPLORERS_RING_4));
 		salveAmulet = new ItemRequirement("Salve amulet or Salve amulet (e)", ItemCollections.SALVE_AMULET);
 	}
@@ -538,12 +539,14 @@ public class LandOfTheGoblins extends BasicQuestHelper
 
 		pickpocketPriest = new NpcStep(this, NpcID.PRIEST_11307, new WorldPoint(3754, 4340, 0), "Pickpocket a key from the priest.");
 		talkToAggie = new NpcStep(this, NpcID.AGGIE, new WorldPoint(3086, 3258, 0), "Talk to Aggie in Draynor Village.");
-		talkToAggie.addDialogSteps("Can you make dyes for me please?", "Can you make black or white dye?", "Thanks.");
+		((NpcStep) talkToAggie).addTeleport(draynorTeleport.quantity(1).named("Amulet of glory (Draynor Village [3])"));
+		talkToAggie.addDialogSteps("Draynor Village", "Can you make dyes for me please?", "Can you make black or white dye?", "Thanks.");
 		goToHemenster = new ObjectStep(this, ObjectID.GATE_48, new WorldPoint(2642, 3441, 0), "Go to Hemenster to catch a whitefish.", fishingRod, rawSlimyEel);
 		goToHemenster.addDialogStep("I need to catch a Hemenster Whitefish.");
 		catchWhitefish = new NpcStep(this, NpcID.FISHING_SPOT_4080, new WorldPoint(2637, 3444, 0), "Catch a Hemenster whitefish.", fishingRod, rawSlimyEel);
 		talkToAggieWithFish = new NpcStep(this, NpcID.AGGIE, new WorldPoint(3086, 3258, 0), "Bring the whitefish and black goblin mail to Aggie.", coins, hemensterWhitefish, blackGoblinMail);
-		talkToAggieWithFish.addDialogSteps("Can you make dyes for me please?", "Could you remove the dye from this goblin mail?");
+		((NpcStep) talkToAggieWithFish).addTeleport(draynorTeleport.quantity(1).named("Amulet of glory (Draynor Village [3])"));
+		talkToAggieWithFish.addDialogSteps("Draynor Village", "Can you make dyes for me please?", "Could you remove the dye from this goblin mail?");
 		goToTempleWithDyes = new ObjectStep(this, ObjectID.CAVE_ENTRANCE, new WorldPoint(2624, 3393, 0),
 			"", whiteGoblinMail, goblinPotion, huzamogaarbKey, yellowDye, blueDye, orangeDye, purpleDye, noEquippedItems, combatGear);
 		((ObjectStep) goToTempleWithDyes).addTeleport(skillsNecklace.quantity(1).named("Skills necklace (Fishing Guild [1])"));

--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -459,6 +459,7 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		goDownIntoBasement = new ObjectStep(this, ObjectID.TRAPDOOR_14880, new WorldPoint(3209, 3216, 0), "Enter the Lumbridge Castle basement.");
 		climbThroughHole = new ObjectStep(this, NullObjectID.NULL_6898, new WorldPoint(3219, 9618, 0), "");
 		talkToKazgar = new NpcStep(this, NpcID.KAZGAR_7301, new WorldPoint(3230, 9610, 0), "Travel with Kazgar to shortcut to Mistag.");
+		talkToKazgar.addDialogStep("Can you show me the way to the mines?");
 
 		talkToGrubfoot = new NpcStep(this, NpcID.GRUBFOOT_11255, new WorldPoint(3318, 9611, 0), "");
 		talkToGrubfoot.addDialogStep("Yes.");

--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -185,6 +185,7 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		returnToTempleWithDyes.addStep(goblinSelectionActive, confirmGoblin);
 		returnToTempleWithDyes.addStep(inFrontOfGuardsWithGoblinPotion, drinkGoblinPotion);
 		returnToTempleWithDyes.addStep(new Conditions(LogicType.NOR, isAGoblin), goToGuards);
+		goToTempleWithDyes.addSubSteps(returnToTempleWithDyes);
 
 		ConditionalStep dyeing = new ConditionalStep(this, goToHemenster);
 		dyeing.addStep(hasAllGoblinKeys, unlockCrypt);
@@ -548,7 +549,7 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		((NpcStep) talkToAggieWithFish).addTeleport(draynorTeleport.quantity(1).named("Amulet of glory (Draynor Village [3])"));
 		talkToAggieWithFish.addDialogSteps("Draynor Village", "Can you make dyes for me please?", "Could you remove the dye from this goblin mail?");
 		goToTempleWithDyes = new ObjectStep(this, ObjectID.CAVE_ENTRANCE, new WorldPoint(2624, 3393, 0),
-			"", whiteGoblinMail, goblinPotion, huzamogaarbKey, yellowDye, blueDye, orangeDye, purpleDye, noEquippedItems, combatGear);
+			"Return to the goblin temple with all the dyes and some combat gear.", whiteGoblinMail, goblinPotion, huzamogaarbKey, yellowDye, blueDye, orangeDye, purpleDye, noEquippedItems, combatGear);
 		((ObjectStep) goToTempleWithDyes).addTeleport(skillsNecklace.quantity(1).named("Skills necklace (Fishing Guild [1])"));
 
 		enterTempleDoorForThieving = new ObjectStep(this, ObjectID.STAIRS_43261, new WorldPoint(2581, 9853, 0), "Enter the temple.");

--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -184,7 +184,8 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		returnToTempleWithDyes.addStep(isAGoblin, enterTempleDoorForThieving);
 		returnToTempleWithDyes.addStep(goblinSelectionActive, confirmGoblin);
 		returnToTempleWithDyes.addStep(inFrontOfGuardsWithGoblinPotion, drinkGoblinPotion);
-		returnToTempleWithDyes.addStep(new Conditions(LogicType.NOR, isAGoblin), goToGuards);
+		returnToTempleWithDyes.addStep(inGoblinCaveWithGoblinPotion, goToGuards);
+		returnToTempleWithDyes.addStep(goblinPotion.alsoCheckBank(questBank), goBackToGoblinCave);
 		goToTempleWithDyes.addSubSteps(returnToTempleWithDyes);
 
 		ConditionalStep dyeing = new ConditionalStep(this, goToHemenster);

--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -643,6 +643,7 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		goTalkToZanik.addStep(inDorgeshKaanWithGrubfoot, talkToZanik);
 		goTalkToZanik.addStep(grubfootFollowing, enterCity);
 
+		// TODO: Add a teleport step to use one of the Dorgesh-Kaan spheres
 		goReturnToDorg = new ConditionalStep(this, enterCity, "Return to Dorgesh-Kaan and speak to Oldak.");
 
 		returnToDorgeshKaanOrFairyRing = new ConditionalStep(this, enterCity, "If you have access to fairy rings, travel to AJQ. Otherwise, return to Dorgesh-Kaan.");


### PR DESCRIPTION
<details>
<summary>Add a travel hint dialog step when speaking to Kazgar</summary>

![001-travel-option-with-kazgar](https://github.com/Zoinkwiz/quest-helper/assets/962989/ebe3004e-c2ba-4087-9d52-6730505562cf)

</details>

<details>
<summary>Add skills necklace teleport options</summary>

![002-teleport-to-makeover-mage](https://github.com/Zoinkwiz/quest-helper/assets/962989/a7c9127f-9165-46ee-b202-5bfdb0674602)

</details>

<details>
<summary>Add Amulet of Glory as the Draynor Village teleport hint</summary>

![005-teleport-back-to-aggie_000](https://github.com/Zoinkwiz/quest-helper/assets/962989/6e094162-9015-485f-979e-8eafe150a9f7)

</details>

<details>
<summary>fix: Keys to the Crypt step now correctly tracks in the side panel</summary>

It used to show up like this:
![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/b415efd8-d18d-4317-b2dc-6a9e1dcb3d84)

Now it shows up like this:
![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/a255b472-09a9-4801-87eb-2536cc6c6f4e)


</details>

<details>
<summary>Add Combat Bracelet (Ranging Guild) tele hint to Hemnester catch step</summary>

![004-teleport-to-hemenster](https://github.com/Zoinkwiz/quest-helper/assets/962989/c6b4b000-bb80-4aab-aa85-95d6056a7721)

</details>

I wanted to add a teleport hint to use the Dorgesh-kaan sphere in the last step, but since it's a conditional step & it uses the same "climb down the basement" part as the first step of the quest does, I didn't feel confident enough messing around in there, so I left a little TODO for the next adventurer checking the quest out.