### PR TITLE
Add a test ensuring requirements from quests are not null

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/herbrun/HerbRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/herbrun/HerbRun.java
@@ -194,12 +194,12 @@ public class HerbRun extends ComplexStateQuestHelper
 				seed.setId(Seed.valueOf(seedName).seedID);
 			} catch (IllegalArgumentException err)
 			{
-				questHelperPlugin.getConfigManager().setRSProfileConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, HERB_SEEDS, Seed.GUAM);
+				configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, HERB_SEEDS, Seed.GUAM);
 			}
 			seed.setName(Text.titleCase(Seed.valueOf(seedName)) + " seed");
 		} else
 		{
-			questHelperPlugin.getConfigManager().setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, HERB_SEEDS, Seed.GUAM);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, HERB_SEEDS, Seed.GUAM);
 		}
 		compost = new ItemRequirement("Compost", ItemCollections.COMPOST);
 		compost.setDisplayMatchedItemName(true);

--- a/src/test/java/com/questhelper/MockedTest.java
+++ b/src/test/java/com/questhelper/MockedTest.java
@@ -26,8 +26,22 @@
 package com.questhelper;
 
 import com.google.inject.testing.fieldbinder.Bind;
+import com.questhelper.managers.QuestOverlayManager;
+import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectManager;
 import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.callback.Hooks;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.overlay.OverlayManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
+import javax.inject.Named;
+import java.util.concurrent.ScheduledExecutorService;
+
 
 /**
  * Based on <a href="https://github.com/pajlads/DinkPlugin/blob/d7c0d4d3f044c25bcff256efc5217955ec1c1494/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java">Dink's MockedNotifierTest</a>
@@ -37,7 +51,51 @@ public abstract class MockedTest extends MockedTestBase
 	@Bind
 	protected Client client = Mockito.mock(Client.class);
 
+	@Bind
+	protected ConfigManager configManager = Mockito.mock(ConfigManager.class);
+
+	@Bind
+	protected ChatMessageManager chatMessageManager = Mockito.mock(ChatMessageManager.class);
+
+	@Bind
+	protected ItemManager itemManager = Mockito.mock(ItemManager.class);
+
+	@Bind
+	protected OverlayManager overlayManager = Mockito.mock(OverlayManager.class);
+
+	@Bind
+	protected QuestHelperConfig questHelperConfig = Mockito.mock(QuestHelperConfig.class);
+
+	@Bind
+	protected QuestOverlayManager questOverlayManager = Mockito.mock(QuestOverlayManager.class);
+
+	@Bind
+	protected RuneliteObjectManager runeliteObjectManager = Mockito.mock(RuneliteObjectManager.class);
+
+	@Bind
+	protected Hooks hooks = Mockito.mock(Hooks.class);
+
+	@Bind
+	protected QuestHelperPlugin questHelperPlugin = Mockito.mock(QuestHelperPlugin.class);
+
+	@Bind
+	protected ClientToolbar clientToolbar = Mockito.mock(ClientToolbar.class);
+
+	@Bind
+	protected ClientThread clientThread = Mockito.mock(ClientThread.class);
+
+	@Bind
+	protected EventBus eventBus = Mockito.mock(EventBus.class);
+
+	@Bind
+	protected ScheduledExecutorService scheduledExecutorService = Mockito.mock(ScheduledExecutorService.class);
+
+	@Bind
+	@Named("developerMode")
+	private boolean developerMode;
+
 	@Override
+	@BeforeEach
 	protected void setUp()
 	{
 		super.setUp();

--- a/src/test/java/com/questhelper/MockedTestBase.java
+++ b/src/test/java/com/questhelper/MockedTestBase.java
@@ -26,6 +26,7 @@
 package com.questhelper;
 
 import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,13 +37,15 @@ import org.mockito.MockitoAnnotations;
  */
 public abstract class MockedTestBase
 {
+	protected Injector injector;
 	private AutoCloseable mocks;
 
 	@BeforeEach
 	protected void setUp()
 	{
 		this.mocks = MockitoAnnotations.openMocks(this);
-		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		this.injector = Guice.createInjector(BoundFieldModule.of(this));
+		this.injector.injectMembers(this);
 	}
 
 	@AfterEach
@@ -50,5 +53,4 @@ public abstract class MockedTestBase
 	{
 		mocks.close();
 	}
-
 }

