### PR TITLE
The Great Brain Robbery: Some polish

### DIFF
--- a/src/main/java/com/questhelper/ItemWithCharge.java
+++ b/src/main/java/com/questhelper/ItemWithCharge.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 import lombok.Getter;
+import net.runelite.api.ItemID;
 import static net.runelite.api.ItemID.*;
 
 /**
@@ -131,6 +132,7 @@ public enum ItemWithCharge
 	TCRYSTAL5(TELEPORT_CRYSTAL_5, 5),
 
 	// Infinite charges
+	ECTOPHIAL(ItemID.ECTOPHIAL, 10000000),
 	FAIRY_RING_STAFF(ItemCollections.FAIRY_STAFF, 10000000)
 	;
 

--- a/src/main/java/com/questhelper/ItemWithCharge.java
+++ b/src/main/java/com/questhelper/ItemWithCharge.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 import lombok.Getter;
-import net.runelite.api.ItemID;
 import static net.runelite.api.ItemID.*;
 
 /**
@@ -132,7 +131,7 @@ public enum ItemWithCharge
 	TCRYSTAL5(TELEPORT_CRYSTAL_5, 5),
 
 	// Infinite charges
-	ECTOPHIAL(ItemID.ECTOPHIAL, 10000000),
+	TP_ECTOPHIAL(ECTOPHIAL, 10000000),
 	FAIRY_RING_STAFF(ItemCollections.FAIRY_STAFF, 10000000)
 	;
 

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -616,7 +616,9 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Starting off",
 			Arrays.asList(talkToTranquility, pullStatue, enterWater, repairWaterStairs, climbFromWater,
 				climbFromWaterCaveToPeep, peerThroughHole, talkToTranquilityAfterPeeping),
-			plank.quantity(4), nails.quantity(60), hammer, fishbowlHelmet, divingApparatus, noPet));
+			Arrays.asList(plank.quantity(4), nails.quantity(60), hammer, fishbowlHelmet, divingApparatus,
+				holySymbol, // For the next step, saves some time & the inventory slot is not really needed
+				noPet)));
 
 		allSteps.add(new PanelDetails("Protecting the windmill",
 			Arrays.asList(searchBookcase, readBook, returnToTranquility, recitePrayer, talkToTranquilityAfterPrayer),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -366,6 +366,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	{
 		moveToCapt = new ObjectStep(this, ObjectID.GANGPLANK_11209, new WorldPoint(3710, 3496, 0),
 			"Cross the gangplank to Bill Teach's ship.");
+		((ObjectStep) moveToCapt).addTeleport(ectophial);
 		moveToMos = new NpcStep(this, NpcID.BILL_TEACH_4016, new WorldPoint(3714, 3497, 1),
 			"Talk to Bill Teach to travel to Mos Le'Harmless.");
 		talkToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -78,7 +78,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 {
 	// Required
 	ItemRequirement fishbowlHelmet, divingApparatus, woodenCats, oakPlank, saw, plank, fur, hammer, nails,
-		holySymbol, ringOfCharos, catsOrResources, tinderbox;
+		holySymbol, ringOfCharos, catsOrResources, tinderbox, noPet;
 
 	// Recommended
 	ItemRequirement ectophial, edgevilleTeleport, fenkenstrainTeleport, watermelonSeeds, combatGearForSafespotting,
@@ -240,6 +240,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			woodenCats.quantity(10), new ItemRequirements(plank.quantity(10), fur.quantity(10)));
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX).isNotConsumed();
 		tinderbox.addAlternates(ItemID.TINDERBOX_7156);
+		noPet = new ItemRequirement("No pet following you or in your inventory", -1, -1);
 
 		// Item recommended
 		ectophial = new ItemRequirement("Ectophial", ItemID.ECTOPHIAL).isNotConsumed();
@@ -549,7 +550,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return Arrays.asList(fishbowlHelmet, divingApparatus, catsOrResources, plank.quantity(8), hammer,
-			nails.quantity(100), holySymbol, ringOfCharos);
+			nails.quantity(100), holySymbol, ringOfCharos, noPet);
 	}
 
 	@Override
@@ -613,7 +614,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Starting off",
 			Arrays.asList(talkToTranquility, pullStatue, enterWater, repairWaterStairs, climbFromWater,
 				climbFromWaterCaveToPeep, peerThroughHole, talkToTranquilityAfterPeeping),
-			plank.quantity(4), nails.quantity(60), hammer, fishbowlHelmet, divingApparatus));
+			plank.quantity(4), nails.quantity(60), hammer, fishbowlHelmet, divingApparatus, noPet));
 
 		allSteps.add(new PanelDetails("Protecting the windmill",
 			Arrays.asList(searchBookcase, readBook, returnToTranquility, recitePrayer, talkToTranquilityAfterPrayer),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -415,7 +415,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			leaveWaterBack, talkToTranquilityMosAfterPeeping);
 
 		searchBookcase = new ObjectStep(this, ObjectID.BOOKCASE_380, new WorldPoint(3049, 3484, 0),
-			"Search the south west bookcase in the Edgeville Monastery.");
+			"Search the south west bookcase in the Edgeville Monastery.", holySymbol);
 		((ObjectStep) searchBookcase).addTeleport(edgevilleTeleport);
 		readBook = new DetailedQuestStep(this, "Read the prayer book.", prayerBook.highlighted());
 		returnToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -373,6 +373,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			"Talk to Brother Tranquility on Mos Le'Harmless.");
 		talkToTranquility.addDialogSteps("Yes.");
 		talkToTranquility.addSubSteps(moveToCapt);
+		talkToTranquility.addSubSteps(moveToMos);
 
 		talkToTranquilityOnIsland = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3787, 2825,
 			0), "Talk to Brother Tranquility on Harmony.");

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -369,7 +369,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	{
 		moveToCapt = new ObjectStep(this, ObjectID.GANGPLANK_11209, new WorldPoint(3710, 3496, 0),
 			"Cross the gangplank to Bill Teach's ship.");
-		((ObjectStep) moveToCapt).addTeleport(ectophial);
+		((ObjectStep) moveToCapt).addTeleport(ectophial.quantity(1));
 		moveToMos = new NpcStep(this, NpcID.BILL_TEACH_4016, new WorldPoint(3714, 3497, 1),
 			"Talk to Bill Teach to travel to Mos Le'Harmless.");
 		talkToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
@@ -426,7 +426,6 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 
 		// Return to Harmony
 		ObjectStep moveToCapt2 = ((ObjectStep) moveToCapt).copy();
-		moveToCapt2.addTeleport(ectophial.quantity(1));
 		NpcStep moveToMos2 = ((NpcStep) moveToMos).copy();
 		NpcStep speakToTranquilityToTeleportBack = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Speak to Brother Tranquility to transport to Harmony.");

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -130,7 +130,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		goStart.addStep(inHarmony, talkToTranquilityOnIsland);
 		steps.put(0, goStart);
 
-		ConditionalStep goPeep = new ConditionalStep(this, talkToTranquility);
+		ConditionalStep goPeep = new ConditionalStep(this, goStart);
 		goPeep.addStep(inPeepRoom, peerThroughHole);
 		goPeep.addStep(inWaterExit, climbFromWaterCaveToPeep);
 		goPeep.addStep(new Conditions(inWater, repairedStairs), climbFromWater);

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -383,8 +383,8 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		ItemRequirement conditionalNails = nails.quantity(60).hideConditioned(repairedStairs);
 		ItemRequirement conditionalHammer = hammer.hideConditioned(repairedStairs);
 		pullStatue = new ObjectStep(this, NullObjectID.NULL_22355, new WorldPoint(3795, 2844, 0),
-			"Pull the saradomin statue on Harmony, then enter it.\nPlant the watermelon seeds in the patch first if you brought them for the Hard Morytania Diary.", fishbowlHelmet.equipped(),
-			divingApparatus.equipped(), conditionalHammer, conditionalPlanks, conditionalNails);
+			"Pull the saradomin statue on Harmony, then enter it.\nPlant the watermelon seeds in the patch first if you brought them for the Hard Morytania Diary.",
+			fishbowlHelmet.highlighted().equipped(), divingApparatus.highlighted().equipped(), conditionalHammer, conditionalPlanks, conditionalNails);
 		enterWater = new ObjectStep(this, ObjectID.STAIRS_22365, new WorldPoint(3788, 9254, 0),
 			"Enter the water.");
 		repairWaterStairs = new ObjectStep(this, NullObjectID.NULL_22370, new WorldPoint(3829, 9254, 1),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -416,6 +416,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 
 		searchBookcase = new ObjectStep(this, ObjectID.BOOKCASE_380, new WorldPoint(3049, 3484, 0),
 			"Search the south west bookcase in the Edgeville Monastery.", holySymbol);
+		searchBookcase.addDialogStep("Monastery");
 		((ObjectStep) searchBookcase).addTeleport(edgevilleTeleport);
 		readBook = new DetailedQuestStep(this, "Read the prayer book.", prayerBook.highlighted());
 		returnToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -461,7 +461,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			"Go up to the second floor of Fenkenstrain's Castle and talk to Dr. Fenkenstrain.");
 		talkToFenk.addSubSteps(goToF1Fenk, goToF2Fenk);
 		talkToRufus = new NpcStep(this, NpcID.RUFUS_6478, new WorldPoint(3507, 3494, 0),
-			"Talk to Rufus in Canifis' food store.", ringOfCharos.equipped());
+			"Talk to Rufus in Canifis' food store.", ringOfCharos.equipped().highlighted());
 		talkToRufus.addDialogStep("Talk about the meat shipment");
 		makeOrGetWoodenCats = new DetailedQuestStep(this,
 			"Either buy 10 wooden cats from the G.E., or make them on a clockmaker's bench in your POH.",

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -371,7 +371,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			"Talk to Bill Teach to travel to Mos Le'Harmless.");
 		talkToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Talk to Brother Tranquility on Mos Le'Harmless.");
-		talkToTranquility.addDialogSteps("Yes.", "Undead pirates? Let me at 'em!");
+		talkToTranquility.addDialogSteps("Yes.");
 		talkToTranquility.addSubSteps(moveToCapt);
 
 		talkToTranquilityOnIsland = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3787, 2825,

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -197,6 +197,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		goBlowTheDoor.addStep(new Conditions(onBoat, hasFuse), getTinderbox);
 		goBlowTheDoor.addStep(new Conditions(inHarmony, hasFuse), climbShipLadder);
 		goBlowTheDoor.addStep(onBoat, climbDownFromShip);
+		goBlowTheDoor.addStep(inHarmonyBasement, leaveWindmillBasement);
 		goBlowTheDoor.addStep(inHarmony, getFuse);
 		steps.put(80, goBlowTheDoor);
 		steps.put(90, goBlowTheDoor);
@@ -522,7 +523,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		getFuse = new ObjectStep(this, ObjectID.LOCKER_22298, new WorldPoint(3791, 2873, 0),
 			"Search the locker on the ship on the north of Harmony.", fishbowlHelmet.equipped(), divingApparatus.equipped());
 		((ObjectStep) getFuse).addAlternateObjects(ObjectID.LOCKER_22299);
-		getFuse.addSubSteps(goToHarmonyForBrainItems);
+		getFuse.addSubSteps(goToHarmonyForBrainItems, leaveWindmillBasement);
 		climbShipLadder = new ObjectStep(this, ObjectID.LADDER_22274, new WorldPoint(3802, 2873, 0),
 			"Climb the ship's ladder.");
 		getTinderbox = new ItemStep(this, "Take a tinderbox.", tinderbox);

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -32,6 +32,7 @@ import com.questhelper.Zone;
 import com.questhelper.banktab.BankSlotIcons;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
+import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.ZoneRequirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
@@ -41,7 +42,6 @@ import com.questhelper.requirements.item.TeleportItemRequirement;
 import com.questhelper.requirements.player.InInstanceRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
-import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
@@ -60,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.IntUnaryOperator;
-
 import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -92,7 +91,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	Zone harmony, waterEntrance, water, waterExit, peepRoom, fenkF2, fenkF1, harmonyBasement, boat, boatToMos, mos;
 
 	Requirement inHarmony, inWaterEntrance, inWater, inWaterExit, inPeepRoom, inFenkF2, inFenkF1, inHarmonyBasement,
-		onBoat, repairedStairs,	hasReadPrayerBook, talkedToFenk, talkedToRufus, madeCrateWalls, madeCrateBottom,
+		onBoat, repairedStairs, hasReadPrayerBook, talkedToFenk, talkedToRufus, madeCrateWalls, madeCrateBottom,
 		addedCats, addedCatsOrHas10, fenkInCrate, placedKeg, addedFuse, litFuse, churchDoorGone, hasKeg, hasFuse,
 		hasTinderbox, givenClamp, givenStaples, givenBells, givenTongs, hadClamp, hadStaples, hadBells, hadTongs,
 		givenHammer, barrelchestAppeared, inBoatToMos, inMos;
@@ -112,7 +111,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 
 	QuestStep goToHarmonyAfterFenk, goDownToFenk, talkToFenkOnHarmony, leaveWindmillBasement, goToHarmonyForBrainItems,
 		getFuse, climbShipLadder, getTinderbox, getKeg, climbDownFromShip, useKegOnDoor, useFuseOnDoor, lightFuse,
-		killSorebones,  goBackDownToFenk, talkToFenkWithItems, goUpFromFenkAfterItems, talkToTranquilityAfterHelping;
+		killSorebones, goBackDownToFenk, talkToFenkWithItems, goUpFromFenkAfterItems, talkToTranquilityAfterHelping;
 
 	QuestStep enterChurchForFight, confrontMigor, defeatBarrelchest, pickupAnchor, talkToTranquilityToFinish;
 
@@ -336,7 +335,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		placedKeg = new VarbitRequirement(3393, 2, Operation.GREATER_EQUAL);
 		addedFuse = new VarbitRequirement(3393, 3, Operation.GREATER_EQUAL);
 		litFuse = new VarbitRequirement(3393, 4, Operation.GREATER_EQUAL);
-		churchDoorGone  = new VarbitRequirement(3393, 5, Operation.GREATER_EQUAL);
+		churchDoorGone = new VarbitRequirement(3393, 5, Operation.GREATER_EQUAL);
 
 		hasKeg = new Conditions(LogicType.OR, keg, placedKeg);
 		hasFuse = new Conditions(LogicType.OR, fuse, addedFuse);
@@ -477,15 +476,15 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			plank.quantity(4).hideConditioned(madeCrateBottom), nails.quantity(100).hideConditioned(madeCrateBottom),
 			hammer.hideConditioned(madeCrateBottom), woodenCats.quantity(10).hideConditioned(addedCats),
 			cratePart.quantity(6).hideConditioned(madeCrateWalls), wolfWhistle);
-		buildCrate = new ObjectStep(this, NullObjectID.NULL_22489,  new WorldPoint(3550, 3554, 2),
+		buildCrate = new ObjectStep(this, NullObjectID.NULL_22489, new WorldPoint(3550, 3554, 2),
 			"Return to Dr. Fenkenstrain and build the crate next to him.", ringOfCharos.equipped(), plank.quantity(4), nails.quantity(100),
 			hammer, woodenCats.quantity(10), cratePart.quantity(6), wolfWhistle);
 		buildCrate.addSubSteps(goToF1FenkForCrate, goToF2FenkForCrate);
 
-		addBottomToCrate = new ObjectStep(this, NullObjectID.NULL_22489,  new WorldPoint(3550, 3554, 2),
+		addBottomToCrate = new ObjectStep(this, NullObjectID.NULL_22489, new WorldPoint(3550, 3554, 2),
 			"Add a bottom to the crate.", plank.quantity(4), nails.quantity(100), hammer);
 
-		fillCrate = new ObjectStep(this, NullObjectID.NULL_22489,  new WorldPoint(3550, 3554, 2),
+		fillCrate = new ObjectStep(this, NullObjectID.NULL_22489, new WorldPoint(3550, 3554, 2),
 			"Fill the crate next to Fenkenstrain with wooden cats.", woodenCats.quantity(10).highlighted());
 		fillCrate.addIcon(ItemID.WOODEN_CAT);
 
@@ -495,7 +494,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			"Return to Dr. Fenkenstrain and place the shipping order on the crate.", shippingOrder);
 		goF2WithOrder = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(3548, 3554, 1),
 			"Return to Dr. Fenkenstrain and place the shipping order on the crate.", shippingOrder);
-		putOrderOnCrate = new ObjectStep(this, NullObjectID.NULL_22489,  new WorldPoint(3550, 3554, 2),
+		putOrderOnCrate = new ObjectStep(this, NullObjectID.NULL_22489, new WorldPoint(3550, 3554, 2),
 			"Return to Dr. Fenkenstrain and place the shipping order on the crate..", shippingOrder.highlighted());
 		putOrderOnCrate.addIcon(ItemID.SHIPPING_ORDER);
 		putOrderOnCrate.addSubSteps(goF1WithOrder, goF2WithOrder);
@@ -623,18 +622,18 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 	public List<ExperienceReward> getExperienceRewards()
 	{
 		return Arrays.asList(
-				new ExperienceReward(Skill.PRAYER, 6000),
-				new ExperienceReward(Skill.CRAFTING, 2000),
-				new ExperienceReward(Skill.CONSTRUCTION, 2000));
+			new ExperienceReward(Skill.PRAYER, 6000),
+			new ExperienceReward(Skill.CRAFTING, 2000),
+			new ExperienceReward(Skill.CONSTRUCTION, 2000));
 	}
 
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
 		return Arrays.asList(
-				new ItemReward("Barrelchest Anchor", ItemID.BARRELCHEST_ANCHOR, 1),
-				new ItemReward("5,000 Exp Reward Lamp (Any skill above 30)", ItemID.ANTIQUE_LAMP, 1),
-				new ItemReward("Prayer Book", ItemID.PRAYER_BOOK, 1));
+			new ItemReward("Barrelchest Anchor", ItemID.BARRELCHEST_ANCHOR, 1),
+			new ItemReward("5,000 Exp Reward Lamp (Any skill above 30)", ItemID.ANTIQUE_LAMP, 1),
+			new ItemReward("Prayer Book", ItemID.PRAYER_BOOK, 1));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -383,7 +383,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		ItemRequirement conditionalNails = nails.quantity(60).hideConditioned(repairedStairs);
 		ItemRequirement conditionalHammer = hammer.hideConditioned(repairedStairs);
 		pullStatue = new ObjectStep(this, NullObjectID.NULL_22355, new WorldPoint(3794, 2844, 0),
-			"Pull the saradomin statue on Harmony, then enter it.", fishbowlHelmet.equipped(),
+			"Pull the saradomin statue on Harmony, then enter it.\nPlant the watermelon seeds in the patch first if you brought them for the Hard Morytania Diary.", fishbowlHelmet.equipped(),
 			divingApparatus.equipped(), conditionalHammer, conditionalPlanks, conditionalNails);
 		enterWater = new ObjectStep(this, ObjectID.STAIRS_22365, new WorldPoint(3788, 9254, 0),
 			"Enter the water.");

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -372,6 +372,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		talkToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Talk to Brother Tranquility on Mos Le'Harmless.");
 		talkToTranquility.addDialogStep("Undead pirates? Let me at 'em!");
+		talkToTranquility.addSubSteps(moveToCapt);
 
 		talkToTranquilityOnIsland = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3787, 2825,
 			0), "Talk to Brother Tranquility on Harmony.");

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -382,7 +382,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		ItemRequirement conditionalPlanks = plank.quantity(4).hideConditioned(repairedStairs);
 		ItemRequirement conditionalNails = nails.quantity(60).hideConditioned(repairedStairs);
 		ItemRequirement conditionalHammer = hammer.hideConditioned(repairedStairs);
-		pullStatue = new ObjectStep(this, NullObjectID.NULL_22355, new WorldPoint(3794, 2844, 0),
+		pullStatue = new ObjectStep(this, NullObjectID.NULL_22355, new WorldPoint(3795, 2844, 0),
 			"Pull the saradomin statue on Harmony, then enter it.\nPlant the watermelon seeds in the patch first if you brought them for the Hard Morytania Diary.", fishbowlHelmet.equipped(),
 			divingApparatus.equipped(), conditionalHammer, conditionalPlanks, conditionalNails);
 		enterWater = new ObjectStep(this, ObjectID.STAIRS_22365, new WorldPoint(3788, 9254, 0),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -416,6 +416,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 
 		searchBookcase = new ObjectStep(this, ObjectID.BOOKCASE_380, new WorldPoint(3049, 3484, 0),
 			"Search the south west bookcase in the Edgeville Monastery.");
+		((ObjectStep) searchBookcase).addTeleport(edgevilleTeleport);
 		readBook = new DetailedQuestStep(this, "Read the prayer book.", prayerBook.highlighted());
 		returnToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Return to Harmony.", prayerBook, holySymbol.equipped());

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -659,7 +659,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			ringOfCharos, catsOrResources, plank.quantity(4), nails.quantity(100), hammer));
 
 		allSteps.add(new PanelDetails("Saving the Monks",
-			Arrays.asList(talkToFenkOnHarmony, getFuse, climbShipLadder, getTinderbox, climbDownFromShip,
+			Arrays.asList(talkToFenkOnHarmony, getFuse, climbShipLadder, getTinderbox, getKeg, climbDownFromShip,
 				useKegOnDoor, useFuseOnDoor, lightFuse, killSorebones, talkToFenkWithItems, talkToTranquilityAfterHelping),
 			hammer, fishbowlHelmet, divingApparatus, combatGearForSafespotting));
 

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -372,7 +372,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			"Talk to Bill Teach to travel to Mos Le'Harmless.");
 		talkToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Talk to Brother Tranquility on Mos Le'Harmless.");
-		talkToTranquility.addDialogSteps("Yes.");
+		talkToTranquility.addDialogSteps("Yes.", "Yes, please.");
 		talkToTranquility.addSubSteps(moveToCapt);
 		talkToTranquility.addSubSteps(moveToMos);
 

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -450,8 +450,10 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			0), "Talk to Brother Tranquility again.");
 		talkToTranquilityAfterPrayer.addSubSteps(returnToHarmonyAfterPrayer);
 
+		/// Finding a Doctor
 		goToF1Fenk = new ObjectStep(this, ObjectID.STAIRCASE_5206, new WorldPoint(3538, 3552, 0),
 			"Go up to the second floor of Fenkenstrain's Castle and talk to Dr. Fenkenstrain.");
+		((ObjectStep) goToF1Fenk).addTeleport(fenkenstrainTeleport);
 		goToF1Fenk.addDialogStep("Yes, please.");
 		goToF2Fenk = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(3548, 3554, 1),
 			"Go up to the second floor of Fenkenstrain's Castle and talk to Dr. Fenkenstrain.");

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -420,7 +420,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		((ObjectStep) searchBookcase).addTeleport(edgevilleTeleport);
 		readBook = new DetailedQuestStep(this, "Read the prayer book.", prayerBook.highlighted());
 		returnToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
-			"Return to Harmony.", prayerBook, holySymbol.equipped());
+			"Return to Harmony.", prayerBook, holySymbol.equipped().highlighted());
 		recitePrayer = new DetailedQuestStep(this, new WorldPoint(3787, 2825,
 			0), "Right-click recite the prayer book on Harmony.", prayerBook.highlighted(), holySymbol.equipped());
 

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -371,7 +371,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 			"Talk to Bill Teach to travel to Mos Le'Harmless.");
 		talkToTranquility = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Talk to Brother Tranquility on Mos Le'Harmless.");
-		talkToTranquility.addDialogStep("Undead pirates? Let me at 'em!");
+		talkToTranquility.addDialogSteps("Yes.", "Undead pirates? Let me at 'em!");
 		talkToTranquility.addSubSteps(moveToCapt);
 
 		talkToTranquilityOnIsland = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3787, 2825,

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -245,7 +245,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		noPet = new ItemRequirement("No pet following you or in your inventory", -1, -1);
 
 		// Item recommended
-		ectophial = new TeleportItemRequirement("Ectophial or Mos le'harmless teleport", ItemID.ECTOPHIAL, 2);
+		ectophial = new TeleportItemRequirement("Ectophial or Mos le'harmless teleport", ItemID.ECTOPHIAL, 3);
 		edgevilleTeleport = new ItemRequirement("Monastery teleport", ItemCollections.COMBAT_BRACELETS);
 		edgevilleTeleport.addAlternates(ItemCollections.AMULET_OF_GLORIES);
 
@@ -500,8 +500,16 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		putOrderOnCrate.addIcon(ItemID.SHIPPING_ORDER);
 		putOrderOnCrate.addSubSteps(goF1WithOrder, goF2WithOrder);
 
-		goToHarmonyAfterFenk = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
-			"Return to Harmony and talk to Fenkenstrain in the windmill's basement.");
+		/// Saving the Monks
+		ObjectStep moveToCapt3 = moveToCapt2.copy();
+		NpcStep moveToMos3 = moveToMos2.copy();
+		NpcStep tranqTpToHarmony3 = speakToTranquilityToTeleportBack.copy();
+		NpcStep savingTheMonksTalkToFenk = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
+			"Talk to Fenkenstrain in the windmill's basement.");
+		goToHarmonyAfterFenk = new ConditionalStep(this, moveToCapt3, "Talk to Dr. Fenkenstrain in the Harmony Windmill basement.");
+		((ConditionalStep) goToHarmonyAfterFenk).addStep(inMos, tranqTpToHarmony3);
+		((ConditionalStep) goToHarmonyAfterFenk).addStep(inBoatToMos, moveToMos3);
+		((ConditionalStep) goToHarmonyAfterFenk).addStep(inHarmony, savingTheMonksTalkToFenk);
 		goDownToFenk = new ObjectStep(this, ObjectID.LADDER_22173, new WorldPoint(3789, 2826, 0),
 			"Talk to Dr. Fenkenstrain in the Harmony Windmill basement.");
 		talkToFenkOnHarmony = new NpcStep(this, NpcID.DR_FENKENSTRAIN, new WorldPoint(3785, 9225, 0),

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -521,7 +521,8 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		goToHarmonyForBrainItems = new NpcStep(this, NpcID.BROTHER_TRANQUILITY, new WorldPoint(3681, 2963, 0),
 			"Return to Harmony.");
 		getFuse = new ObjectStep(this, ObjectID.LOCKER_22298, new WorldPoint(3791, 2873, 0),
-			"Search the locker on the ship on the north of Harmony.", fishbowlHelmet.equipped(), divingApparatus.equipped());
+			"Search the locker on the ship on the north of Harmony.",
+			fishbowlHelmet.highlighted().equipped(), divingApparatus.highlighted().equipped());
 		((ObjectStep) getFuse).addAlternateObjects(ObjectID.LOCKER_22299);
 		getFuse.addSubSteps(goToHarmonyForBrainItems, leaveWindmillBasement);
 		climbShipLadder = new ObjectStep(this, ObjectID.LADDER_22274, new WorldPoint(3802, 2873, 0),

--- a/src/main/java/com/questhelper/steps/NpcStep.java
+++ b/src/main/java/com/questhelper/steps/NpcStep.java
@@ -148,6 +148,23 @@ public class NpcStep extends DetailedQuestStep
 		this(questHelper, npcID, null, text, allowMultipleHighlights, requirements);
 	}
 
+	public NpcStep copy()
+	{
+		NpcStep newStep = new NpcStep(getQuestHelper(), npcID, worldPoint, null, requirements, recommended);
+		if (text != null)
+		{
+			newStep.setText(text);
+		}
+		newStep.allowMultipleHighlights = allowMultipleHighlights;
+		newStep.addAlternateNpcs(alternateNpcIDs);
+		if (mustBeFocused) {
+			newStep.setMustBeFocused(true);
+		}
+		newStep.setMaxRoamRange(maxRoamRange);
+
+		return newStep;
+	}
+
 	private boolean npcPassesChecks(NPC npc)
 	{
 		if (npcName != null && (npc.getName() == null || !npc.getName().equals(npcName))) return false;

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -121,6 +121,9 @@ public class ObjectStep extends DetailedQuestStep
 		newStep.addAlternateObjects(alternateObjectIDs);
 		newStep.setMaxObjectDistance(maxObjectDistance);
 		newStep.setMaxRenderDistance(maxRenderDistance);
+		for (Requirement tp : teleport) {
+			newStep.addTeleport(tp);
+		}
 
 		return newStep;
 	}


### PR DESCRIPTION
PR diff without the last commit's reformatting: https://github.com/Zoinkwiz/quest-helper/pull/1287/files/76e62ea3c1b2c94ea6c982e88a85711aaa2a10de

Most notably, this fixes ObjectStep's copy function - it didn't copy teleports before.

NpcStep now also has a copy function

The rest of the quest steps were mostly small teleport additions, recovery fixes (e.g. if you teleport away, it will now guide you back easier),

I also made the ectophial tp recommendation also suggest a Mos le'harmless teleport scroll

You're not allowed to bring a pet under water, so I added a hint in the requirements that you shouldn't bring a pet.
I would use the "no follower" thing but you also can't have a pet in your inventory, so I didn't want to give a false sense of "I'm ok" if you just have a pet in your inventory.
