### PR TITLE
Kourend & Kebos Medium Diary: Fix Mahogany tree object ID

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
@@ -330,7 +330,7 @@ public class KourendMedium extends ComplexStateQuestHelper
 		catchChinchompa.addIcon(ItemID.BOX_TRAP);
 
 		// Chop some mahogany logs
-		chopMahoganyTree = new ObjectStep(this, ObjectID.MAHOGANY, new WorldPoint(1238, 3771, 0),
+		chopMahoganyTree = new ObjectStep(this, ObjectID.MAHOGANY_TREE, new WorldPoint(1238, 3771, 0),
 			"Chop some logs from a mahogany tree North of the Farming Guild.", true, axe);
 
 		// Claim reward


### PR DESCRIPTION
The ID was confirmed in leagues & on normal worlds

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/9c7a2ca3-f79a-422a-b745-4ab83d3150c7)
