### PR TITLE
fix: bts grand tree only requires 3 logs

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/GrandTreeBalloonFlight.java
+++ b/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/GrandTreeBalloonFlight.java
@@ -73,7 +73,7 @@ public class GrandTreeBalloonFlight extends ComplexStateQuestHelper
 	@Override
 	public void setupRequirements()
 	{
-		magicLogs = new ItemRequirement("Magic logs", ItemID.MAGIC_LOGS, 10);
+		magicLogs = new ItemRequirement("Magic logs", ItemID.MAGIC_LOGS, 3);
 	}
 
 	@Override


### PR DESCRIPTION
This path is unlike the others and only costs 3 magic logs instead of 10.