### PR TITLE
fix:Handle incorrect state assumption in AKD

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/akingdomdivided/AKingdomDivided.java
+++ b/src/main/java/com/questhelper/helpers/quests/akingdomdivided/AKingdomDivided.java
@@ -360,10 +360,10 @@ public class AKingdomDivided extends BasicQuestHelper
 		steps.put(124, megaStep);
 
 		// then jagex decides to split speaking to each person as one step
-		steps.put(126, talkToAllLeadersLookoutFinish);
-		steps.put(128, talkToAllLeadersLookoutFinish);
-		steps.put(130, talkToAllLeadersLookoutFinish);
-		steps.put(132, talkToAllLeadersLookoutFinish);
+		steps.put(126, megaStep);
+		steps.put(128, megaStep);
+		steps.put(130, megaStep);
+		steps.put(132, megaStep);
 
 		steps.put(134, new XericsLookoutStepper(this, talkToFulloreAfterHelpingAll, 0));
 		steps.put(136, watchCutsceneAfterHelpingAll);


### PR DESCRIPTION
I haven't been able to test it, but this should handle a scenario where the player can talk to one of the leaders of Kourend before finishing all of their tasks, which'd progress the state. This wasn't then handled correctly.

fixes #697