### PR TITLE
fix: Removed deprecated AccountType/getAccountType usages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.4'
 	annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
+	// 23.0.0 is verified by RuneLite
+	compileOnly 'org.jetbrains:annotations:23.0.0'
+
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
     testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 

--- a/src/main/java/com/questhelper/domain/AccountType.java
+++ b/src/main/java/com/questhelper/domain/AccountType.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2022, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2023, pajlada <https://github.com/pajlada>
+ * Copyright (c) 2023, pajlads <https://github.com/pajlads>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -18,42 +19,42 @@
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABI`LITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.questhelper.requirements.player;
+package com.questhelper.domain;
 
-import com.questhelper.requirements.AbstractRequirement;
-import com.questhelper.util.Utils;
-import net.runelite.api.Client;
-
-public class IronmanRequirement extends AbstractRequirement
+public enum AccountType
 {
-	final boolean shouldBeIronman;
+	NORMAL,
+	IRONMAN,
+	ULTIMATE_IRONMAN,
+	HARDCORE_IRONMAN,
+	GROUP_IRONMAN,
+	HARDCORE_GROUP_IRONMAN,
+	UNRANKED_GROUP_IRONMAN;
 
-	public IronmanRequirement(boolean shouldBeIronman)
+	private static final AccountType[] TYPES = values();
+
+	/**
+	 * @param varbitValue the value associated with {@link net.runelite.api.Varbits#ACCOUNT_TYPE}
+	 * @return the equivalent enum value
+	 */
+	public static AccountType get(int varbitValue)
 	{
-		this.shouldBeIronman = shouldBeIronman;
+		if (varbitValue < 0 || varbitValue >= TYPES.length)
+		{
+			return null;
+		}
+		return TYPES[varbitValue];
 	}
 
-	@Override
-	public boolean check(Client client)
+	/**
+	 * Checks whether this account type is any of the ironman types, solo or group.
+	 */
+	public boolean isAnyIronman()
 	{
-		return client.getLocalPlayer() != null &&
-			Utils.getAccountType(client).isAnyIronman() == shouldBeIronman;
-	}
-
-	@Override
-	public String getDisplayText()
-	{
-		if (shouldBeIronman)
-		{
-			return "You need to be an ironman";
-		}
-		else
-		{
-			return "You need to not be an ironman";
-		}
+		return this == IRONMAN || this == ULTIMATE_IRONMAN || this == HARDCORE_IRONMAN || this == GROUP_IRONMAN || this == HARDCORE_GROUP_IRONMAN || this == UNRANKED_GROUP_IRONMAN;
 	}
 }

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
@@ -25,6 +25,7 @@
 package com.questhelper.helpers.achievementdiaries.ardougne;
 
 import com.questhelper.collections.ItemCollections;
+import com.questhelper.domain.AccountType;
 import com.questhelper.questinfo.QuestHelperQuest;
 import com.questhelper.questinfo.QuestVarbits;
 import com.questhelper.requirements.zone.Zone;
@@ -54,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.questhelper.util.Utils;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -65,7 +67,6 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.questinfo.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.steps.QuestStep;
-import net.runelite.api.vars.AccountType;
 import net.runelite.client.game.FishingSpot;
 
 @QuestDescriptor(
@@ -258,7 +259,7 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		grapYan2 = new ObjectStep(this, ObjectID.WALL_17048, new WorldPoint(2556, 3075, 1),
 			"Jump off the opposite side!");
 
-		if (client.getAccountType() == AccountType.ULTIMATE_IRONMAN)// will need testing to confirm this works
+		if (Utils.getAccountType(client) == AccountType.ULTIMATE_IRONMAN)
 		{
 			claimSand = new ObjectStep(this, ObjectID.SANDPIT, new WorldPoint(2543, 3104, 0),
 				"Fill a bucket with sand using Bert's sand pit.", bucket);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.questhelper.util.Utils;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -262,7 +263,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 
 		tpEnakhra = new DetailedQuestStep(this, "Teleport to Enakhra's Temple with the Camulet.", camulet);
 
-		if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
+		if (Utils.getAccountType(client).isAnyIronman())
 		{
 			tpPollnivneach = new DetailedQuestStep(this, "Move your house to Pollnivneach, then enter your house " +
 				"there.", coins.quantity(7500));

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import com.questhelper.util.Utils;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -937,7 +938,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 
 		enterDeathAltarBarrier = new ObjectStep(this, NullObjectID.NULL_9788, new WorldPoint(1865, 4639, 0), "Enter the barrier to the death altar to the west.");
 
-		if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
+		if (Utils.getAccountType(client).isAnyIronman())
 		{
 			if (client.getRealSkillLevel(Skill.SLAYER) > 85)
 			{

--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
@@ -54,6 +54,7 @@ import com.questhelper.steps.QuestStep;
 
 import java.util.*;
 
+import com.questhelper.util.Utils;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -226,7 +227,7 @@ public class RFDPiratePete extends BasicQuestHelper
 
 		generalReqs = new ArrayList<>();
 		generalReqs.add(new SkillRequirement(Skill.COOKING, 31));
-		if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
+		if (Utils.getAccountType(client).isAnyIronman())
 		{
 			generalReqs.add(new ComplexRequirement(LogicType.OR, "42 Crafting or started Rum Deal for a fishbowl",
 				new SkillRequirement(Skill.CRAFTING, 42, true),

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
@@ -56,6 +56,7 @@ import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
+import com.questhelper.util.Utils;
 import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -337,7 +338,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
+			if (Utils.getAccountType(client).isAnyIronman())
 			{
 				splitLogs8.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 				splitLogs4.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
@@ -556,7 +557,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 	public void setupPanels()
 	{
-		if (client.getAccountType().isIronman() || client.getAccountType().isGroupIronman())
+		if (Utils.getAccountType(client).isAnyIronman())
 		{
 			prepareForRepairPanel = new PanelDetails("Helping Mawnis", Arrays.asList(talkToMawnis, talkToMawnisWithLogs, repairBridge1, talkToMawnisAfterRepair), rope8, axe, knife);
 			prepareForCombatPanel = new PanelDetails("Preparing to fight", Arrays.asList(getYakArmour, makeShield), needle, thread, coins15, bronzeNail, hammer, rope);

--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2022, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2023, pajlada <https://github.com/pajlada>
+ * Copyright (c) 2023, pajlads <https://github.com/pajlads>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -18,42 +19,31 @@
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABI`LITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.questhelper.requirements.player;
+package com.questhelper.util;
 
