### PR TITLE
feat:Added filters for quests giving/requiring exp in any skill

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -28,6 +28,7 @@ import com.questhelper.panel.questorders.QuestOrders;
 import com.questhelper.questhelpers.QuestDetails;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.quest.QuestRequirement;
 import java.awt.Color;
 import java.util.Arrays;
 import java.util.Collection;
@@ -207,27 +208,6 @@ public interface QuestHelperConfig extends Config
 			return Arrays.stream(QuestFilter.values()).filter((questFilter -> questFilter.shouldDisplay)).toArray(QuestFilter[]::new);
 		}
 	}
-
-	Predicate<QuestHelper> filterOutSkillsNeeded = (questHelper -> {
-		List<Skill> skillsToFilterOut = Arrays.stream(Skill.values())
-			.filter(skill -> "true".equals(questHelper.getConfigManager().getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilter" + skill.getName())))
-			.collect(Collectors.toList());
-
-		boolean passesAll = true;
-		if (questHelper.getGeneralRequirements() != null)
-		{
-			passesAll = questHelper.getGeneralRequirements().stream()
-				.filter(SkillRequirement.class::isInstance)
-				.map(SkillRequirement.class::cast)
-				.noneMatch(req -> skillsToFilterOut.contains(req.getSkill()));
-		}
-		if (questHelper.getExperienceRewards() != null)
-		{
-			passesAll = passesAll && questHelper.getExperienceRewards().stream()
-				.noneMatch(req -> skillsToFilterOut.contains(req.getSkill()));
-		}
-		return passesAll;
-	});
 
 	enum NpcHighlightStyle
 	{

--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -167,7 +167,7 @@ public interface QuestHelperConfig extends Config
 		@Getter
 		private final String displayName;
 
-		protected final boolean shouldDisplay;
+		private final boolean shouldDisplay;
 
 		QuestFilter(Predicate<QuestHelper> predicate)
 		{

--- a/src/main/java/com/questhelper/config/SkillFiltering.java
+++ b/src/main/java/com/questhelper/config/SkillFiltering.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2024, Harrison Tarr <https://github.com/harrison-tarr>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.config;
+
+import com.questhelper.QuestHelperConfig;
+import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.questinfo.QuestHelperQuest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.runelite.api.Skill;
+
+public class SkillFiltering
+{
+	/**
+	 * Recursively get all quest requirements
+	 *
+	 * @param questHelper the quest to be tested
+	 * @return a boolean indicating if any of the quests give defense experience
+	 */
+	public static boolean passesSkillFilter(QuestHelper questHelper)
+	{
+		if (!questPassesSkillFilter(questHelper))
+		{
+			return false;
+		}
+		List<QuestRequirement> questRequirements = questHelper.getGeneralRequirements() != null
+			? questHelper.getGeneralRequirements().stream()
+			.filter(QuestRequirement.class::isInstance)
+			.map(QuestRequirement.class::cast)
+			.collect(Collectors.toList())
+			: Collections.emptyList();
+
+		if (questRequirements.isEmpty())
+		{
+			return true;
+		}
+		else
+		{
+			return questRequirements.stream()
+				.map(QuestRequirement::getQuest)
+				.map(QuestHelperQuest::getQuestHelper)
+				.allMatch(SkillFiltering::passesSkillFilter);
+		}
+	}
+
+	public static boolean questPassesSkillFilter(QuestHelper questHelper)
+	{
+		List<Skill> skillsToFilterOut = Arrays.stream(Skill.values())
+			.filter(skill -> "true".equals(questHelper.getConfigManager().getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilter" + skill.getName())))
+			.collect(Collectors.toList());
+
+		boolean passesAll = true;
+		if (questHelper.getGeneralRequirements() != null)
+		{
+			passesAll = questHelper.getGeneralRequirements().stream()
+				.filter(SkillRequirement.class::isInstance)
+				.map(SkillRequirement.class::cast)
+				.noneMatch(req -> skillsToFilterOut.contains(req.getSkill()));
+		}
+		if (passesAll && questHelper.getExperienceRewards() != null)
+		{
+			passesAll = questHelper.getExperienceRewards().stream()
+				.noneMatch(req -> skillsToFilterOut.contains(req.getSkill()));
+		}
+		return passesAll;
+	}
+}

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -27,6 +27,7 @@ package com.questhelper.managers;
 
 import com.questhelper.QuestHelperConfig;
 import com.questhelper.QuestHelperPlugin;
+import com.questhelper.config.SkillFiltering;
 import com.questhelper.panel.QuestHelperPanel;
 import com.questhelper.questhelpers.QuestDetails;
 import com.questhelper.questhelpers.QuestHelper;
@@ -235,7 +236,7 @@ public class QuestManager
 				.filter(config.filterListBy())
 				.filter(config.difficulty())
 				.filter(QuestDetails::showCompletedQuests)
-				.filter(config.filterOutSkillsNeeded)
+				.filter(SkillFiltering::passesSkillFilter)
 				.sorted(config.orderListBy())
 				.collect(Collectors.toList());
 			Map<QuestHelperQuest, QuestState> completedQuests = QuestHelperQuest.getQuestHelpers()

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -235,6 +235,7 @@ public class QuestManager
 				.filter(config.filterListBy())
 				.filter(config.difficulty())
 				.filter(QuestDetails::showCompletedQuests)
+				.filter(config.filterOutSkillsNeeded)
 				.sorted(config.orderListBy())
 				.collect(Collectors.toList());
 			Map<QuestHelperQuest, QuestState> completedQuests = QuestHelperQuest.getQuestHelpers()

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -25,6 +25,7 @@
 package com.questhelper.panel;
 
 import com.questhelper.managers.QuestManager;
+import com.questhelper.panel.skillfiltering.SkillFilterPanel;
 import com.questhelper.tools.Icon;
 import com.questhelper.QuestHelperConfig;
 import com.questhelper.QuestHelperPlugin;
@@ -38,12 +39,15 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.event.ItemEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -73,8 +77,8 @@ public class QuestHelperPanel extends PluginPanel
 	private final QuestOverviewPanel questOverviewPanel;
 	private final FixedWidthPanel questOverviewWrapper = new FixedWidthPanel();
 
-	private JPanel allQuestsCompletedPanel = new JPanel();
-	private JPanel searchQuestsPanel;
+	private final JPanel allQuestsCompletedPanel = new JPanel();
+	private final JPanel searchQuestsPanel;
 
 	private final JPanel allDropdownSections = new JPanel();
 	private final JComboBox<Enum> filterDropdown, difficultyDropdown, orderDropdown;
@@ -83,7 +87,7 @@ public class QuestHelperPanel extends PluginPanel
 	private final FixedWidthPanel questListPanel = new FixedWidthPanel();
 	private final FixedWidthPanel questListWrapper = new FixedWidthPanel();
 	private final JScrollPane scrollableContainer;
-	public static final int DROPDOWN_HEIGHT = 20;
+	public static final int DROPDOWN_HEIGHT = 26;
 //	private boolean settingsPanelActive = false;
 	public boolean questActive = false;
 
@@ -97,6 +101,8 @@ public class QuestHelperPanel extends PluginPanel
 	private static final ImageIcon GITHUB_ICON;
 	private static final ImageIcon PATREON_ICON;
 	private static final ImageIcon SETTINGS_ICON;
+	private static final ImageIcon COLLAPSED_ICON;
+	private static final ImageIcon EXPANDED_ICON;
 
 	static
 	{
@@ -104,6 +110,8 @@ public class QuestHelperPanel extends PluginPanel
 		GITHUB_ICON = Icon.GITHUB.getIcon(img -> ImageUtil.resizeImage(img, 16, 16));
 		PATREON_ICON = Icon.PATREON.getIcon(img -> ImageUtil.resizeImage(img, 16, 16));
 		SETTINGS_ICON = Icon.SETTINGS.getIcon(img -> ImageUtil.resizeImage(img, 16, 16));
+		COLLAPSED_ICON = Icon.COLLAPSED.getIcon();
+		EXPANDED_ICON = Icon.EXPANDED.getIcon();
 	}
 
 	public QuestHelperPanel(QuestHelperPlugin questHelperPlugin, QuestManager questManager)
@@ -300,11 +308,50 @@ public class QuestHelperPanel extends PluginPanel
 		JPanel orderPanel = makeDropdownPanel(orderDropdown, "Ordering");
 		orderPanel.setPreferredSize(new Dimension(PANEL_WIDTH, DROPDOWN_HEIGHT));
 
+		// Skill filtering
+		SkillFilterPanel skillFilterPanel = new SkillFilterPanel(questHelperPlugin.skillIconManager, questHelperPlugin.getConfigManager());
+		skillFilterPanel.setVisible(false);
+
+		JLabel filterName = new JLabel("Skill filtering");
+		filterName.setForeground(Color.WHITE);
+		JLabel skillExpandButton = new JLabel();
+		skillExpandButton.setIcon(COLLAPSED_ICON);
+
+		JPanel skillExpandBar = new JPanel();
+		skillExpandBar.setLayout(new BorderLayout());
+		skillExpandBar.setToolTipText("Choose skills to hide quests which would require them or reward experience in them");
+		skillExpandBar.add(filterName, BorderLayout.CENTER);
+		skillExpandBar.add(skillExpandButton, BorderLayout.EAST);
+
+		JPanel skillsFilterPanel = new JPanel();
+		skillsFilterPanel.setLayout(new BorderLayout());
+		skillsFilterPanel.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
+		skillsFilterPanel.add(skillExpandBar, BorderLayout.CENTER);
+		skillsFilterPanel.add(skillFilterPanel, BorderLayout.SOUTH);
+		skillExpandBar.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				skillFilterPanel.setVisible(!skillFilterPanel.isVisible());
+				if (skillFilterPanel.isVisible())
+				{
+					skillExpandButton.setIcon(EXPANDED_ICON);
+				}
+				else
+				{
+					skillExpandButton.setIcon(COLLAPSED_ICON);
+				}
+			}
+		});
+
+		// Filter dropdown + search
+		allDropdownSections.setLayout(new BoxLayout(allDropdownSections, BoxLayout.Y_AXIS));
 		allDropdownSections.setBorder(new EmptyBorder(0, 0, 10, 0));
-		allDropdownSections.setLayout(new BorderLayout(0, BORDER_OFFSET));
-		allDropdownSections.add(filtersPanel, BorderLayout.NORTH);
-		allDropdownSections.add(difficultyPanel, BorderLayout.CENTER);
-		allDropdownSections.add(orderPanel, BorderLayout.SOUTH);
+		allDropdownSections.add(filtersPanel);
+		allDropdownSections.add(difficultyPanel);
+		allDropdownSections.add(orderPanel);
+		allDropdownSections.add(skillsFilterPanel);
 
 		searchQuestsPanel.add(allDropdownSections, BorderLayout.NORTH);
 
@@ -315,6 +362,8 @@ public class QuestHelperPanel extends PluginPanel
 		scrollableContainer = new JScrollPane(questListWrapper);
 		scrollableContainer.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 
+
+		// Finishing off head panel
 		JPanel introDetailsPanel = new JPanel();
 		introDetailsPanel.setLayout(new BorderLayout());
 		introDetailsPanel.add(titlePanel, BorderLayout.NORTH);
@@ -374,7 +423,8 @@ public class QuestHelperPanel extends PluginPanel
 
 		JPanel filtersPanel = new JPanel();
 		filtersPanel.setLayout(new BorderLayout());
-		filtersPanel.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
+		filtersPanel.setBorder(new EmptyBorder(0, 0, BORDER_OFFSET, 0));
+		filtersPanel.setMinimumSize(new Dimension(PANEL_WIDTH, BORDER_OFFSET));
 		filtersPanel.add(filterName, BorderLayout.CENTER);
 		filtersPanel.add(dropdown, BorderLayout.EAST);
 

--- a/src/main/java/com/questhelper/panel/skillfiltering/SkillFilterPanel.java
+++ b/src/main/java/com/questhelper/panel/skillfiltering/SkillFilterPanel.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.panel.skillfiltering;
+
+import com.questhelper.QuestHelperConfig;
+import java.awt.Color;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import com.google.inject.Singleton;
+import net.runelite.api.Skill;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.SkillIconManager;
+import net.runelite.client.ui.ColorScheme;
+
+@Singleton
+public class SkillFilterPanel extends JPanel
+{
+	private final SkillIconManager iconManager;
+	private final SkillTabGroup tabGroup;
+
+	private final ConfigManager configManager;
+
+	public SkillFilterPanel(SkillIconManager iconManager, ConfigManager configManager)
+	{
+		super();
+
+		this.iconManager = iconManager;
+		this.configManager = configManager;
+
+		setBorder(new EmptyBorder(10, 10, 10, 10));
+		setLayout(new GridBagLayout());
+
+		GridBagConstraints c = new GridBagConstraints();
+		c.fill = GridBagConstraints.HORIZONTAL;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.gridy = 0;
+
+		tabGroup = new SkillTabGroup();
+		tabGroup.setLayout(new GridLayout(0, 6, 7, 7));
+
+		addSkillIcons();
+
+		add(tabGroup, c);
+		c.gridy++;
+	}
+
+	private void addSkillIcons()
+	{
+		for (Skill skill : Skill.values())
+		{
+			ImageIcon icon = new ImageIcon(iconManager.getSkillImage(skill, true));
+			SkillIconLabel tab = new SkillIconLabel(icon, configManager, skill.getName());
+
+			tabGroup.addTab(tab);
+		}
+	}
+}

--- a/src/main/java/com/questhelper/panel/skillfiltering/SkillIconLabel.java
+++ b/src/main/java/com/questhelper/panel/skillfiltering/SkillIconLabel.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.panel.skillfiltering;
+
+import com.questhelper.QuestHelperConfig;
+import java.awt.Color;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.border.Border;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.ui.ColorScheme;
+
+public class SkillIconLabel extends JLabel
+{
+	private static final Border ICON_BORDER = BorderFactory
+		.createEmptyBorder(5, 10, 5, 10);
+
+	final Color FILTERED_COLOR = Color.RED.darker();
+	final Color NOT_FILTERED_COLOR = ColorScheme.DARKER_GRAY_COLOR;
+	public SkillIconLabel(ImageIcon icon, ConfigManager configManager, String skillName)
+	{
+		super();
+		setIcon(icon);
+		setOpaque(true);
+		setVerticalAlignment(SwingConstants.CENTER);
+		setHorizontalAlignment(SwingConstants.CENTER);
+		setBorder(ICON_BORDER);
+		setToolTipText("Hide quests that'd require or reward experience in " + skillName);
+
+		if (isFiltered(configManager, skillName))
+		{
+			setToolTipText("Show quests that'd require or reward experience in " + skillName);
+			setBackground(FILTERED_COLOR);
+		}
+		else
+		{
+			setToolTipText("Hide quests that'd require or reward experience in " + skillName);
+			setBackground(NOT_FILTERED_COLOR);
+		}
+
+		addMouseListener(new MouseAdapter()
+		{
+			private Color currentColor = getBackground();
+
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+
+				if (isFiltered(configManager, skillName))
+				{
+					currentColor = NOT_FILTERED_COLOR;
+					setBackground(currentColor);
+					configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilter" + skillName, "false");
+					setToolTipText("Hide quests that'd require or reward experience in " + skillName);
+				}
+				else
+				{
+					currentColor = FILTERED_COLOR;
+					setBackground(currentColor);
+					configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilter" + skillName, "true");
+					setToolTipText("Show quests that'd require or reward experience in " + skillName);
+				}
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				setBackground(currentColor.brighter());
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				setBackground(currentColor);
+			}
+		});
+	}
+
+	public boolean isFiltered(ConfigManager configManager, String skillName)
+	{
+		String isFiltered = configManager.getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilter" + skillName);
+		return "true".equals(isFiltered);
+	}
+}

--- a/src/main/java/com/questhelper/panel/skillfiltering/SkillTabGroup.java
+++ b/src/main/java/com/questhelper/panel/skillfiltering/SkillTabGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Zoinkwiz
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,51 +22,40 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.questhelper.rewards;
+package com.questhelper.panel.skillfiltering;
 
-import java.util.Locale;
-import javax.annotation.Nonnull;
-import lombok.Getter;
-import net.runelite.api.Skill;
-import net.runelite.client.util.QuantityFormatter;
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JPanel;
 
-public class ExperienceReward implements Reward
+public class SkillTabGroup extends JPanel
 {
-	@Getter
-    private final Skill skill;
-    private final int experience;
-	/**
-	 * Set to true if this experience reward is provided in the form of a single-skill XP lamp
-	 */
-	private final boolean lamp;
+	/* The panel on which the content tab's content will be displayed on. */
+	private final JPanel display;
+	/* A list of all the tabs contained in this group. */
+	private final List<SkillIconLabel> tabs = new ArrayList<>();
 
-    public ExperienceReward(Skill skill, int experience)
-    {
-		this(skill, experience, false);
-    }
-
-	public ExperienceReward(Skill skill, int experience, boolean lamp)
+	public SkillTabGroup(JPanel display)
 	{
-		this.skill = skill;
-		this.experience = experience;
-		this.lamp = lamp;
+		this.display = display;
+		if (display != null)
+		{
+			this.display.setLayout(new BorderLayout());
+		}
+		setLayout(new FlowLayout(FlowLayout.CENTER, 8, 0));
+		setOpaque(false);
 	}
 
-    @Nonnull
-    @Override
-    public RewardType rewardType()
-    {
-        return RewardType.EXPERIENCE;
-    }
+	public SkillTabGroup()
+	{
+		this(null);
+	}
 
-    @Nonnull
-    @Override
-    public String getDisplayText()
-    {
-		if (lamp) {
-			return  QuantityFormatter.formatNumber(experience) + " " + Character.toUpperCase(skill.name().charAt(0)) + skill.name().toLowerCase(Locale.ROOT).substring(1) + " Experience Lamp";
-		} else {
-			return  QuantityFormatter.formatNumber(experience) + " " + Character.toUpperCase(skill.name().charAt(0)) + skill.name().toLowerCase(Locale.ROOT).substring(1) + " Experience";
-		}
-    }
+	public void addTab(SkillIconLabel tab)
+	{
+		tabs.add(tab);
+		add(tab, BorderLayout.NORTH);
+	}
 }

--- a/src/test/java/com/questhelper/helpers/quests/pures/OneDefPureTest.java
+++ b/src/test/java/com/questhelper/helpers/quests/pures/OneDefPureTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2024, Harrison Tarr <https://github.com/harrison-tarr>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.helpers.quests.pures;
+
+import com.questhelper.MockedTestBase;
+import com.questhelper.QuestHelperConfig;
+import com.questhelper.config.SkillFiltering;
+import com.questhelper.helpers.quests.childrenofthesun.ChildrenOfTheSun;
+import com.questhelper.helpers.quests.deserttreasure.DesertTreasure;
+import com.questhelper.helpers.quests.fairytalei.FairytaleI;
+import com.questhelper.helpers.quests.legendsquest.LegendsQuest;
+import com.questhelper.helpers.quests.naturespirit.NatureSpirit;
+import com.questhelper.helpers.quests.waterfallquest.WaterfallQuest;
+import com.questhelper.questhelpers.QuestHelper;
+import net.runelite.client.config.ConfigManager;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.anyString;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OneDefPureTest extends MockedTestBase
+{
+	private ConfigManager configManager;
+
+	@BeforeEach
+	public void setup()
+	{
+		configManager = mock(ConfigManager.class);
+		when(configManager.getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilterDefence")).thenReturn("true");
+		when(configManager.getConfiguration(anyString(), anyString())).thenReturn("false");
+	}
+
+	private QuestHelper setupQuest(QuestHelper questHelper)
+	{
+		QuestHelper qh = Mockito.spy(questHelper);
+		doReturn(configManager).when(qh).getConfigManager();
+		return qh;
+	}
+
+	@Test
+	public void testChildrenOfTheSunPassesSkillFilter_WithDefenceFilteredOut()
+	{
+		ChildrenOfTheSun childrenOfTheSun = new ChildrenOfTheSun();
+		QuestHelper questHelperSpy = setupQuest(childrenOfTheSun);
+
+		boolean result = SkillFiltering.questPassesSkillFilter(questHelperSpy);
+		assertTrue(result, "Children of the Sun should pass the skill filter with Defence skill filtered out.");
+	}
+
+	@Test
+	public void testWaterfallQuestPassesSkillFilter_WithDefenceFilteredOut()
+	{
+		WaterfallQuest waterfallQuest = new WaterfallQuest();
+		QuestHelper questHelperSpy = setupQuest(waterfallQuest);
+
+		boolean result = SkillFiltering.questPassesSkillFilter(questHelperSpy);
+		assertTrue(result, "Waterfall Quest should pass the skill filter with Defence skill filtered out.");
+	}
+
+	@Test
+	public void testNatureSpiritPassesSkillFilter_WithDefenceFilteredOut()
+	{
+		NatureSpirit natureSpirit = new NatureSpirit();
+		QuestHelper questHelperSpy = setupQuest(natureSpirit);
+
+		boolean result = SkillFiltering.questPassesSkillFilter(questHelperSpy);
+		assertTrue(result, "Nature Spirit should pass the skill filter with Defence skill filtered out.");
+	}
+
+	@Test
+	public void testFairytaleIPassesSkillFilter_WithDefenceFilteredOut()
+	{
+		FairytaleI fairyTale1 = new FairytaleI();
+		QuestHelper questHelperSpy = setupQuest(fairyTale1);
+
+		boolean result = SkillFiltering.questPassesSkillFilter(questHelperSpy);
+		assertTrue(result, "Fairy Tale I should pass the skill filter with Defence skill filtered out.");
+	}
+
+	@Test
+	public void testDesertTreasurePassesSkillFilter_WithDefenceFilteredOut()
+	{
+		DesertTreasure desertTreasure = new DesertTreasure();
+		QuestHelper questHelperSpy = setupQuest(desertTreasure);
+
+		boolean result = SkillFiltering.questPassesSkillFilter(questHelperSpy);
+		assertTrue(result, "Desert Treasure should pass the skill filter with Defence skill filtered out.");
+	}
+
+	@Test
+	public void testLegendsQuestPassesSkillFilter_WithDefenceFilteredOut()
+	{
+		LegendsQuest legendsQuest = new LegendsQuest();
+		QuestHelper questHelperSpy = setupQuest(legendsQuest);
+
+		boolean result = SkillFiltering.questPassesSkillFilter(questHelperSpy);
+		assertTrue(result, "Legends' Quest should pass the skill filter with Defence skill filtered out.");
+	}
+}


### PR DESCRIPTION
This is somewhat an inverse implementation of https://github.com/Zoinkwiz/quest-helper/pull/1283, where this would work to filter out quests with skill requirements/rewards. It could still be used for the intent of only showing quests requiring/rewarding X, but it means it should also be useful for various limited accounts as well.