### PR TITLE
Shadow of the Storm: Minor polish

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/IncantationStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/IncantationStep.java
@@ -29,26 +29,59 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.steps.DetailedQuestStep;
 import java.util.Collections;
 import net.runelite.api.ItemID;
+import net.runelite.api.annotations.Varbit;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
 
-import java.util.HashMap;
 import net.runelite.client.eventbus.Subscribe;
-import org.apache.commons.lang3.ArrayUtils;
 
 public class IncantationStep extends DetailedQuestStep
 {
-	private final HashMap<Integer, String> words = new HashMap<Integer, String>()
-	{{
-		put(0, "Caldar");
-		put(1, "Nahudu");
-		put(2, "Agrith-Naar");
-		put(3, "Camerinthum");
-		put(4, "Tarren");
-	}};
+	/**
+	 * The index of the first word in the incantation, as per the order of the Demonic tome (reverse of the order Denath gives you).
+	 * The order of the words received by Denath is reverse.
+	 * The value of this varbit maps to the {@link IncantationStep#WORDS} array.
+	 */
+	private static final @Varbit int INCANTATION_WORD_1 = 1373;
+	/**
+	 * The index of the second word in the incantation, as per the order of the Demonic tome (reverse of the order Denath gives you).
+	 * The order of the words received by Denath is reverse.
+	 * The value of this varbit maps to the {@link IncantationStep#WORDS} array.
+	 */
+	private static final @Varbit int INCANTATION_WORD_2 = 1374;
+	/**
+	 * The index of the third word in the incantation, as per the order of the Demonic tome (reverse of the order Denath gives you).
+	 * The order of the words received by Denath is reverse.
+	 * The value of this varbit maps to the {@link IncantationStep#WORDS} array.
+	 */
+	private static final @Varbit int INCANTATION_WORD_3 = 1375;
+	/**
+	 * The index of the fourth word in the incantation, as per the order of the Demonic tome (reverse of the order Denath gives you).
+	 * The order of the words received by Denath is reverse.
+	 * The value of this varbit maps to the {@link IncantationStep#WORDS} array.
+	 */
+	private static final @Varbit int INCANTATION_WORD_4 = 1376;
+	/**
+	 * The index of the fifth word in the incantation, as per the order of the Demonic tome (reverse of the order Denath gives you).
+	 * The order of the words received by Denath is reverse.
+	 * The value of this varbit maps to the {@link IncantationStep#WORDS} array.
+	 */
+	private static final @Varbit int INCANTATION_WORD_5 = 1377;
+
+	/**
+	 * The possible words that that can be used the incantation
+	 * The index correlates to the value of the varbit
+	 */
+	private static final String[] WORDS = {
+		"Caldar",
+		"Nahudu",
+		"Agrith-Naar",
+		"Camerinthum",
+		"Tarren",
+	};
 
 	private final boolean reverse;
 	private String[] incantationOrder;
@@ -144,20 +177,34 @@ public class IncantationStep extends DetailedQuestStep
 	 */
 	protected void updateHints()
 	{
-		if (incantationOrder != null || (client.getVarbitValue(1374) == 0 && client.getVarbitValue(1375) == 0))
+		if (incantationOrder != null)
 		{
+			// The order has already been calculated
 			return;
 		}
-		incantationOrder = new String[]{
-			words.get(client.getVarbitValue(1373)),
-			words.get(client.getVarbitValue(1374)),
-			words.get(client.getVarbitValue(1375)),
-			words.get(client.getVarbitValue(1376)),
-			words.get(client.getVarbitValue(1377))
-		};
-		if (reverse)
+
+		if (client.getVarbitValue(INCANTATION_WORD_2) == 0 && client.getVarbitValue(INCANTATION_WORD_3) == 0)
 		{
-			ArrayUtils.reverse(incantationOrder);
+			// The word order hasn't been received yet (two incantations can't point to the same word)
+			return;
+		}
+
+		if (reverse) {
+			incantationOrder = new String[]{
+				WORDS[client.getVarbitValue(INCANTATION_WORD_5)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_4)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_3)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_2)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_1)],
+			};
+		} else {
+			incantationOrder = new String[]{
+				WORDS[client.getVarbitValue(INCANTATION_WORD_1)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_2)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_3)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_4)],
+				WORDS[client.getVarbitValue(INCANTATION_WORD_5)],
+			};
 		}
 		String incantString = "Say the following in order: " + String.join(", ", incantationOrder);
 

