### PR TITLE
fix: Initialize Fairytale II requirements in setupRequirements

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/fairytaleii/FairytaleII.java
+++ b/src/main/java/com/questhelper/helpers/quests/fairytaleii/FairytaleII.java
@@ -172,6 +172,10 @@ public class FairytaleII extends BasicQuestHelper
 	@Override
 	public void setupRequirements()
 	{
+		thievingReq = new SkillRequirement(Skill.THIEVING, 40);
+		farmReq = new SkillRequirement(Skill.FARMING, 49, true);
+		herbReq = new SkillRequirement(Skill.HERBLORE, 57, true);
+
 		dramenOrLunarStaff = new ItemRequirement("Dramen or lunar staff", ItemID.DRAMEN_STAFF).isNotConsumed();
 		dramenOrLunarStaff.addAlternates(ItemID.LUNAR_STAFF);
 		dramenOrLunarStaff.setDisplayMatchedItemName(true);
@@ -208,9 +212,6 @@ public class FairytaleII extends BasicQuestHelper
 		inStarPlane = new ZoneRequirement(starPlane);
 		inGorakPlane = new ZoneRequirement(gorakPlane);
 
-		thievingReq = new SkillRequirement(Skill.THIEVING, 40);
-		farmReq = new SkillRequirement(Skill.FARMING, 49, true);
-		herbReq = new SkillRequirement(Skill.HERBLORE, 57, true);
 
 		// Started, 2333 0->1
 


### PR DESCRIPTION
This ensures they are initialized when quests that have Fairytale II as a requirement might want to see what's required

Fixes https://discord.com/channels/772056816242130964/1225106185158660186

How to reproduce the bug before this PR:

1. Enable the "Show full quest requirements" option
2. Open a helper that has Fairytale II as a pre-requisite (e.g. Kourend & Kebos Medium Diary)
