### PR TITLE
fix: Remove deprecated widget API usages

### DIFF
--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -57,10 +57,10 @@ import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetType;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
@@ -189,7 +189,7 @@ public class QuestBankTab
 			// own title.
 			if (questBankTabInterface.isQuestTabActive())
 			{
-				Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
+				Widget bankTitle = client.getWidget(ComponentID.BANK_TITLE_BAR);
 				if (bankTitle != null)
 				{
 					if (questHelper.getSelectedQuest() != null)
@@ -305,7 +305,7 @@ public class QuestBankTab
 			return;
 		}
 
-		Widget itemContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		Widget itemContainer = client.getWidget(ComponentID.BANK_ITEM_CONTAINER);
 		if (itemContainer == null)
 		{
 			return;
@@ -395,7 +395,7 @@ public class QuestBankTab
 
 		totalSectionsHeight = addGeneralSection(itemContainer, itemList, totalSectionsHeight);
 
-		final Widget bankItemContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		final Widget bankItemContainer = client.getWidget(ComponentID.BANK_ITEM_CONTAINER);
 		if (bankItemContainer == null) return;
 		int itemContainerHeight = bankItemContainer.getHeight();
 
@@ -404,8 +404,8 @@ public class QuestBankTab
 		final int itemContainerScroll = bankItemContainer.getScrollY();
 		clientThread.invokeLater(() ->
 			client.runScript(ScriptID.UPDATE_SCROLLBAR,
-				WidgetInfo.BANK_SCROLLBAR.getId(),
-				WidgetInfo.BANK_ITEM_CONTAINER.getId(),
+				ComponentID.BANK_SCROLLBAR,
+				ComponentID.BANK_ITEM_CONTAINER,
 				itemContainerScroll));
 	}
 

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -58,9 +58,9 @@ import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetType;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
@@ -232,7 +232,7 @@ public class QuestBankTab
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
-		if (event.getGroupId() == WidgetID.BANK_GROUP_ID && questHelper.getSelectedQuest() != null)
+		if (event.getGroupId() == InterfaceID.BANK && questHelper.getSelectedQuest() != null)
 		{
 			questBankTabInterface.init();
 		}

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTabInterface.java
@@ -38,9 +38,9 @@ import net.runelite.api.VarClientInt;
 import net.runelite.api.VarClientStr;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetType;
 import net.runelite.client.plugins.bank.BankSearch;
 
@@ -78,7 +78,7 @@ public class QuestBankTabInterface
 			return;
 		}
 
-		parent = client.getWidget(WidgetInfo.BANK_CONTAINER);
+		parent = client.getWidget(ComponentID.BANK_CONTAINER);
 
 		int QUEST_BUTTON_SIZE = 25;
 		int QUEST_BUTTON_X = 408;
@@ -153,7 +153,7 @@ public class QuestBankTabInterface
 
 	public boolean isHidden()
 	{
-		Widget widget = client.getWidget(WidgetInfo.BANK_CONTAINER);
+		Widget widget = client.getWidget(ComponentID.BANK_CONTAINER);
 		return widget == null || widget.isHidden();
 	}
 
@@ -203,7 +203,7 @@ public class QuestBankTabInterface
 		// and remove the timer. However since we are going from a bank search to our fake search this will not remove
 		// the timer but instead re-add it and reset the background. So remove the timer and the background. This is the
 		// same as bankmain_search_setbutton.
