### PR TITLE
feat:Added click to load quest option on quest reqs

### DIFF
--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -481,7 +481,7 @@ public class QuestOverviewPanel extends JPanel
 		{
 			for (Requirement generalRecommend : requirements)
 			{
-				QuestRequirementPanel reqPanel = new QuestRequirementPanel(generalRecommend);
+				QuestRequirementPanel reqPanel = new QuestRequirementPanel(generalRecommend, questManager);
 				panels.add(reqPanel);
 				listPanel.add(new QuestRequirementWrapperPanel(reqPanel));
 
@@ -503,7 +503,7 @@ public class QuestOverviewPanel extends JPanel
 		{
 			for (Requirement generalRecommend : requirements)
 			{
-				QuestRequirementPanel reqPanel = new QuestRequirementPanel(generalRecommend);
+				QuestRequirementPanel reqPanel = new QuestRequirementPanel(generalRecommend, questManager);
 				panels.add(reqPanel);
 				listPanel.add(new QuestRequirementWrapperPanel(reqPanel));
 
@@ -598,7 +598,7 @@ public class QuestOverviewPanel extends JPanel
 			public void mouseEntered(java.awt.event.MouseEvent evt)
 			{
 				wikiBtn.setForeground(Color.blue.brighter().brighter().brighter());
-				wikiBtn.setText("<html><body style = 'text-decoration:underline'>Open RuneScape Wiki</body></html>");
+				wikiBtn.setText("<html><body style='text-decoration:underline'>Open RuneScape Wiki</body></html>");
 			}
 
 			public void mouseExited(java.awt.event.MouseEvent evt)

--- a/src/main/java/com/questhelper/panel/QuestRequirementPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRequirementPanel.java
@@ -24,6 +24,9 @@
  */
 package com.questhelper.panel;
 
+import com.questhelper.managers.QuestManager;
+import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.tools.Icon;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.Requirement;
@@ -50,7 +53,7 @@ public class QuestRequirementPanel extends JPanel
 	@Getter
 	private final Requirement requirement;
 
-	public QuestRequirementPanel(Requirement requirement)
+	public QuestRequirementPanel(Requirement requirement, QuestManager questManager)
 	{
 		this.requirement = requirement;
 
@@ -72,6 +75,7 @@ public class QuestRequirementPanel extends JPanel
 
 		String html1 = "<html><body style='padding: 0px; margin: 0px; width: 140px'>";
 		String html2 = "</body></html>";
+		String html1Underline = "<html><body style='padding: 0px; margin: 0px; width: 140px; text-decoration:underline'>";
 
 		label = new JLabel(html1 + text + html2);
 		label.setForeground(Color.GRAY);
@@ -121,6 +125,28 @@ public class QuestRequirementPanel extends JPanel
 							menu.show(label, e.getX(), e.getY());
 						}
 					}
+				}
+			});
+		}
+		else if (questManager != null && requirement instanceof QuestRequirement)
+		{
+			QuestHelper quest = ((QuestRequirement) requirement).getQuest().getQuestHelper();
+			if (quest.isCompleted()) return;
+			label.addMouseListener(new MouseAdapter()
+			{
+				public void mouseClicked(MouseEvent event)
+				{
+					questManager.setSidebarSelectedQuest(((QuestRequirement) requirement).getQuest().getQuestHelper());
+				}
+
+				public void mouseEntered(MouseEvent evt)
+				{
+					label.setText(html1Underline + text + html2);
+				}
+
+				public void mouseExited(MouseEvent evt)
+				{
+					label.setText(html1 + text + html2);
 				}
 			});
 		}

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -188,7 +188,7 @@ public class QuestStepPanel extends JPanel
 
 		for (Requirement req : reqs)
 		{
-			QuestRequirementPanel reqPanel = new QuestRequirementPanel(req);
+			QuestRequirementPanel reqPanel = new QuestRequirementPanel(req, null);
 			requirementPanels.add(reqPanel);
 			questRequirementsListPanel.add(new QuestRequirementWrapperPanel(reqPanel));
 		}


### PR DESCRIPTION
This should make it easier to go down a quest chain and see what a bottom req is.

This takes on the work started in https://github.com/Zoinkwiz/quest-helper/pull/291 for issue #265. 