### PR TITLE
Re-working checkRange to make take into account thieving boost

### DIFF
--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -133,11 +133,15 @@ public class SkillRequirement extends AbstractRequirement
 		{
 			highestBoost = 5;
 		}
-		else if (skill == THIEVING){ //player only has access to Summer sq'irk juice at level 65 thieving which is the default boost value for thieving, currently that's blind to player current skill level
-			if(client.getRealSkillLevel(skill) < 65){
+		else if (skill == THIEVING)
+		{
+			//player only has access to Summer sq'irk juice at level 65 thieving which is the default boost value for thieving, currently that's blind to player current skill level
+			if (client.getRealSkillLevel(skill) < 65)
+			{
 				highestBoost = 2; //autumn sq'irk
 			}
-			else if(client.getRealSkillLevel(skill) < 45){
+			else if (client.getRealSkillLevel(skill) < 45)
+			{
 				highestBoost = 1;  //spring sq'irk
 			}
 		}

--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -133,12 +133,12 @@ public class SkillRequirement extends AbstractRequirement
 		{
 			highestBoost = 5;
 		}
-		else if (skill == THIEVING && client.getRealSkillLevel(skill) < 65){ //player only has access to Summer sq'irk juice at level 65 thieving which is the default boost value for thieving, currently that's blind to player current skill level
-			if(client.getRealSkillLevel(skill) >= 45){
-				highestBoost = 2;
+		else if (skill == THIEVING){ //player only has access to Summer sq'irk juice at level 65 thieving which is the default boost value for thieving, currently that's blind to player current skill level
+			if(client.getRealSkillLevel(skill) < 65){
+				highestBoost = 2; //autumn sq'irk
 			}
-			else{
-				highestBoost = 1;
+			else if(client.getRealSkillLevel(skill) < 45){
+				highestBoost = 1;  //spring sq'irk
 			}
 		}
 

--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -35,6 +35,7 @@ import java.awt.Color;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
+import static net.runelite.api.Skill.THIEVING;
 
 /**
  * Requirement that checks if a player meets a certain skill level.
@@ -131,6 +132,14 @@ public class SkillRequirement extends AbstractRequirement
 		if (config.stewBoosts() && highestBoost < 5)
 		{
 			highestBoost = 5;
+		}
+		else if (skill == THIEVING && client.getRealSkillLevel(skill) < 65){ //player only has access to Summer sq'irk juice at level 65 thieving which is the default boost value for thieving, currently that's blind to player current skill level
+			if(client.getRealSkillLevel(skill) >= 45){
+				highestBoost = 2;
+			}
+			else{
+				highestBoost = 1;
+			}
 		}
 
 		return requiredLevel - highestBoost <= currentSkill;


### PR DESCRIPTION
Fixes #1273:

Thieving currently has a static max boost of "3", reworking checkRange to be more dynamic.