--- a/src/test/java/com/questhelper/helpers/quests/pures/OneDefPureTest.java
+++ b/src/test/java/com/questhelper/helpers/quests/pures/OneDefPureTest.java
@@ -25,7 +25,7 @@
  */
 package com.questhelper.helpers.quests.pures;
 
-import com.questhelper.MockedTestBase;
+import com.questhelper.MockedTest;
 import com.questhelper.QuestHelperConfig;
 import com.questhelper.config.SkillFiltering;
 import com.questhelper.helpers.quests.childrenofthesun.ChildrenOfTheSun;
@@ -35,24 +35,19 @@ import com.questhelper.helpers.quests.legendsquest.LegendsQuest;
 import com.questhelper.helpers.quests.naturespirit.NatureSpirit;
 import com.questhelper.helpers.quests.waterfallquest.WaterfallQuest;
 import com.questhelper.questhelpers.QuestHelper;
-import net.runelite.client.config.ConfigManager;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class OneDefPureTest extends MockedTestBase
+public class OneDefPureTest extends MockedTest
 {
-	private ConfigManager configManager;
-
 	@BeforeEach
 	public void setup()
 	{
-		configManager = mock(ConfigManager.class);
 		when(configManager.getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilterDefence")).thenReturn("true");
 		when(configManager.getConfiguration(anyString(), anyString())).thenReturn("false");
 	}

--- a/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
+++ b/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
@@ -4,7 +4,6 @@ import com.questhelper.MockedTest;
 import com.questhelper.questinfo.QuestHelperQuest;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
 
 public class QuestHelperTest extends MockedTest
 {
@@ -17,6 +16,7 @@ public class QuestHelperTest extends MockedTest
 			var helper = quest.getQuestHelper();
 			helper.setQuest(quest);
 			this.injector.injectMembers(helper);
+			helper.setQuestHelperPlugin(questHelperPlugin);
 			helper.setupRequirements();
 
 			var itemRecommended = helper.getItemRecommended();

--- a/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
+++ b/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
@@ -1,0 +1,59 @@
+package com.questhelper.questhelpers;
+
+import com.questhelper.MockedTest;
+import com.questhelper.questinfo.QuestHelperQuest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class QuestHelperTest extends MockedTest
+{
+	@Test
+	void ensureRequirementsSetUpBySetupRequirements()
+	{
+		for (var quest : QuestHelperQuest.values())
+		{
+			// Instantiate helper
+			var helper = quest.getQuestHelper();
+			helper.setQuest(quest);
+			this.injector.injectMembers(helper);
+			helper.setupRequirements();
+
+			var itemRecommended = helper.getItemRecommended();
+			if (itemRecommended != null)
+			{
+				for (var requirement : itemRecommended)
+				{
+					assertNotNull(requirement, String.format("Requirement for quest %s must not be null", quest.getName()));
+				}
+			}
+
+			var itemRequirements = helper.getItemRequirements();
+			if (itemRequirements != null)
+			{
+				for (var requirement : itemRequirements)
+				{
+					assertNotNull(requirement, String.format("Requirement for quest %s must not be null", quest.getName()));
+				}
+			}
+
+			var generalRecommended = helper.getGeneralRecommended();
+			if (generalRecommended != null)
+			{
+				for (var requirement : generalRecommended)
+				{
+					assertNotNull(requirement, String.format("Requirement for quest %s must not be null", quest.getName()));
+				}
+			}
+
+			var generalRequirements = helper.getGeneralRequirements();
+			if (generalRequirements != null)
+			{
+				for (var requirement : generalRequirements)
+				{
+					assertNotNull(requirement, String.format("Requirement for quest %s must not be null", quest.getName()));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- **chore: Use `configManager` directly where possible, instead of getting it from QuestHelperPlugin**
- **chore: Allow the injector to be used in tests**
- **chore: Mock a bunch of stuff in MockedTest**
- **chore: Add test for ensuring requirements are set up in the setupRequirements function**

The tests will fail until https://github.com/Zoinkwiz/quest-helper/pull/1519 has been merged in