### PR TITLE
X Marks the Spot: Add alternate Npc ID for Veos from speedrunning worlds

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/xmarksthespot/XMarksTheSpot.java
+++ b/src/main/java/com/questhelper/helpers/quests/xmarksthespot/XMarksTheSpot.java
@@ -115,9 +115,11 @@ public class XMarksTheSpot extends BasicQuestHelper
 		speakVeosSarim = new NpcStep(this, NpcID.VEOS_8484, new WorldPoint(3054, 3245, 0),
 			"Talk to Veos directly south of the Rusty Anchor Inn in Port Sarim to finish the quest.",
 			ancientCasket);
+		((NpcStep) speakVeosSarim).addAlternateNpcs(NpcID.VEOS_8630);
 
 		speakVeosSarimWithoutCasket = new NpcStep(this, NpcID.VEOS_8484, new WorldPoint(3054, 3245, 0),
 			"Talk to Veos directly south of the Rusty Anchor Inn in Port Sarim to finish the quest.");
+		((NpcStep) speakVeosSarimWithoutCasket).addAlternateNpcs(NpcID.VEOS_8630);
 
 		speakVeosSarim.addSubSteps(speakVeosSarimWithoutCasket);
 	}


### PR DESCRIPTION
Only the turn-in npc has its ID changed, so I only added the alternate NPC ID there
