### PR TITLE
Getting Ahead: Fix missing sidebar entry

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/gettingahead/GettingAhead.java
+++ b/src/main/java/com/questhelper/helpers/quests/gettingahead/GettingAhead.java
@@ -361,7 +361,7 @@ public class GettingAhead extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Killing the Beast", Arrays.asList(goUseFlourOnGate, goToMine, returnToGordon),
 			potOfFlour));
 		allSteps.add(new PanelDetails("Making the fake head", Arrays.asList(talkToMary2, makeClayHead, addFurToHead,
-			useDyeOnHead, putUpHead, talkToGordonFinal), bearFur, softClay, hammer, saw, planks, nails, knife, redDye, needle, thread));
+			dyeHead, putUpHead, talkToGordonFinal), bearFur, softClay, hammer, saw, planks, nails, knife, redDye, needle, thread));
 		return allSteps;
 	}
 	


### PR DESCRIPTION
Fixes https://discord.com/channels/772056816242130964/1158253185664811038

<details>
<summary>Before image</summary>

![before](https://github.com/Zoinkwiz/quest-helper/assets/962989/e8d5522a-7100-4a0f-bfd3-493cc8d8b8bd)


</details>

<details>
<summary>After image</summary>

![after](https://github.com/Zoinkwiz/quest-helper/assets/962989/f33a5ab6-883c-42a8-9949-728e07159fb8)


</details>


I have not tested step-tracking, but this should be good