-		Widget searchButtonBackground = client.getWidget(WidgetInfo.BANK_SEARCH_BUTTON_BACKGROUND);
+		Widget searchButtonBackground = client.getWidget(ComponentID.BANK_SEARCH_BUTTON_BACKGROUND);
 		if (searchButtonBackground != null)
 		{
 			searchButtonBackground.setOnTimerListener((Object[]) null);
@@ -228,7 +228,7 @@ public class QuestBankTabInterface
 		// and remove the timer. However since we are going from a bank search to our fake search this will not remove
 		// the timer but instead re-add it and reset the background. So remove the timer and the background. This is the
 		// same as bankmain_search_setbutton.
-		Widget searchButtonBackground = client.getWidget(WidgetInfo.BANK_SEARCH_BUTTON_BACKGROUND);
+		Widget searchButtonBackground = client.getWidget(ComponentID.BANK_SEARCH_BUTTON_BACKGROUND);
 		if (searchButtonBackground != null)
 		{
 			searchButtonBackground.setOnTimerListener((Object[]) null);

--- a/src/main/java/com/questhelper/bank/banktab/QuestGrandExchangeInterface.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestGrandExchangeInterface.java
@@ -38,9 +38,9 @@ import net.runelite.api.SoundEffectID;
 import net.runelite.api.SpriteID;
 import net.runelite.api.VarClientInt;
 import net.runelite.api.VarClientStr;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetType;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.ui.JagexColors;
@@ -84,7 +84,7 @@ public class QuestGrandExchangeInterface
 			return;
 		}
 
-		parent = client.getWidget(WidgetInfo.CHATBOX_CONTAINER);
+		parent = client.getWidget(ComponentID.CHATBOX_CONTAINER);
 
 		int QUEST_BUTTON_SIZE = 20;
 		int QUEST_BUTTON_X = 480;
@@ -137,7 +137,7 @@ public class QuestGrandExchangeInterface
 
 	public boolean isHidden()
 	{
-		Widget widget = client.getWidget(WidgetInfo.CHATBOX_CONTAINER);
+		Widget widget = client.getWidget(ComponentID.CHATBOX_CONTAINER);
 		return widget == null || widget.isHidden();
 	}
 
@@ -191,7 +191,7 @@ public class QuestGrandExchangeInterface
 
 	private void updateSearchInterface(boolean hideSearchBox)
 	{
-		Widget geSearchBox = client.getWidget(WidgetInfo.CHATBOX_FULL_INPUT);
+		Widget geSearchBox = client.getWidget(ComponentID.CHATBOX_FULL_INPUT);
 		if (geSearchBox == null)
 		{
 			return;
@@ -231,7 +231,7 @@ public class QuestGrandExchangeInterface
 
 	private Widget createTitle(Widget container)
 	{
-		Widget chatbox = client.getWidget(WidgetInfo.CHATBOX_FULL_INPUT);
+		Widget chatbox = client.getWidget(ComponentID.CHATBOX_FULL_INPUT);
 
 		Widget widget = container.createChild(-1, WidgetType.TEXT);
 		if (chatbox == null)

--- a/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/BarrowsHelper.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/BarrowsHelper.java
@@ -53,12 +53,12 @@ import java.util.Collections;
 import java.util.List;
 
 import net.runelite.api.*;
+import net.runelite.api.annotations.Interface;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 
 @QuestDescriptor(
@@ -66,6 +66,11 @@ import net.runelite.client.eventbus.Subscribe;
 )
 public class BarrowsHelper extends ComplexStateQuestHelper
 {
+	/**
+	 * The interface that contains a list of messages in a dialog
+	 */
+	static final @Interface int CHATBOX_MESSAGES_MESSAGE_LIST = 229;
+
 	// Required
 	ItemRequirement combatGear, spade;
 
@@ -288,14 +293,12 @@ public class BarrowsHelper extends ComplexStateQuestHelper
 			}
 		}
 
-		Widget textBox = client.getWidget(WidgetInfo.DIALOG_OPTION_OPTIONS);
-		if (textBox == null)
+		Widget textOption = client.getWidget(CHATBOX_MESSAGES_MESSAGE_LIST, 1);
+		if (textOption == null)
 		{
 			return;
 		}
-		Widget text = textBox.getChild(0);
-		if (text == null) return;
-		if (text.getText().equals("You've found a hidden tunnel, do you want to enter?"))
+		if (textOption.getText().equals("You've found a hidden tunnel, do you want to enter?"))
 		{
 			updateTunnel();
 		}

--- a/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/HisFaithfulServants.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/HisFaithfulServants.java
@@ -55,12 +55,12 @@ import java.util.List;
 import java.util.Map;
 
 import net.runelite.api.*;
+import net.runelite.api.annotations.Interface;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 
 @QuestDescriptor(
@@ -68,6 +68,11 @@ import net.runelite.client.eventbus.Subscribe;
 )
 public class HisFaithfulServants extends BasicQuestHelper
 {
+	/**
+	 * The interface that contains a list of messages in a dialog
+	 */
+	static final @Interface int CHATBOX_MESSAGES_MESSAGE_LIST = 229;
+
 	// Required
 	ItemRequirement combatGear, spade;
 
@@ -283,14 +288,12 @@ public class HisFaithfulServants extends BasicQuestHelper
 			}
 		}
 
-		Widget textBox = client.getWidget(WidgetInfo.DIALOG_OPTION_OPTIONS);
-		if (textBox == null)
+		Widget textOption = client.getWidget(CHATBOX_MESSAGES_MESSAGE_LIST, 1);
+		if (textOption == null)
 		{
 			return;
 		}
-		Widget text = textBox.getChild(0);
-		if (text == null) return;
-		if (text.getText().equals("You've found a hidden tunnel, do you want to enter?"))
+		if (textOption.getText().equals("You've found a hidden tunnel, do you want to enter?"))
 		{
 			updateTunnel();
 		}

--- a/src/main/java/com/questhelper/helpers/quests/demonslayer/IncantationStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/demonslayer/IncantationStep.java
@@ -29,8 +29,8 @@ import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.QuestStep;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 
 import java.util.HashMap;
 import net.runelite.client.eventbus.Subscribe;
@@ -65,11 +65,11 @@ public class IncantationStep extends ConditionalStep
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
 		int groupId = event.getGroupId();
-		if (groupId == WidgetID.DIALOG_PLAYER_GROUP_ID)
+		if (groupId == InterfaceID.DIALOG_PLAYER)
 		{
 			clientThread.invokeLater(this::resetIncarnationIfRequired);
 		}
-		else if (groupId == WidgetID.DIALOG_OPTION_GROUP_ID)
+		else if (groupId == InterfaceID.DIALOG_OPTION)
 		{
 			clientThread.invokeLater(this::updateChoiceIfRequired);
 		}
@@ -83,7 +83,7 @@ public class IncantationStep extends ConditionalStep
 	 */
 	private void resetIncarnationIfRequired()
 	{
-		Widget widget = client.getWidget(WidgetID.DIALOG_PLAYER_GROUP_ID, 4);
+		Widget widget = client.getWidget(InterfaceID.DIALOG_PLAYER, 4);
 		if (widget == null)
 		{
 			return;
@@ -114,7 +114,7 @@ public class IncantationStep extends ConditionalStep
 
 	private boolean shouldUpdateChoice()
 	{
-		Widget widget = client.getWidget(WidgetID.DIALOG_OPTION_GROUP_ID, 1);
+		Widget widget = client.getWidget(InterfaceID.DIALOG_OPTION, 1);
 		if (widget == null)
 		{
 			return false;

--- a/src/main/java/com/questhelper/helpers/quests/fishingcontest/FishingContest.java
+++ b/src/main/java/com/questhelper/helpers/quests/fishingcontest/FishingContest.java
@@ -63,7 +63,7 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.FISHING_CONTEST
@@ -221,7 +221,7 @@ public class FishingContest extends BasicQuestHelper
 
 		garlicInPipeVarbit = new VarbitRequirement(2054, 1);
 		enteredContest = new Conditions(true, LogicType.AND, hasEverything, onContestGrounds);
-		garlicInPipeScreen = new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You stash the garlic in the pipe.");
+		garlicInPipeScreen = new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You stash the garlic in the pipe.");
 		confirmGarlicInPipe = new DialogRequirement(client.getLocalPlayer().getName(), "I shoved some garlic up here.");
 		hasPutGarlicInPipe = new Conditions(true, LogicType.OR, garlicInPipeVarbit, garlicInPipeScreen, confirmGarlicInPipe);
 	}

--- a/src/main/java/com/questhelper/helpers/quests/ghostsahoy/DyeShipSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/ghostsahoy/DyeShipSteps.java
@@ -43,8 +43,8 @@ import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 
 public class DyeShipSteps extends DetailedOwnerStep
@@ -88,7 +88,7 @@ public class DyeShipSteps extends DetailedOwnerStep
 
 	private void updateCurrentColours()
 	{
-		Widget dyed = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+		Widget dyed = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
 		if (dyed == null)
 		{
 			return;

--- a/src/main/java/com/questhelper/helpers/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/legendsquest/LegendsQuest.java
@@ -74,7 +74,7 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.LEGENDS_QUEST
@@ -675,7 +675,7 @@ public class LegendsQuest extends BasicQuestHelper
 		inFire = new ZoneRequirement(fire1, fire2, fire3);
 		inChallengeCave = new ZoneRequirement(challengeCave);
 
-		completeTextAppeared = new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT,
+		completeTextAppeared = new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT,
 			"You have already completed this part of the map.");
 
 		completeEast = new Conditions(true, LogicType.OR,

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -68,7 +68,7 @@ import net.runelite.api.Prayer;
 import net.runelite.api.QuestState;
 import net.runelite.api.SpriteID;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MONKEY_MADNESS_I
@@ -458,13 +458,13 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		talkedToZooknock = new VarbitRequirement(127, 5, Operation.GREATER_EQUAL);
 
 		givenDentures = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Zooknock the magical monkey dentures."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the magical monkey dentures."),
 			new WidgetTextRequirement(119, 3, true, "<str> - Something to do with monkey speech."));
 		givenBar = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Zooknock the gold bar."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the gold bar."),
 			new WidgetTextRequirement(119, 3, true, "<str> - A gold bar."));
 		givenMould = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey amulet mould."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey amulet mould."),
 			new WidgetTextRequirement(119, 3, true, "<str> - A monkey amulet mould."));
 
 		hasTalisman = new Conditions(LogicType.OR, karamjanGreegree, talisman);
@@ -473,11 +473,11 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		hadDenturesAndMould = new Conditions(LogicType.OR, hadEnchantedBar, new Conditions(monkeyDentures, mould));
 
 		givenTalisman = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey talisman."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey talisman."),
 			new WidgetTextRequirement(119, 3, true, "<str> - An authentic magical monkey talisman.")
 		);
 		givenBones = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey remains."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey remains."),
 			new WidgetTextRequirement(119, 3, true, "<str> - Some kind of monkey remains.")
 		);
 

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -65,7 +65,7 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.MOURNINGS_END_PART_II
@@ -610,7 +610,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 		f2r2c0ER = new VarbitRequirement(1239, RED);
 		f2r0c4D = new VarbitRequirement(1193, BLUE);
 		blueCrystalNotPlaced = new VarbitRequirement(1193, WHITE);
