### PR TITLE
fix:Ensure general reqs are instantiated for meet req check

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
@@ -262,38 +262,6 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		ratCatchers = new QuestRequirement(QuestHelperQuest.RATCATCHERS, QuestState.IN_PROGRESS);
 		skippyAndMogres = new QuestRequirement(QuestHelperQuest.SKIPPY_AND_THE_MOGRES, QuestState.FINISHED);
 		recDrive = new QuestRequirement(QuestHelperQuest.RECRUITMENT_DRIVE, QuestState.FINISHED);
-
-		generalRequirements = new ArrayList<>();
-
-		generalRequirements.add(new SkillRequirement(Skill.AGILITY, 42, true));
-		generalRequirements.add(new SkillRequirement(Skill.CRAFTING, 40, true));
-		generalRequirements.add(new SkillRequirement(Skill.DEFENCE, 20));
-		if (Utils.getAccountType(client).isAnyIronman())
-		{
-			// 47 Farming is required to get a Watermelon for the "Brain not included" step
-			generalRequirements.add(new SkillRequirement(Skill.FARMING, 47, true));
-
-			// 59 Fletching & 59 Smithing is required to craft a Mithril Grapple
-			generalRequirements.add(new SkillRequirement(Skill.FLETCHING, 59, true));
-			generalRequirements.add(new SkillRequirement(Skill.SMITHING, 59, true));
-		}
-		else
-		{
-			generalRequirements.add(new SkillRequirement(Skill.FARMING, 23, true));
-		}
-		generalRequirements.add(new SkillRequirement(Skill.FIREMAKING, 49, true));
-		generalRequirements.add(new SkillRequirement(Skill.MAGIC, 37, true));
-		generalRequirements.add(new SkillRequirement(Skill.MINING, 40, true));
-		generalRequirements.add(new SkillRequirement(Skill.PRAYER, 10));
-		generalRequirements.add(new SkillRequirement(Skill.RANGED, 19));
-		generalRequirements.add(new SkillRequirement(Skill.SLAYER, 32));
-		generalRequirements.add(new SkillRequirement(Skill.STRENGTH, 37));
-		generalRequirements.add(new SkillRequirement(Skill.THIEVING, 40, true));
-		generalRequirements.add(new SkillRequirement(Skill.WOODCUTTING, 30, true));
-
-		generalRequirements.add(ratCatchers);
-		generalRequirements.add(recDrive);
-		generalRequirements.add(skippyAndMogres);
 	}
 
 	public void loadZones()
@@ -421,9 +389,45 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		return Arrays.asList(faladorTeleport, explorersRing, combatBracelet);
 	}
 
+	public void setupGeneralRequirements()
+	{
+		generalRequirements = new ArrayList<>();
+
+		generalRequirements.add(new SkillRequirement(Skill.AGILITY, 42, true));
+		generalRequirements.add(new SkillRequirement(Skill.CRAFTING, 40, true));
+		generalRequirements.add(new SkillRequirement(Skill.DEFENCE, 20));
+		if (Utils.getAccountType(client).isAnyIronman())
+		{
+			// 47 Farming is required to get a Watermelon for the "Brain not included" step
+			generalRequirements.add(new SkillRequirement(Skill.FARMING, 47, true));
+
+			// 59 Fletching & 59 Smithing is required to craft a Mithril Grapple
+			generalRequirements.add(new SkillRequirement(Skill.FLETCHING, 59, true));
+			generalRequirements.add(new SkillRequirement(Skill.SMITHING, 59, true));
+		}
+		else
+		{
+			generalRequirements.add(new SkillRequirement(Skill.FARMING, 23, true));
+		}
+		generalRequirements.add(new SkillRequirement(Skill.FIREMAKING, 49, true));
+		generalRequirements.add(new SkillRequirement(Skill.MAGIC, 37, true));
+		generalRequirements.add(new SkillRequirement(Skill.MINING, 40, true));
+		generalRequirements.add(new SkillRequirement(Skill.PRAYER, 10));
+		generalRequirements.add(new SkillRequirement(Skill.RANGED, 19));
+		generalRequirements.add(new SkillRequirement(Skill.SLAYER, 32));
+		generalRequirements.add(new SkillRequirement(Skill.STRENGTH, 37));
+		generalRequirements.add(new SkillRequirement(Skill.THIEVING, 40, true));
+		generalRequirements.add(new SkillRequirement(Skill.WOODCUTTING, 30, true));
+
+		generalRequirements.add(ratCatchers);
+		generalRequirements.add(recDrive);
+		generalRequirements.add(skippyAndMogres);
+	}
+
 	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
+		setupGeneralRequirements();
 		return generalRequirements;
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
@@ -85,8 +85,6 @@ public class RFDPiratePete extends BasicQuestHelper
 	//Zones
 	Zone diningRoom, underwater;
 
-	ArrayList<Requirement> generalReqs;
-
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
 	{
@@ -225,15 +223,6 @@ public class RFDPiratePete extends BasicQuestHelper
 		hasCrabMeat = new Conditions(LogicType.OR, crabMeat, groundCrabMeatHighlighted);
 		hasKelp = new Conditions(LogicType.OR, kelp, groundKelpHighlighted);
 
-		generalReqs = new ArrayList<>();
-		generalReqs.add(new SkillRequirement(Skill.COOKING, 31));
-		if (Utils.getAccountType(client).isAnyIronman())
-		{
-			generalReqs.add(new ComplexRequirement(LogicType.OR, "42 Crafting or started Rum Deal for a fishbowl",
-				new SkillRequirement(Skill.CRAFTING, 42, true),
-				new QuestRequirement(QuestHelperQuest.RUM_DEAL, QuestState.IN_PROGRESS)));
-		}
-
 		// 1852 = number of people saved
 		// Talked to cook through base dialog: 1854 0->1
 
@@ -315,6 +304,14 @@ public class RFDPiratePete extends BasicQuestHelper
 	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
+		ArrayList<Requirement> generalReqs = new ArrayList<>();
+		generalReqs.add(new SkillRequirement(Skill.COOKING, 31));
+		if (Utils.getAccountType(client).isAnyIronman())
+		{
+			generalReqs.add(new ComplexRequirement(LogicType.OR, "42 Crafting or started Rum Deal for a fishbowl",
+				new SkillRequirement(Skill.CRAFTING, 42, true),
+				new QuestRequirement(QuestHelperQuest.RUM_DEAL, QuestState.IN_PROGRESS)));
+		}
 		return generalReqs;
 	}
 


### PR DESCRIPTION
Fally medium and RFD Pirate Pete both had their general requirements instantiated in the setupConditions function, which is only called on a quest being loaded up.

This means it wouldn't be initially instantiated for the 'meet reqs' filter, so they'd show incorrectly.