### PR TITLE
Ardougne Hard Diary thieving requirement is boostable

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
@@ -344,7 +344,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.MAGIC, 66));
 		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 65, true));
 		reqs.add(new SkillRequirement(Skill.SMITHING, 68, true));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 72));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 72, true));
 
 		reqs.add(monkeyMadness);
 		reqs.add(legendsQuest);


### PR DESCRIPTION
As shown on the wiki, and confirmed personally just a few mins ago