### PR TITLE
Fix quest instruction typo

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/betweenarock/BetweenARock.java
+++ b/src/main/java/com/questhelper/helpers/quests/betweenarock/BetweenARock.java
@@ -370,8 +370,8 @@ public class BetweenARock extends BasicQuestHelper
 
 		assembleSchematic = new PuzzleStep(this, schematicHighlight);
 
-		enterDwarfCaveWithHelmet = new ObjectStep(this, ObjectID.TUNNEL_5008, new WorldPoint(2732, 3713, 0), "Prepare" +
-			" to for a fight, then return to Dondakan.", coins5, goldHelmetEquipped, solvedSchematic, pickaxe,
+		enterDwarfCaveWithHelmet = new ObjectStep(this, ObjectID.TUNNEL_5008, new WorldPoint(2732, 3713, 0),
+			"Prepare for a fight, then return to Dondakan.", coins5, goldHelmetEquipped, solvedSchematic, pickaxe,
 			combatGear, food);
 		enterDwarfCave2WithHelmet = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_5973, new WorldPoint(2781, 10161, 0),
 			"Prepare for a fight, then return to Dondakan.", coins5, goldHelmetEquipped, solvedSchematic, pickaxe,


### PR DESCRIPTION
Problem:
Between A Rock quest has an instruction line that appears to be incorrect and inconsistent with the message in the side panel. 

Solution:
Remove the unexpected word from the string.