-import com.questhelper.requirements.AbstractRequirement;
-import com.questhelper.util.Utils;
+import com.questhelper.domain.AccountType;
+import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+import org.jetbrains.annotations.NotNull;
 
-public class IronmanRequirement extends AbstractRequirement
+@UtilityClass
+public class Utils
 {
-	final boolean shouldBeIronman;
-
-	public IronmanRequirement(boolean shouldBeIronman)
+	/**
+	 * Transforms the value from {@link Varbits#ACCOUNT_TYPE} to a convenient enum.
+	 *
+	 * @param client {@link Client}
+	 * @return {@link AccountType}
+	 * @apiNote This function should only be called from the client thread.
+	 */
+	public AccountType getAccountType(@NotNull Client client)
 	{
-		this.shouldBeIronman = shouldBeIronman;
+		return AccountType.get(client.getVarbitValue(Varbits.ACCOUNT_TYPE));
 	}
 
-	@Override
-	public boolean check(Client client)
-	{
-		return client.getLocalPlayer() != null &&
-			Utils.getAccountType(client).isAnyIronman() == shouldBeIronman;
-	}
-
-	@Override
-	public String getDisplayText()
-	{
-		if (shouldBeIronman)
-		{
-			return "You need to be an ironman";
-		}
-		else
-		{
-			return "You need to not be an ironman";
-		}
-	}
 }


### PR DESCRIPTION
Adds a `Utils` UtilityClass, with the `getAccountType` function that takes a RuneLite `Client` & returns the `AccountType`.

I implemented the helper function `isAnyIronman` on the `AccountType` since that's how it was mostly used.