--- a/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -378,7 +378,7 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		allSteps.add(new PanelDetails("Starting off", Collections.singletonList(talkToReen)));
-		allSteps.add(new PanelDetails("Infiltrate the cult", Arrays.asList(talkToBadden, pickMushroom, dyeSilverlight, goIntoRuin, pickUpStrangeImplement, talkToEvilDave, talkToJennifer, talkToMatthew), silverlight, darkItems));
+		allSteps.add(new PanelDetails("Infiltrate the cult", Arrays.asList(talkToBadden, pickMushroom, dyeSilverlight, goIntoRuin, pickUpStrangeImplement, talkToEvilDave, talkToDenath, talkToJennifer, talkToMatthew), silverlight, darkItems));
 		allSteps.add(new PanelDetails("Uncovering the truth", Arrays.asList(smeltSigil, talkToGolem, searchKiln, readBook, talkToMatthewAfterBook, standInCircle, readIncantation), silverBar, silverlightDyed, combatGear));
 		allSteps.add(new PanelDetails("Defeating Agrith-Naar", Arrays.asList(pickUpSigil, leavePortal, pickUpSigil2, tellDaveToReturn, talkToBaddenAfterRitual, talkToReenAfterRitual, talkToTheGolemAfterRitual, useImplementOnGolem, talkToGolemAfterReprogramming,
 			talkToMatthewToStartFight, standInCircleAgain, incantRitual, killDemon, unequipDarklight), silverlightDyed, combatGear));

--- a/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -251,7 +251,7 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 		talkToReen.addDialogStep("That's me!");
 		talkToReen.addDialogStep("Yes.");
 		talkToBadden = new NpcStep(this, NpcID.FATHER_BADDEN, new WorldPoint(3490, 3090, 0), "Talk to Father Badden in Uzer.", silverlight, darkItems);
-		talkToBadden.addDialogSteps("Reen sent me.", "So what do you want me to do?", "How can I do that?");
+		talkToBadden.addDialogSteps("Uzer", "Reen sent me.", "So what do you want me to do?", "How can I do that?");
 		pickMushroom = new ObjectStep(this, ObjectID.BLACK_MUSHROOMS, new WorldPoint(3495, 3088, 0), "Pick up some black mushrooms.");
 		dyeSilverlight = new DetailedQuestStep(this, "Use the black mushrooms on Silverlight.", silverlightHighlighted, blackMushroomHighlighted);
 		goIntoRuin = new ObjectStep(this, ObjectID.STAIRCASE_6373, new WorldPoint(3493, 3090, 0), "Enter the Uzer ruins.", silverlightDyedEquipped, darkItems);
@@ -270,6 +270,7 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 		talkToMatthew.addDialogStep("Do you know what happened to Josef?");
 		smeltSigil = new DetailedQuestStep(this, "Travel to any furnace with the sigil mould and silver bar and smelt a sigil.", silverBar, sigilMould);
 		talkToGolem = new NpcStep(this, NpcID.CLAY_GOLEM_5136, new WorldPoint(3485, 3088, 0), "Talk to the Golem in Uzer.", silverlightDyed, sigil, combatGear);
+		talkToGolem.addDialogStep("Uzer");
 		talkToGolem.addDialogStep("Did you see anything happen last night?");
 		searchKiln = new SearchKilns(this);
 		readBook = new DetailedQuestStep(this, "Read the book.", bookHighlighted);

--- a/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/src/main/java/com/questhelper/helpers/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -249,6 +249,7 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 	{
 		talkToReen = new NpcStep(this, NpcID.FATHER_REEN, new WorldPoint(3270, 3159, 0), "Talk to Father Reen outside Al Kharid bank.");
 		talkToReen.addDialogStep("That's me!");
+		talkToReen.addDialogStep("Yes.");
 		talkToBadden = new NpcStep(this, NpcID.FATHER_BADDEN, new WorldPoint(3490, 3090, 0), "Talk to Father Badden in Uzer.", silverlight, darkItems);
 		talkToBadden.addDialogSteps("Reen sent me.", "So what do you want me to do?", "How can I do that?");
 		pickMushroom = new ObjectStep(this, ObjectID.BLACK_MUSHROOMS, new WorldPoint(3495, 3088, 0), "Pick up some black mushrooms.");


### PR DESCRIPTION
- Clean up incantation step
  - I verified & documented the varbits we use, moving them to proper annotated variables
  - I converted the HashMap that held the varbitvalue -> word to an array
  - I split up the two early out conditions for the hint update
  - I "simplified" the incantation order calculations. This removed our reliance on ArrayUtils for (imo) no loss in code clarity.
- Highlight quest start step (just making sure the "Yes." is blue)
- Highlight carpet ride to Uzer
  - There are two times during the quest where, during an optimal-ish run, the player will be taking the carpet ride from outside Shantay Pass to Uzer. We now highlight Uzer for both of those times.
- Add missing step to talk to Denath to the side panel
  - The step was being tracked properly, but it just wasn't added to the list of steps in the side panel

I tested these changes fully on Leagues & everything works as expected
