### PR TITLE
Bump minimum Java version from 8 to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,9 @@ dependencies {
 
 group = 'com.questhelper'
 version = '4.1.2'
-sourceCompatibility = '1.8'
+sourceCompatibility = "11"
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
+targetCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Since RuneLite & plugin hub plugins are now built with Java 11, we can get some niceties by upgrading our source & target compatability.
This gives us access to some nice `.of` functions, and the use of `var` to avoid repeating the type of local variables.
