### PR TITLE
feat: Support minimap zoom levels when rendering the direction arrow

### DIFF
--- a/src/main/java/com/questhelper/steps/overlay/DirectionArrow.java
+++ b/src/main/java/com/questhelper/steps/overlay/DirectionArrow.java
@@ -42,9 +42,23 @@ import net.runelite.api.coords.WorldPoint;
 
 public class DirectionArrow
 {
+	/**
+	 * @param client the {@link Client}
+	 * @return the rough number of tiles distance the minimap can draw
+	 */
+	public static int getMaxMinimapDrawDistance(Client client)
+	{
+		var minimapZoom = client.getMinimapZoom();
+		if (minimapZoom > 0.0)
+		{
+			return (int) (64.0 / client.getMinimapZoom());
+		}
+		return 16;
+	}
+
 	public static void renderMinimapArrow(Graphics2D graphics, Client client, WorldPoint worldPoint, Color color)
 	{
-		final int MAX_DRAW_DISTANCE = 16;
+		var maxMinimapDrawDistance = getMaxMinimapDrawDistance(client);
 		Player player = client.getLocalPlayer();
 		if (player == null)
 		{
@@ -59,7 +73,7 @@ public class DirectionArrow
 			return;
 		}
 
-		if (worldPoint.distanceTo(playerRealLocation) >= MAX_DRAW_DISTANCE)
+		if (worldPoint.distanceTo(playerRealLocation) >= maxMinimapDrawDistance)
 		{
 			createMinimapDirectionArrow(graphics, client, playerRealLocation, worldPoint, color);
 			return;


### PR DESCRIPTION
At the default minimap zoom level, this changes nothing.

The following video shows the old & new behaviour - the blinking arrow effect was disabled to show better how it works

https://github.com/Zoinkwiz/quest-helper/assets/962989/5c7e1cc7-bdf5-4a13-8fa1-b57e9b57b608


