### PR TITLE
Fix: Flatlaf Runelite compatability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = 'latest.release'
+def runeLiteVersion = '1.10.18-flatlaf-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 }
 
 group = 'com.questhelper'
-version = '4.2.3'
+version = '4.2.4'
 sourceCompatibility = "11"
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -487,10 +487,7 @@ public class QuestHelperPlugin extends Plugin
 	public void displayPanel()
 	{
 		SwingUtilities.invokeLater(() -> {
-			if (!navButton.isSelected())
-			{
-				navButton.getOnSelect().run();
-			}
+			clientToolbar.openPanel(navButton);
 		});
 	}
 


### PR DESCRIPTION
This makes Quest Helper work with the Runeltie flatlaf changes (https://github.com/runelite/runelite/issues/17284). There's the opportunity still to improve the aesthetic to look better with the new styling (image qualities, some weird outlining, etc), but from what I can tell it's all thankfully fairly functional.