### PR TITLE
fix: Add bank resetting for Quest Speedrunning worlds

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -73,6 +73,8 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
+import net.runelite.api.WorldType;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.GameStateChanged;
@@ -330,6 +332,14 @@ public class QuestHelperPlugin extends Plugin
 		if (!(client.getGameState() == GameState.LOGGED_IN))
 		{
 			return;
+		}
+
+		if (client.getWorldType().contains(WorldType.QUEST_SPEEDRUNNING)
+			&& event.getVarpId() == VarPlayer.IN_RAID_PARTY
+			&& event.getValue() == 0
+			&& client.getGameState() == GameState.LOGGED_IN)
+		{
+			questBankManager.updateBankForQuestSpeedrunningWorld();
 		}
 
 		questManager.handleVarbitChanged();

--- a/src/main/java/com/questhelper/managers/QuestBankManager.java
+++ b/src/main/java/com/questhelper/managers/QuestBankManager.java
@@ -115,6 +115,11 @@ public class QuestBankManager
 		questBank.updateLocalBank(itemContainer.getItems());
 	}
 
+	public void updateBankForQuestSpeedrunningWorld()
+	{
+		questBank.updateLocalBank(new Item[]{ });
+	}
+
 	public void saveBankToConfig()
 	{
 		questBank.saveBankToConfig();


### PR DESCRIPTION
This current implementation makes use of the IN_RAID_PARTY VarPlayer to determine a quest has been reset, as it shouldn't be used in most circumstances of doing speedrunning, but does get set to 0 for the quests I tested.

Ideally we'd identify a var more correlated to  quest speedrunning.