-		placedBlueCrystalInJumpRoom = new Conditions(true, LogicType.OR, f2r0c4D, new Conditions(LogicType.AND, inBlueRoom, new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You place the blue crystal in the pillar.")));
+		placedBlueCrystalInJumpRoom = new Conditions(true, LogicType.OR, f2r0c4D, new Conditions(LogicType.AND, inBlueRoom, new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You place the blue crystal in the pillar.")));
 		cyanDoorOpen = new VarbitRequirement(1176, RED);
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/piratestreasure/RumSmugglingStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/piratestreasure/RumSmugglingStep.java
@@ -37,7 +37,7 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
@@ -142,7 +142,7 @@ public class RumSmugglingStep extends ConditionalStep
 	{
 		onKaramja = new ZoneRequirement(karamjaZone1, karamjaZone2, karamjaBoat);
 		Requirement offKaramja = new ZoneRequirement(false, karamjaZone1, karamjaZone2, karamjaBoat);
-		Requirement inPirateTreasureMenu = new WidgetTextRequirement(WidgetInfo.DIARY_QUEST_WIDGET_TITLE, getQuestHelper().getQuest().getName());
+		Requirement inPirateTreasureMenu = new WidgetTextRequirement(ComponentID.DIARY_TITLE, getQuestHelper().getQuest().getName());
 
 		hasRumOffKaramja = new Conditions(LogicType.AND, karamjanRum, offKaramja);
 		hadRumOffKaramja = new Conditions(true, karamjanRum, offKaramja);

--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/QuizSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/QuizSteps.java
@@ -38,8 +38,8 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 
 public class QuizSteps extends DetailedOwnerStep
@@ -87,7 +87,7 @@ public class QuizSteps extends DetailedOwnerStep
 			items.add(flour);
 		}
 
-		Widget currentDialog = client.getWidget(WidgetInfo.DIALOG_NPC_TEXT);
+		Widget currentDialog = client.getWidget(ComponentID.DIALOG_NPC_TEXT);
 
 		if (currentDialog != null)
 		{

--- a/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/IncantationStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/IncantationStep.java
@@ -31,11 +31,11 @@ import java.util.Collections;
 import net.runelite.api.ItemID;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 
 import java.util.HashMap;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -88,7 +88,17 @@ public class IncantationStep extends DetailedQuestStep
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if(event.getWidgetId() == WidgetInfo.INVENTORY.getId() && event.getMenuOption().equals("Chant"))
+		var widget = event.getWidget();
+
+		if (widget == null) {
+			return;
+		}
+
+		if (widget.getId() != ComponentID.INVENTORY_CONTAINER) {
+			return;
+		}
+
+		if (event.getMenuOption().equals("Chant"))
 		{
 			incantationPosition = 0;
 		}

--- a/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/IncantationStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/IncantationStep.java
@@ -32,8 +32,8 @@ import net.runelite.api.ItemID;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 
 import java.util.HashMap;
 import net.runelite.client.eventbus.Subscribe;
@@ -74,7 +74,7 @@ public class IncantationStep extends DetailedQuestStep
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
 		int groupId = event.getGroupId();
-		if (groupId == WidgetID.DIALOG_OPTION_GROUP_ID)
+		if (groupId == InterfaceID.DIALOG_OPTION)
 		{
 			clientThread.invokeLater(this::updateChoiceIfRequired);
 		}
@@ -123,7 +123,7 @@ public class IncantationStep extends DetailedQuestStep
 
 	private boolean shouldUpdateChoice()
 	{
-		Widget widget = client.getWidget(WidgetID.DIALOG_OPTION_GROUP_ID, 1);
+		Widget widget = client.getWidget(InterfaceID.DIALOG_OPTION, 1);
 		if (widget == null)
 		{
 			return false;

--- a/src/main/java/com/questhelper/helpers/quests/songoftheelves/BaxtorianPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/songoftheelves/BaxtorianPuzzle.java
@@ -45,8 +45,8 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.GraphicsObjectCreated;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import org.apache.commons.lang3.StringUtils;
@@ -149,7 +149,7 @@ public class BaxtorianPuzzle extends DetailedOwnerStep
 		{
 			clientThread.invokeLater(() ->
 			{
-				Widget itemPlacedWidget = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+				Widget itemPlacedWidget = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
 
 				if (itemPlacedWidget == null)
 				{

--- a/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -69,7 +69,7 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.TAI_BWO_WANNAI_TRIO
@@ -361,7 +361,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 
 		givenVessel = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(119, 3, true, "<str>He has successfully caught a Karambwan."),
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand over the Karambwan vessel to Tiadeche."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand over the Karambwan vessel to Tiadeche."),
 			new DialogRequirement("What is it?")
 		);
 
@@ -399,13 +399,13 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		);
 
 		givenPotion = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand over the agility potion to Tamayu."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand over the agility potion to Tamayu."),
 			new DialogRequirement("Thank you Bwana. Now I must prepare for my next"),
 			new WidgetTextRequirement(119, 3, true, "<str>I have increased his agility to match the Shaikahan's.")
 		);
 		givenSpear = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Tamayu, try using this weapon."),
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand the spear to Tamayu."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand the spear to Tamayu."),
 			new WidgetTextRequirement(119, 3, true, "<str>I have give him a stronger and Karambwan poisoned spear.")
 		);
 
@@ -421,20 +421,20 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 
 
 		givenBones = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Tinsay the burnt Jogre bones marinated"),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Tinsay the burnt Jogre bones marinated"),
 			new WidgetTextRequirement(119, 3, true, "<str>I have given him a burnt Jogre bones marinated in"),
 			new DialogRequirement("Finally! A near lifetime of craving satisfied!")
 		);
 
 		givenSandwich = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Tinsay the seaweed in monkey skin sandwich."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Tinsay the seaweed in monkey skin sandwich."),
 			new WidgetTextRequirement(119, 3, true, "<str>I have given him a seaweed in monkey skin sandwich."),
 			new DialogRequirement("Yes ... perfect! You really do not understand how necessary that was."),
 			givenBones
 		);
 
 		givenRum = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand Tinsay the sliced bananas in Karamjan " +
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Tinsay the sliced bananas in Karamjan " +
 				"rum."),
 			new WidgetTextRequirement(119, 3, true, "<str>I have given him sliced banana in Karamja rum."),
 			new DialogRequirement("Yes ... that's it! Hits just the spot!"),
