### PR TITLE
fix: widget pack/unpack test failing

### DIFF
--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -52,18 +52,6 @@ public class Utils
 	}
 
 	/**
-	 * Pack a widget group ID (Interface) and widget child ID into a widget ID (Component)
-	 * @param groupId the {@link Interface}
-	 * @param childId the child id
-	 * @return the corresponding {@link Component}
-	 */
-	@Component
-	@SuppressWarnings("MagicConstant")
-	public int packWidget(@Interface int groupId, int childId) {
-		return groupId << 16 | childId;
-	}
-
-	/**
 	 * Unpack a widget ID (Component) into a widget group ID (Interface) and widget child ID
 	 * @param componentId the {@link Component}
 	 * @return the corresponding Interface & Child ID

--- a/src/test/java/com/questhelper/util/UtilsTest.java
+++ b/src/test/java/com/questhelper/util/UtilsTest.java
@@ -9,15 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UtilsTest
 {
 	@Test
-	void pack()
-	{
-		assertEquals(
-			Utils.packWidget(InterfaceID.FAIRY_RING_PANEL, 8),
-			ComponentID.FAIRY_RING_PANEL_FAVORITES
-		);
-	}
-
-	@Test
 	void unpack()
 	{
 		assertEquals(

--- a/src/test/java/com/questhelper/util/UtilsTest.java
+++ b/src/test/java/com/questhelper/util/UtilsTest.java
@@ -2,6 +2,7 @@ package com.questhelper.util;
 
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.WidgetUtil;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,13 +12,12 @@ public class UtilsTest
 	@Test
 	void unpack()
 	{
+		var interfaceID = InterfaceID.CHATBOX;
+		var childID = 1;
+		var componentID = WidgetUtil.packComponentId(interfaceID, childID);
 		assertEquals(
-			Utils.unpackWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_INTERFACE_CONTAINER),
-			Pair.of(164, 69)
-		);
-		assertEquals(
-			Utils.unpackWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP),
-			Pair.of(164, 90)
+			Utils.unpackWidget(componentID),
+			Pair.of(interfaceID, childID)
 		);
 	}
 }


### PR DESCRIPTION
We previously relied on a ComponentID from RuneLite staying constant, which is not the case.
We now build our own ComponentID based on an Interface ID & a Child ID, and test the function with that

I've also removed our packWidget function since it

1. wasn't used
2. is now implemented in RuneLite if we need it going forward
