### PR TITLE
fix:Add potential fix for state missing in Eadgar's Ruse

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/eadgarsruse/EadgarsRuse.java
+++ b/src/main/java/com/questhelper/helpers/quests/eadgarsruse/EadgarsRuse.java
@@ -152,6 +152,9 @@ public class EadgarsRuse extends BasicQuestHelper
 
 		steps.put(15, talkToCooksAboutGoutweed);
 
+		// This is presumed based on 20 being a missing varp state, and players reporting talking to the cooks first result in a broken state where you need to go talk to Eadgar after
+		steps.put(20, enterTheStronghold);
+
 		ConditionalStep returnToEadgar = new ConditionalStep(this, getCoinsOrBoots);
 		returnToEadgar.addStep(inEadgarsCave, talkToEadgarFromCook);
 		returnToEadgar.addStep(inTrollheimArea, enterEadgarsCaveFromCook);


### PR DESCRIPTION
This 'might' fix the issue reported in #796, based on the [missing weirdgloop state](https://chisel.weirdgloop.org/varbs/display?varplayer=335). Preferably someone can test this before this is merged.

fixes #796