### PR TITLE
changed Treznor NPC ID to reflect recent update 

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/fairytalei/FairytaleI.java
+++ b/src/main/java/com/questhelper/helpers/quests/fairytalei/FairytaleI.java
@@ -228,7 +228,7 @@ public class FairytaleI extends BasicQuestHelper
 		talkToFarmers.addText("Dreven south of Varrock, next to the Champions' Guild.");
 		talkToFarmers.addDialogStep("Are you a member of the Group of Advanced Gardeners?");
 		((NpcStep) (talkToFarmers)).addAlternateNpcs(NpcID.FRIZZY_SKERNIP, NpcID.HESKEL, NpcID.DREVEN, NpcID.FAYETH,
-			NpcID.TREZNOR);
+			NpcID.TREZNOR_11957);
 
 		talkToMartinAgain = new NpcStep(this, NpcID.MARTIN_THE_MASTER_GARDENER, new WorldPoint(3078, 3256, 0),
 			"Return to Martin in the Draynor Market.");


### PR DESCRIPTION
fixes #1303 

Treznor's npc id was [apparently updated ](https://oldschool.runescape.wiki/w/Treznor#Changes) in late 2022, and I confirmed the new id 11957 to be accurate on my character (who did already have the quest done, but I don't think it would change). 