### PR TITLE
fix:Allow for decrementing state of quests

### DIFF
--- a/src/main/java/com/questhelper/questhelpers/BasicQuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/BasicQuestHelper.java
@@ -68,7 +68,7 @@ public abstract class BasicQuestHelper extends QuestHelper
 	@Override
 	public boolean updateQuest()
 	{
-		if (var < getVar())
+		if (var != getVar())
 		{
 			var = getVar();
 			shutDownStep();


### PR DESCRIPTION
Usually a quest doesn't have a decrementing value for its state, however for Witch's House and on Quest Speedrunning worlds it can.

This allows for detection of changing state even on the value going down.

fixes #1221