@@ -456,7 +456,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 
 		hadManual = new Conditions(true, LogicType.OR,
 			craftingManual,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You hand over the crafting manual to Tiadeche."),
+			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand over the crafting manual to Tiadeche."),
 			new WidgetTextRequirement(119, 3, true, "<str>retrieved crafting instructions for Tiadeche.")
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
@@ -54,8 +54,8 @@ import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -119,7 +119,7 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 
 	protected void updateSteps()
 	{
-		Widget widget = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+		Widget widget = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
 
 		if (widget != null)
 		{

--- a/src/main/java/com/questhelper/helpers/quests/thefremenniktrials/TheFremennikTrials.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremenniktrials/TheFremennikTrials.java
@@ -65,7 +65,7 @@ import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.THE_FREMENNIK_TRIALS
@@ -397,7 +397,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 
 	public void setupConditions()
 	{
-		inQuestJournal = new WidgetTextRequirement(WidgetInfo.DIARY_QUEST_WIDGET_TITLE, "The Fremennik Trials");
+		inQuestJournal = new WidgetTextRequirement(ComponentID.DIARY_TITLE, "The Fremennik Trials");
 
 		Requirement syncedReqs = new Conditions(true, LogicType.OR, inQuestJournal,
 			new DialogRequirement("I think I would enjoy the challenge"));
@@ -458,7 +458,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 
 		hasPlacedStrangeObject = new RuneliteRequirement(configManager, "fremmytrialsplacedstrangeobject",
 			new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_PLAYER_TEXT,
+			new WidgetTextRequirement(ComponentID.DIALOG_PLAYER_TEXT,
 				"That is going to make a really loud bang when it goes off!"),
 			new ChatMessageRequirement("You put the lit strange object into the pipe."))
 		);

--- a/src/main/java/com/questhelper/helpers/quests/thegardenofdeath/TheGardenOfDeath.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegardenofdeath/TheGardenOfDeath.java
@@ -56,7 +56,7 @@ import java.util.Map;
 
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.THE_GARDEN_OF_DEATH
@@ -224,7 +224,7 @@ public class TheGardenOfDeath extends BasicQuestHelper
 
 		translationOpen = new WidgetTextRequirement(804, 4, "Translations");
 		chatInputOpen = new Conditions(LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.CHATBOX_TITLE, "Enter a possible translation for a word you've found:"),
+			new WidgetTextRequirement(ComponentID.CHATBOX_TITLE, "Enter a possible translation for a word you've found:"),
 			new WidgetTextRequirement(229, 1, "You've discovered a new translation",
 				"You've already discovered this translation", "You can't think of any suitable translations"),
 			new WidgetTextRequirement(219, 1, 0, "Attempt another translation?")

--- a/src/main/java/com/questhelper/helpers/quests/thegiantdwarf/TheGiantDwarf.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegiantdwarf/TheGiantDwarf.java
@@ -65,7 +65,7 @@ import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @SuppressWarnings("CheckStyle")
 @QuestDescriptor(
@@ -216,7 +216,7 @@ public class TheGiantDwarf extends BasicQuestHelper
 			new WidgetTextRequirement(219, 1, 2, "Yes, about those special clothes again..."));
 
 		talkedToLibrarian = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(WidgetInfo.DIALOG_NPC_TEXT,
+			new WidgetTextRequirement(ComponentID.DIALOG_NPC_TEXT,
 				"Let me think... I believe it is on the top shelf of one of<br>the bookcases in the library, because it is such an old<br>book.",
 				"Well, thanks, I'll have a look."
 			),

--- a/src/main/java/com/questhelper/helpers/quests/thetouristtrap/TheTouristTrap.java
+++ b/src/main/java/com/questhelper/helpers/quests/thetouristtrap/TheTouristTrap.java
@@ -63,7 +63,7 @@ import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.THE_TOURIST_TRAP
@@ -287,7 +287,7 @@ public class TheTouristTrap extends BasicQuestHelper
 
 		hasSlaveClothes = new ItemRequirements(slaveTop, slaveBoot, slaveRobe);
 
-		searchedBookcase = new Conditions(true, new WidgetTextRequirement(WidgetInfo.DIALOG_SPRITE_TEXT, "You notice several books on the subject of sailing."));
+		searchedBookcase = new Conditions(true, new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You notice several books on the subject of sailing."));
 		distractedSiad = new Conditions(true, new WidgetTextRequirement(229, 1, "The captain starts rambling on about his days as a salty sea dog. He<br>looks quite distracted..."));
 
 		anaPlacedOnCartOfLift = new VarbitRequirement(2805, 1);

--- a/src/main/java/com/questhelper/helpers/quests/watchtower/SkavidChoice.java
+++ b/src/main/java/com/questhelper/helpers/quests/watchtower/SkavidChoice.java
@@ -30,8 +30,8 @@ import com.questhelper.steps.choice.DialogChoiceSteps;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 
 public class SkavidChoice extends NpcStep
@@ -49,7 +49,7 @@ public class SkavidChoice extends NpcStep
 
 	private void updateCorrectChoice()
 	{
-		Widget widget = client.getWidget(WidgetInfo.DIALOG_NPC_TEXT);
+		Widget widget = client.getWidget(ComponentID.DIALOG_NPC_TEXT);
 		if (widget == null)
 		{
 			return;

--- a/src/main/java/com/questhelper/managers/QuestMenuHandler.java
+++ b/src/main/java/com/questhelper/managers/QuestMenuHandler.java
@@ -35,7 +35,7 @@ import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.util.Text;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -82,7 +82,7 @@ public class QuestMenuHandler
 
 	private static final int[] ACHIEVEMENTLIST_WIDGET_IDS = new int[]
 		{
-			WidgetInfo.ACHIEVEMENT_DIARY_CONTAINER.getId()
+			ComponentID.ACHIEVEMENT_DIARY_CONTAINER
 		};
 
 	private static final String[] ACHIEVEMENT_TIERS = new String[]

--- a/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
@@ -29,9 +29,11 @@ package com.questhelper.requirements.widget;
 import com.questhelper.requirements.SimpleRequirement;
 import java.util.Arrays;
 import java.util.List;
+import com.questhelper.util.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 
@@ -58,6 +60,23 @@ public class WidgetTextRequirement extends SimpleRequirement
 
 		this.groupId = widgetInfo.getGroupId();
 		this.childId = widgetInfo.getChildId();
+		this.text = Arrays.asList(text);
+	}
+
+	public WidgetTextRequirement(@Component int componentId, String... text)
+	{
+		var pair = Utils.unpackWidget(componentId);
+		this.groupId = pair.getLeft();
+		this.childId = pair.getRight();
+		this.text = Arrays.asList(text);
+	}
+
+	public WidgetTextRequirement(@Component int componentId, boolean checkChildren, String... text)
+	{
+		var pair = Utils.unpackWidget(componentId);
+		this.groupId = pair.getLeft();
+		this.childId = pair.getRight();
+		this.checkChildren = checkChildren;
 		this.text = Arrays.asList(text);
 	}
 

--- a/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
@@ -35,7 +35,6 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 
 public class WidgetTextRequirement extends SimpleRequirement
 {
@@ -54,14 +53,6 @@ public class WidgetTextRequirement extends SimpleRequirement
 	// Used to restrict the considered set of children
 	private int min = -1;
 	private int max = -1;
-
-	public WidgetTextRequirement(WidgetInfo widgetInfo, String... text)
-	{
-
-		this.groupId = widgetInfo.getGroupId();
-		this.childId = widgetInfo.getChildId();
-		this.text = Arrays.asList(text);
-	}
 
 	public WidgetTextRequirement(@Component int componentId, String... text)
 	{
@@ -84,14 +75,6 @@ public class WidgetTextRequirement extends SimpleRequirement
 	{
 		this.groupId = groupId;
 		this.childId = childId;
-		this.checkChildren = checkChildren;
-		this.text = Arrays.asList(text);
-	}
-
-	public WidgetTextRequirement(WidgetInfo widgetInfo, boolean checkChildren, String... text)
-	{
-		this.groupId = widgetInfo.getGroupId();
-		this.childId = widgetInfo.getChildId();
 		this.checkChildren = checkChildren;
 		this.text = Arrays.asList(text);
 	}

--- a/src/main/java/com/questhelper/runeliteobjects/GlobalFakeObjects.java
+++ b/src/main/java/com/questhelper/runeliteobjects/GlobalFakeObjects.java
@@ -36,7 +36,7 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.config.ConfigManager;
 
 public class GlobalFakeObjects
@@ -67,6 +67,6 @@ public class GlobalFakeObjects
 		replacedHopleez.setExamine("He was here first.");
 		replacedHopleez.addExamineAction(runeliteObjectManager);
 		replacedHopleez.setDisplayRequirement(new PlayerQuestStateRequirement(configManager, PlayerQuests.COOKS_HELPER, 4, Operation.GREATER_EQUAL));
-		replacedHopleez.addWidgetReplacement(new WidgetReplacement(new WidgetDetails(WidgetInfo.DIALOG_NPC_TEXT), "Hatius Cosaintus", "Hopleez"));
+		replacedHopleez.addWidgetReplacement(new WidgetReplacement(new WidgetDetails(ComponentID.DIALOG_NPC_TEXT), "Hatius Cosaintus", "Hopleez"));
 	}
 }

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/RuneliteObjectManager.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/RuneliteObjectManager.java
@@ -60,8 +60,8 @@ import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.callback.Hooks;
 import net.runelite.client.chat.ChatColorType;
@@ -904,7 +904,7 @@ public class RuneliteObjectManager
 			}
 		}
 
-		if (event.getGroupId() == WidgetID.DIALOG_NPC_GROUP_ID)
+		if (event.getGroupId() == InterfaceID.DIALOG_NPC)
 		{
 			Widget npcChatName = client.getWidget(ComponentID.DIALOG_NPC_NAME);
 			Widget npcChatHead = client.getWidget(ComponentID.DIALOG_NPC_HEAD_MODEL);

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/RuneliteObjectManager.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/RuneliteObjectManager.java
@@ -59,9 +59,9 @@ import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.callback.Hooks;
 import net.runelite.client.chat.ChatColorType;
@@ -906,8 +906,8 @@ public class RuneliteObjectManager
 
 		if (event.getGroupId() == WidgetID.DIALOG_NPC_GROUP_ID)
 		{
-			Widget npcChatName = client.getWidget(WidgetInfo.DIALOG_NPC_NAME);
-			Widget npcChatHead = client.getWidget(WidgetInfo.DIALOG_NPC_HEAD_MODEL);
+			Widget npcChatName = client.getWidget(ComponentID.DIALOG_NPC_NAME);
+			Widget npcChatHead = client.getWidget(ComponentID.DIALOG_NPC_HEAD_MODEL);
 
 			clientThread.invokeLater(() -> {
 				if (npcChatHead == null || npcChatName == null)

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/WidgetReplacement.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/WidgetReplacement.java
@@ -26,7 +26,6 @@ package com.questhelper.runeliteobjects.extendedruneliteobjects;
 
 import com.questhelper.steps.WidgetDetails;
 import lombok.Getter;
-import net.runelite.api.widgets.WidgetInfo;
 
 public class WidgetReplacement
 {
@@ -42,13 +41,6 @@ public class WidgetReplacement
 	public WidgetReplacement(WidgetDetails widgetDetails, String textToReplace, String replacementText)
 	{
 		this.widgetDetails = widgetDetails;
-		this.textToReplace = textToReplace;
-		this.replacementText = replacementText;
-	}
-
-	public WidgetReplacement(WidgetInfo widgetInfo, String textToReplace, String replacementText)
-	{
-		this.widgetDetails = new WidgetDetails(widgetInfo);
 		this.textToReplace = textToReplace;
 		this.replacementText = replacementText;
 	}

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -66,8 +66,8 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -539,7 +539,7 @@ public class DetailedQuestStep extends QuestStep
 	}
 
 	protected Widget getInventoryWidget() {
-		return client.getWidget(WidgetInfo.INVENTORY);
+		return client.getWidget(ComponentID.INVENTORY_CONTAINER);
 	}
 
 	private void renderInventory(Graphics2D graphics)

--- a/src/main/java/com/questhelper/steps/EmoteStep.java
+++ b/src/main/java/com/questhelper/steps/EmoteStep.java
@@ -35,8 +35,8 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import net.runelite.api.ScriptID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 
 public class EmoteStep extends DetailedQuestStep
 {
@@ -60,14 +60,14 @@ public class EmoteStep extends DetailedQuestStep
 	{
 		super.makeWidgetOverlayHint(graphics, plugin);
 
-		Widget emoteContainer = client.getWidget(WidgetInfo.EMOTE_CONTAINER);
+		Widget emoteContainer = client.getWidget(ComponentID.EMOTES_EMOTE_CONTAINER);
 
 		if (emoteContainer == null || emoteContainer.isHidden())
 		{
 			return;
 		}
 
-		Widget emoteWindow = client.getWidget(WidgetInfo.EMOTE_WINDOW);
+		Widget emoteWindow = client.getWidget(ComponentID.EMOTES_WINDOW);
 
 		if (emoteWindow == null)
 		{
@@ -98,7 +98,7 @@ public class EmoteStep extends DetailedQuestStep
 
 	void scrollToWidget(Widget widget)
 	{
-		final Widget parent = client.getWidget(WidgetInfo.EMOTE_CONTAINER);
+		final Widget parent = client.getWidget(ComponentID.EMOTES_EMOTE_CONTAINER);
 
 		if (widget == null || parent == null)
 		{
@@ -110,8 +110,8 @@ public class EmoteStep extends DetailedQuestStep
 
 		client.runScript(
 			ScriptID.UPDATE_SCROLLBAR,
-			WidgetInfo.EMOTE_SCROLLBAR.getId(),
-			WidgetInfo.EMOTE_CONTAINER.getId(),
+			ComponentID.EMOTES_EMOTE_SCROLLBAR,
+			ComponentID.EMOTES_EMOTE_CONTAINER,
 			newScroll
 		);
 	}

--- a/src/main/java/com/questhelper/steps/NpcEmoteStep.java
+++ b/src/main/java/com/questhelper/steps/NpcEmoteStep.java
@@ -34,8 +34,8 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import net.runelite.api.ScriptID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 
 public class NpcEmoteStep extends NpcStep
 {
@@ -67,14 +67,14 @@ public class NpcEmoteStep extends NpcStep
 	{
 		super.makeWidgetOverlayHint(graphics, plugin);
 
-		Widget emoteContainer = client.getWidget(WidgetInfo.EMOTE_CONTAINER);
+		Widget emoteContainer = client.getWidget(ComponentID.EMOTES_EMOTE_CONTAINER);
 
 		if (emoteContainer == null || emoteContainer.isHidden())
 		{
 			return;
 		}
 
-		Widget emoteWindow = client.getWidget(WidgetInfo.EMOTE_WINDOW);
+		Widget emoteWindow = client.getWidget(ComponentID.EMOTES_WINDOW);
 
 		if (emoteWindow == null)
 		{
@@ -106,7 +106,7 @@ public class NpcEmoteStep extends NpcStep
 
 	void scrollToWidget(Widget widget)
 	{
-		final Widget parent = client.getWidget(WidgetInfo.EMOTE_CONTAINER);
+		final Widget parent = client.getWidget(ComponentID.EMOTES_EMOTE_CONTAINER);
 
 		if (widget == null || parent == null)
 		{
@@ -118,8 +118,8 @@ public class NpcEmoteStep extends NpcStep
 
 		client.runScript(
 			ScriptID.UPDATE_SCROLLBAR,
-			WidgetInfo.EMOTE_SCROLLBAR.getId(),
-			WidgetInfo.EMOTE_CONTAINER.getId(),
+			ComponentID.EMOTES_EMOTE_SCROLLBAR,
+			ComponentID.EMOTES_EMOTE_CONTAINER,
 			newScroll
 		);
 	}

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -59,7 +59,7 @@ import net.runelite.api.SpriteID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
-import net.runelite.api.widgets.WidgetID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
@@ -223,7 +223,7 @@ public abstract class QuestStep implements Module
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
-		if (event.getGroupId() == WidgetID.DIALOG_OPTION_GROUP_ID) // 219
+		if (event.getGroupId() == InterfaceID.DIALOG_OPTION)
 		{
 			clientThread.invokeLater(this::highlightChoice);
 		}

--- a/src/main/java/com/questhelper/steps/WidgetDetails.java
+++ b/src/main/java/com/questhelper/steps/WidgetDetails.java
@@ -24,8 +24,10 @@
  */
 package com.questhelper.steps;
 
+import com.questhelper.util.Utils;
 import lombok.AllArgsConstructor;
 import lombok.Value;
+import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.WidgetInfo;
 
 @Value
@@ -40,6 +42,14 @@ public class WidgetDetails
 	{
 		groupID = widgetInfo.getGroupId();
 		childID = widgetInfo.getChildId();
+		childChildID = -1;
+	}
+
+	public WidgetDetails(@Component int componentId)
+	{
+		var pair = Utils.unpackWidget(componentId);
+		groupID = pair.getLeft();
+		childID = pair.getRight();
 		childChildID = -1;
 	}
 }

--- a/src/main/java/com/questhelper/steps/WidgetDetails.java
+++ b/src/main/java/com/questhelper/steps/WidgetDetails.java
@@ -28,7 +28,6 @@ import com.questhelper.util.Utils;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import net.runelite.api.annotations.Component;
-import net.runelite.api.widgets.WidgetInfo;
 
 @Value
 @AllArgsConstructor
@@ -37,13 +36,6 @@ public class WidgetDetails
 	public int groupID;
 	public int childID;
 	public int childChildID;
-
-	public WidgetDetails(WidgetInfo widgetInfo)
-	{
-		groupID = widgetInfo.getGroupId();
-		childID = widgetInfo.getChildId();
-		childChildID = -1;
-	}
 
 	public WidgetDetails(@Component int componentId)
 	{

--- a/src/main/java/com/questhelper/steps/overlay/WorldLines.java
+++ b/src/main/java/com/questhelper/steps/overlay/WorldLines.java
@@ -37,8 +37,8 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
 public class WorldLines
@@ -93,15 +93,15 @@ public class WorldLines
 			Line2D.Double line = new Line2D.Double(startPosOnMinimap.getX(), startPosOnMinimap.getY(), destinationPosOnMinimap.getX(), destinationPosOnMinimap.getY());
 
 			Rectangle bounds = new Rectangle(0, 0, client.getCanvasWidth(), client.getCanvasHeight());
-			Widget minimapWidget = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_STONES_DRAW_AREA);
+			Widget minimapWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_MINIMAP_DRAW_AREA);
 
 			if (minimapWidget == null)
 			{
-				minimapWidget = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_DRAW_AREA);
+				minimapWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP_DRAW_AREA);
 			}
 			if (minimapWidget == null)
 			{
-				minimapWidget = client.getWidget(WidgetInfo.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
+				minimapWidget = client.getWidget(ComponentID.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
 			}
 
 			if (minimapWidget != null)

--- a/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
+++ b/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
@@ -37,8 +37,8 @@ import net.runelite.api.RenderOverview;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 
 public class QuestPerspective
 {
@@ -137,7 +137,7 @@ public class QuestPerspective
 
 	public static Rectangle getWorldMapClipArea(Client client)
 	{
-		Widget widget = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
+		Widget widget = client.getWidget(ComponentID.WORLD_MAP_MAPVIEW);
 		if (widget == null)
 		{
 			return null;
@@ -157,7 +157,7 @@ public class QuestPerspective
 
 		float pixelsPerTile = ro.getWorldMapZoom();
 
-		Widget map = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
+		Widget map = client.getWidget(ComponentID.WORLD_MAP_MAPVIEW);
 		if (map != null)
 		{
 			Rectangle worldMapRect = map.getBounds();
@@ -211,16 +211,16 @@ public class QuestPerspective
 		{
 			if (client.getVarbitValue(Varbits.SIDE_PANELS) == 1)
 			{
-				minimapDrawWidget = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_DRAW_AREA);
+				minimapDrawWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP_DRAW_AREA);
 			}
 			else
 			{
-				minimapDrawWidget = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_STONES_DRAW_AREA);
+				minimapDrawWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_MINIMAP_DRAW_AREA);
 			}
 		}
 		else
 		{
-			minimapDrawWidget = client.getWidget(WidgetInfo.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
+			minimapDrawWidget = client.getWidget(ComponentID.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
 		}
 
 		if (minimapDrawWidget == null)

--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -29,7 +29,10 @@ import com.questhelper.domain.AccountType;
 import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
+import net.runelite.api.annotations.Component;
+import net.runelite.api.annotations.Interface;
 
 @UtilityClass
 public class Utils
@@ -44,6 +47,28 @@ public class Utils
 	public AccountType getAccountType(@NotNull Client client)
 	{
 		return AccountType.get(client.getVarbitValue(Varbits.ACCOUNT_TYPE));
+	}
+
+	/**
+	 * Pack a widget group ID (Interface) and widget child ID into a widget ID (Component)
+	 * @param groupId the {@link Interface}
+	 * @param childId the child id
+	 * @return the corresponding {@link Component}
+	 */
+	@Component
+	@SuppressWarnings("MagicConstant")
+	public int packWidget(@Interface int groupId, int childId) {
+		return groupId << 16 | childId;
+	}
+
+	/**
+	 * Unpack a widget ID (Component) into a widget group ID (Interface) and widget child ID
+	 * @param componentId the {@link Component}
+	 * @return the corresponding Interface & Child ID
+	 */
+	@Component
+	public Pair<Integer, Integer> unpackWidget(@Component int componentId) {
+		return Pair.of(componentId >> 16, componentId & 0xFFFF);
 	}
 
 }

--- a/src/test/java/com/questhelper/util/UtilsTest.java
+++ b/src/test/java/com/questhelper/util/UtilsTest.java
@@ -1,0 +1,32 @@
+package com.questhelper.util;
+
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UtilsTest
+{
+	@Test
+	void pack()
+	{
+		assertEquals(
+			Utils.packWidget(InterfaceID.FAIRY_RING_PANEL, 8),
+			ComponentID.FAIRY_RING_PANEL_FAVORITES
+		);
+	}
+
+	@Test
+	void unpack()
+	{
+		assertEquals(
+			Utils.unpackWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_INTERFACE_CONTAINER),
+			Pair.of(164, 69)
+		);
+		assertEquals(
+			Utils.unpackWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP),
+			Pair.of(164, 90)
+		);
+	}
+}


### PR DESCRIPTION
~This relies on https://github.com/Zoinkwiz/quest-helper/pull/1324 being merged in first, then this rebased before it can be merged.~ This has been completed

- feat: Add packWidget & unpackWidget utils
- feat: Add WidgetTextRequirement constructor accepting a Component ID
- feat: Add constructor to WidgetDetails accepting a component ID
- fix: BarrowsHelper widget usage
- fix: shadowofthestorm deprecated widget usage
- fix: inventory container getter deprecated widget usage
- fix: repace WorldLines deprecated WidgetInfo use with ComponentID
- fix: replace deprecated usage of WidgetInfo.\*
- Remove deprecated WidgetInfo constructors for WidgetTextRequirement
- Remove unused WidgetReplacement & WidgetDetails constructors
- fix: replace deprecated usage of WidgetID.\* for group IDs

There were a lot of things here that were not super easy to test, so it is a good idea to go commit by commit here & double check the changes that have been made. I have tried to keep each commit atomic & have it document what it's actually changed.

This PR must be merged in before any further QuestHelper updates can be pushed, see https://github.com/runelite/plugin-hub/commit/db44ca0ecbc0fdcc99f93d423c019caf9ed36cee
