### PR TITLE
Fix Defender of Varrock smithing requirement.

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/defenderofvarrock/DefenderOfVarrock.java
+++ b/src/main/java/com/questhelper/helpers/quests/defenderofvarrock/DefenderOfVarrock.java
@@ -478,7 +478,7 @@ public class DefenderOfVarrock extends BasicQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 
 		//Skill Requirements
-		req.add(new SkillRequirement(Skill.SMITHING, 55, true));
+		req.add(new SkillRequirement(Skill.SMITHING, 55));
 		req.add(new SkillRequirement(Skill.HUNTER, 52));
 
 		//Quest Requirements


### PR DESCRIPTION
You can't even start Defender of Varrock without 55 Smithing (I sadly just ran into this personally). Wiki also backs this up.