### PR TITLE
feat:Reduced mentions of SoA to exclude side taken

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/defenderofvarrock/DefenderOfVarrock.java
+++ b/src/main/java/com/questhelper/helpers/quests/defenderofvarrock/DefenderOfVarrock.java
@@ -481,10 +481,10 @@ public class DefenderOfVarrock extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.SMITHING, 55, true));
 		req.add(new SkillRequirement(Skill.HUNTER, 52));
 
-		Conditions shieldOfArrav = new Conditions(LogicType.OR, new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED), new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_PHOENIX_GANG, QuestState.FINISHED));
-		shieldOfArrav.setText("Completed Shield of Arrav");
 		//Quest Requirements
-		req.add(shieldOfArrav);
+		Conditions shieldOfArravRequirement = new Conditions(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED));
+		shieldOfArravRequirement.setText("Finished Shield of Arrav");
+		req.add(shieldOfArravRequirement);
 		req.add(new QuestRequirement(QuestHelperQuest.TEMPLE_OF_IKOV, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.BELOW_ICE_MOUNTAIN, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.FAMILY_CREST, QuestState.FINISHED));

--- a/src/main/java/com/questhelper/helpers/quests/defenderofvarrock/DefenderOfVarrock.java
+++ b/src/main/java/com/questhelper/helpers/quests/defenderofvarrock/DefenderOfVarrock.java
@@ -39,7 +39,6 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import static com.questhelper.requirements.util.LogicHelper.and;
 import static com.questhelper.requirements.util.LogicHelper.nor;
 import com.questhelper.requirements.item.TeleportItemRequirement;
-import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
@@ -482,9 +481,7 @@ public class DefenderOfVarrock extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.HUNTER, 52));
 
 		//Quest Requirements
-		Conditions shieldOfArravRequirement = new Conditions(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED));
-		shieldOfArravRequirement.setText("Finished Shield of Arrav");
-		req.add(shieldOfArravRequirement);
+		req.add(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED, "Finished Shield of Arrav"));
 		req.add(new QuestRequirement(QuestHelperQuest.TEMPLE_OF_IKOV, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.BELOW_ICE_MOUNTAIN, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.FAMILY_CREST, QuestState.FINISHED));

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -616,14 +616,9 @@ public class HeroesQuest extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.FISHING, 53, true));
 		req.add(new SkillRequirement(Skill.HERBLORE, 25, true));
 		req.add(new SkillRequirement(Skill.MINING, 50, true));
-		if (isInBlackArmGang)
-		{
-			req.add(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED));
-		}
-		else
-		{
-			req.add(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_PHOENIX_GANG, QuestState.FINISHED));
-		}
+		Conditions shieldOfArravRequirement = new Conditions(new Conditions(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED)));
+		shieldOfArravRequirement.setText("Finished Shield of Arrav");
+		req.add(shieldOfArravRequirement);
 		req.add(new QuestRequirement(QuestHelperQuest.LOST_CITY, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.MERLINS_CRYSTAL, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.DRAGON_SLAYER_I, QuestState.FINISHED));

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -616,9 +616,7 @@ public class HeroesQuest extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.FISHING, 53, true));
 		req.add(new SkillRequirement(Skill.HERBLORE, 25, true));
 		req.add(new SkillRequirement(Skill.MINING, 50, true));
-		Conditions shieldOfArravRequirement = new Conditions(new Conditions(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED)));
-		shieldOfArravRequirement.setText("Finished Shield of Arrav");
-		req.add(shieldOfArravRequirement);
+		req.add(new QuestRequirement(QuestHelperQuest.SHIELD_OF_ARRAV_BLACK_ARM_GANG, QuestState.FINISHED, "Finished Shield of Arrav"));
 		req.add(new QuestRequirement(QuestHelperQuest.LOST_CITY, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.MERLINS_CRYSTAL, QuestState.FINISHED));
 		req.add(new QuestRequirement(QuestHelperQuest.DRAGON_SLAYER_I, QuestState.FINISHED));


### PR DESCRIPTION
Hopefully should result in less confusion on needing to take one side over the other.

Although the check is for the black arm gang, in reality the check will check for the quest overall, not just one side.

fixes #748