### PR TITLE
fix:Removed incorrect swing usage when adding quests

### DIFF
--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -299,10 +299,8 @@ public class QuestManager
 				return;
 			}
 			questBankManager.startUpQuest();
-			SwingUtilities.invokeLater(() -> {
-				panel.removeQuest();
-				panel.addQuest(questHelper, true);
-			});
+			panel.removeQuest();
+			panel.addQuest(questHelper, true);
 		}
 		else
 		{


### PR DESCRIPTION
The SwingUtilities usage in adding and removing the sidepanel for quests was unneccesary and resulted in issues for Varbit usage.

fixes #1338