### PR TITLE
Heroes' Quest: Add missing sidepanel step for Phoenix Gang members

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -574,7 +574,7 @@ public class HeroesQuest extends BasicQuestHelper
 		else
 		{
 			thirdPanel = new PanelDetails("Get thieves' armband", 
-				Arrays.asList(talkToStraven, talkToAlfonse, getKeyFromPartner, talkToCharlie, pushWall, useKeyOnDoor,
+				Arrays.asList(enterPhoenixBase, talkToStraven, talkToAlfonse, getKeyFromPartner, talkToCharlie, pushWall, useKeyOnDoor,
 					killGrip, bringCandlestickToStraven), Collections.singletonList(rangedMage),
 				Arrays.asList(varrockTeleport.quantity(2), brimhavenTeleport));
 		}


### PR DESCRIPTION
This could technically be baked into the "Talk to Straven" step, but having clear directions at the beginning of a new side panel category is nice imo.

Looks like this:
![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/bbc38815-92cd-4f60-a952-baf7fed6a32c)

