### PR TITLE
Add quest filter for One def pures

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper;
 
+import com.questhelper.helpers.pures.OneDefPure;
 import com.questhelper.panel.questorders.QuestOrders;
 import com.questhelper.questhelpers.QuestDetails;
 import com.questhelper.questhelpers.QuestHelper;
@@ -157,7 +158,9 @@ public interface QuestHelperConfig extends Config
 		 */
 		SKILL_MEMBERS(QuestDetails.Type.SKILL_P2P),
 
-		PLAYER_MADE_QUESTS("Player-made quests", q -> q.getQuest().getQuestType() == QuestDetails.Type.PLAYER_QUEST);
+		PLAYER_MADE_QUESTS("Player-made quests", q -> q.getQuest().getQuestType() == QuestDetails.Type.PLAYER_QUEST),
+
+		SAFE_FOR_PURES(new OneDefPure()::isSafeForPure);
 
 
 		private final Predicate<QuestHelper> predicate;

--- a/src/main/java/com/questhelper/helpers/pures/OneDefPure.java
+++ b/src/main/java/com/questhelper/helpers/pures/OneDefPure.java
@@ -1,0 +1,55 @@
+package com.questhelper.helpers.pures;
+
+import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.questinfo.QuestHelperQuest;
+import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.rewards.ExperienceReward;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import net.runelite.api.Skill;
+
+public class OneDefPure
+{
+
+
+	public boolean isSafeForPure(QuestHelper questHelper)
+	{
+		return !hasDefenseRewardInQuestChain(questHelper);
+	}
+
+	/**
+	 * Recursively get all quest requirements
+	 *
+	 * @param questHelper the quest to be tested
+	 * @return a boolean indicating if any of the quests give defense experience
+	 */
+	boolean hasDefenseRewardInQuestChain(QuestHelper questHelper)
+	{
+		if (hasDefenseReward(questHelper)) {
+			return true;
+		}
+		List<QuestRequirement> questRequirements = Optional.of(questHelper).map(QuestHelper::getGeneralRequirements).orElse(Collections.emptyList()).stream()
+			.filter(req -> req instanceof QuestRequirement)
+			.map(req -> (QuestRequirement) req)
+			.collect(Collectors.toList());
+		if (questRequirements.isEmpty())
+		{
+			return hasDefenseReward(questHelper);
+		}
+		else
+		{
+			return questRequirements.stream()
+				.map(QuestRequirement::getQuest)
+				.map(QuestHelperQuest::getQuestHelper)
+				.map(this::hasDefenseRewardInQuestChain)
+				.reduce(false, (a, b) -> a || b);
+		}
+	}
+
+	boolean hasDefenseReward(QuestHelper questHelper)
+	{
+		return Optional.of(questHelper).map(QuestHelper::getExperienceRewards).orElse(Collections.emptyList()).stream().map(ExperienceReward::getSkill).anyMatch(Skill.DEFENCE::equals);
+	}
+}

--- a/src/main/java/com/questhelper/rewards/ExperienceReward.java
+++ b/src/main/java/com/questhelper/rewards/ExperienceReward.java
@@ -26,11 +26,13 @@ package com.questhelper.rewards;
 
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 import net.runelite.api.Skill;
 import net.runelite.client.util.QuantityFormatter;
 
 public class ExperienceReward implements Reward
 {
+	@Getter
     private final Skill skill;
     private final int experience;
 	/**

--- a/src/test/java/com/questhelper/helpers/pures/OneDefPureTest.java
+++ b/src/test/java/com/questhelper/helpers/pures/OneDefPureTest.java
@@ -1,0 +1,62 @@
+package com.questhelper.helpers.pures;
+
+
+import com.questhelper.MockedTestBase;
+import com.questhelper.helpers.quests.childrenofthesun.ChildrenOfTheSun;
+import com.questhelper.helpers.quests.deserttreasure.DesertTreasure;
+import com.questhelper.helpers.quests.fairytalei.FairytaleI;
+import com.questhelper.helpers.quests.legendsquest.LegendsQuest;
+import com.questhelper.helpers.quests.naturespirit.NatureSpirit;
+import com.questhelper.helpers.quests.waterfallquest.WaterfallQuest;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OneDefPureTest extends MockedTestBase
+{
+
+	OneDefPure oneDefPure;
+
+	@BeforeEach
+	public void setup()
+	{
+		oneDefPure = new OneDefPure();
+	}
+
+	@Test
+	public void testIsSafeNoRewards()
+	{
+		assertTrue(oneDefPure.isSafeForPure(new ChildrenOfTheSun()));
+	}
+
+	@Test
+	public void testIsSafe()
+	{
+		assertTrue(oneDefPure.isSafeForPure(new WaterfallQuest()));
+	}
+
+	@Test
+	public void natureSpiritNotSafe()
+	{
+		assertFalse(oneDefPure.isSafeForPure(new NatureSpirit()));
+	}
+
+	@Test
+	public void fairyTale1NotSafe()
+	{
+		assertFalse(oneDefPure.isSafeForPure(new FairytaleI()));
+	}
+
+	@Test
+	public void desertTreasureIsSafe()
+	{
+		assertTrue(oneDefPure.isSafeForPure(new DesertTreasure()));
+	}
+
+	@Test
+	public void legendsIsNotSafe()
+	{
+		assertFalse(oneDefPure.isSafeForPure(new LegendsQuest()));
+	}
+}


### PR DESCRIPTION
i've been playing a 1 def pure lately but have been using the quest helper to do quests to unlock things like [Red Book](https://oldschool.runescape.wiki/w/Unholy_book) and [Backpack](https://oldschool.runescape.wiki/w/Ava%27s_accumulator) 

it would be cool if i could sort by optimal quest guide, but also _filter_ to just quests that I can safely do