### PR TITLE
feat: Warn on failed varbit reads

### DIFF
--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -539,7 +539,7 @@ public class QuestBankTab
 			yPos = baseY + 9;
 		}
 
-		boolean hasItem = item.check(client);
+		boolean hasItem = item.check(client, chatMessageManager);
 		int spritePosX = xPos + requirementLength + 10;
 		int spritePosY = yPos;
 		// If required quantity moved down a line, put tick/cross after current quantity

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -88,8 +88,8 @@ public class QuestHelperBankTagService
 			recommendedItems = recommendedItems.stream()
 				.filter(Objects::nonNull)
 				.filter(i -> (!onlyGetMissingItems
-					|| !i.check(plugin.getClient(), false, questBank.getBankItems()))
-					&& i.shouldDisplayText(plugin.getClient()))
+					|| !i.check(plugin.getClient(), plugin.getChatMessageManager(), false, questBank.getBankItems()))
+					&& i.shouldDisplayText(plugin.getClient(), plugin.getChatMessageManager()))
 				.collect(Collectors.toList());
 		}
 
@@ -103,7 +103,7 @@ public class QuestHelperBankTagService
 
 		List<PanelDetails> shouldShowSections = questSections.stream()
 			.filter(panelDetail -> panelDetail.getHideCondition() == null ||
-				!panelDetail.getHideCondition().check(plugin.getClient()))
+				!panelDetail.getHideCondition().check(plugin.getClient(), plugin.getChatMessageManager()))
 			.collect(Collectors.toList());
 
 		for (PanelDetails questSection : shouldShowSections)
@@ -116,8 +116,8 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.check(plugin.getClient(), false, questBank.getBankItems()))
-						&& i.shouldDisplayText(plugin.getClient()))
+						|| !i.check(plugin.getClient(), plugin.getChatMessageManager(), false, questBank.getBankItems()))
+						&& i.shouldDisplayText(plugin.getClient(), plugin.getChatMessageManager()))
 					.collect(Collectors.toList());
 			}
 			List<ItemRequirement> recommendedItemsForSection = new ArrayList<>();
@@ -128,8 +128,8 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.check(plugin.getClient(), false, questBank.getBankItems()))
-						&& i.shouldDisplayText(plugin.getClient()))
+						|| !i.check(plugin.getClient(), plugin.getChatMessageManager(), false, questBank.getBankItems()))
+						&& i.shouldDisplayText(plugin.getClient(), plugin.getChatMessageManager()))
 					.collect(Collectors.toList());
 			}
 
@@ -157,7 +157,7 @@ public class QuestHelperBankTagService
 			if (logicType == LogicType.OR)
 			{
 				List<ItemRequirement> itemsWhichPassReq = requirements.stream()
-					.filter(r -> r.shouldDisplayText(plugin.getClient()))
+					.filter(r -> r.shouldDisplayText(plugin.getClient(), plugin.getChatMessageManager()))
 					.collect(Collectors.toList());
 
 				if (itemsWhichPassReq.isEmpty())
@@ -167,7 +167,7 @@ public class QuestHelperBankTagService
 				else
 				{
 					ItemRequirement match = itemsWhichPassReq.stream()
-						.filter(r -> r.checkBank(plugin.getClient()))
+						.filter(r -> r.checkBank(plugin.getClient(), plugin.getChatMessageManager()))
 						.findFirst()
 						.orElse(itemsWhichPassReq.get(0).named(itemRequirements.getName()));
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
@@ -233,23 +233,23 @@ public class KourendMedium extends ComplexStateQuestHelper
 		}
 
 		travelWithMemoirs.resetDialogSteps();
-		if (memoirArc.check(client))
+		if (memoirArc.check(client, chatMessageManager))
 		{
 			travelWithMemoirs.addDialogStep("'A Dark Disposition' - Arceuus");
 		}
-		if (memoirHos.check(client))
+		if (memoirHos.check(client, chatMessageManager))
 		{
 			travelWithMemoirs.addDialogStep("'Lunch by the Lancalliums' - Hosidius");
 		}
-		if (memoirLova.check(client))
+		if (memoirLova.check(client, chatMessageManager))
 		{
 			travelWithMemoirs.addDialogStep("'Jewellery of Jubilation' - Lovakengj");
 		}
-		if (memoirShay.check(client))
+		if (memoirShay.check(client, chatMessageManager))
 		{
 			travelWithMemoirs.addDialogStep("'History and Hearsay' - Shayzien");
 		}
-		if (memoirPis.check(client))
+		if (memoirPis.check(client, chatMessageManager))
 		{
 			travelWithMemoirs.addDialogStep("'The Fisher's Flute' - Piscarilius");
 		}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -61,6 +61,8 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.questinfo.QuestDescriptor;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.steps.QuestStep;
+import net.runelite.client.chat.ChatMessageManager;
+
 import javax.annotation.Nonnull;
 
 @QuestDescriptor(
@@ -142,7 +144,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		allQuests = new Requirement()
 		{
 			@Override
-			public boolean check(Client client)
+			public boolean check(Client client, ChatMessageManager chatMessageManager)
 			{
 				boolean allQuestsCompleted = true;
 				for (QuestHelperQuest quest : QuestHelperQuest.values())

--- a/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/BarrowsHelper.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/BarrowsHelper.java
@@ -271,7 +271,7 @@ public class BarrowsHelper extends ComplexStateQuestHelper
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		if (inCrypt.check(client))
+		if (inCrypt.check(client, chatMessageManager))
 		{
 			int currentKc = client.getVarpValue(1502);
 			if (lastKc == -1)
@@ -321,12 +321,12 @@ public class BarrowsHelper extends ComplexStateQuestHelper
 
 	private void updateTunnel()
 	{
-		if (inAhrim.check(client)) isAhrimTunnel.setShouldPass(true);
-		if (inDharok.check(client)) isDharokTunnel.setShouldPass(true);
-		if (inVerac.check(client)) isVeracTunnel.setShouldPass(true);
-		if (inGuthan.check(client)) isGuthanTunnel.setShouldPass(true);
-		if (inKaril.check(client)) isKarilTunnel.setShouldPass(true);
-		if (inTorag.check(client)) isToragTunnel.setShouldPass(true);
+		if (inAhrim.check(client, chatMessageManager)) isAhrimTunnel.setShouldPass(true);
+		if (inDharok.check(client, chatMessageManager)) isDharokTunnel.setShouldPass(true);
+		if (inVerac.check(client, chatMessageManager)) isVeracTunnel.setShouldPass(true);
+		if (inGuthan.check(client, chatMessageManager)) isGuthanTunnel.setShouldPass(true);
+		if (inKaril.check(client, chatMessageManager)) isKarilTunnel.setShouldPass(true);
+		if (inTorag.check(client, chatMessageManager)) isToragTunnel.setShouldPass(true);
 	}
 
 	public void setupSteps()

--- a/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/HisFaithfulServants.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/HisFaithfulServants.java
@@ -278,7 +278,7 @@ public class HisFaithfulServants extends BasicQuestHelper
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		if (inCrypt.check(client))
+		if (inCrypt.check(client, chatMessageManager))
 		{
 			List<WorldPoint> barrowsRoute = BarrowsRouteCalculator.startDelving(client);
 			if (barrowsRoute != null)
@@ -316,12 +316,12 @@ public class HisFaithfulServants extends BasicQuestHelper
 
 	private void updateTunnel()
 	{
-		if (inAhrim.check(client)) isAhrimTunnel.setShouldPass(true);
-		if (inDharok.check(client)) isDharokTunnel.setShouldPass(true);
-		if (inVerac.check(client)) isVeracTunnel.setShouldPass(true);
-		if (inGuthan.check(client)) isGuthanTunnel.setShouldPass(true);
-		if (inKaril.check(client)) isKarilTunnel.setShouldPass(true);
-		if (inTorag.check(client)) isToragTunnel.setShouldPass(true);
+		if (inAhrim.check(client, chatMessageManager)) isAhrimTunnel.setShouldPass(true);
+		if (inDharok.check(client, chatMessageManager)) isDharokTunnel.setShouldPass(true);
+		if (inVerac.check(client, chatMessageManager)) isVeracTunnel.setShouldPass(true);
+		if (inGuthan.check(client, chatMessageManager)) isGuthanTunnel.setShouldPass(true);
+		if (inKaril.check(client, chatMessageManager)) isKarilTunnel.setShouldPass(true);
+		if (inTorag.check(client, chatMessageManager)) isToragTunnel.setShouldPass(true);
 	}
 
 	public void setupSteps()

--- a/src/main/java/com/questhelper/helpers/mischelpers/herbrun/HerbRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/herbrun/HerbRun.java
@@ -423,8 +423,8 @@ public class HerbRun extends ComplexStateQuestHelper
 					break;
 			}
 		}
-		Boolean[] seedsNeeded = new Boolean[] {ardougneReady.check(client), catherbyReady.check(client), faladorReady.check(client), farmingGuildReady.check(client), harmonyReady.check(client),
-			morytaniaReady.check(client), hosidiusReady.check(client), trollStrongholdReady.check(client), weissReady.check(client)};
+		Boolean[] seedsNeeded = new Boolean[] {ardougneReady.check(client, chatMessageManager), catherbyReady.check(client, chatMessageManager), faladorReady.check(client, chatMessageManager), farmingGuildReady.check(client, chatMessageManager), harmonyReady.check(client, chatMessageManager),
+			morytaniaReady.check(client, chatMessageManager), hosidiusReady.check(client, chatMessageManager), trollStrongholdReady.check(client, chatMessageManager), weissReady.check(client, chatMessageManager)};
 		int totalSeedsNeeded = (int) Arrays.stream(seedsNeeded)
 			.filter(b -> b)
 			.count();

--- a/src/main/java/com/questhelper/helpers/quests/akingdomdivided/StatuePuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/akingdomdivided/StatuePuzzle.java
@@ -95,7 +95,7 @@ public class StatuePuzzle extends DetailedOwnerStep
 	{
 		if (!readOnce)
 		{
-			if (inLeglessFaunF1.check(client))
+			if (inLeglessFaunF1.check(client, chatMessageManager))
 			{
 				startUpStep(checkPanel);
 			}
@@ -106,30 +106,30 @@ public class StatuePuzzle extends DetailedOwnerStep
 		}
 		else
 		{
-			if (statuesAllValid != null && !statuesAllValid.check(client))
+			if (statuesAllValid != null && !statuesAllValid.check(client, chatMessageManager))
 			{
 				startUpStep(invalidState);
 			}
-			else if (inLeglessFaunF1.check(client))
+			else if (inLeglessFaunF1.check(client, chatMessageManager))
 			{
 				startUpStep(climbDownLeglessFaun);
 			}
 			else
 			{
 				// If conditional exists and
-				if (statueStates[0].check(client))
+				if (statueStates[0].check(client, chatMessageManager))
 				{
 					startUpStep(statueMap.get(cityOrder.get(0)));
 				}
-				else if (statueStates[1].check(client))
+				else if (statueStates[1].check(client, chatMessageManager))
 				{
 					startUpStep(statueMap.get(cityOrder.get(1)));
 				}
-				else if (statueStates[2].check(client))
+				else if (statueStates[2].check(client, chatMessageManager))
 				{
 					startUpStep(statueMap.get(cityOrder.get(2)));
 				}
-				else if (statueStates[3].check(client))
+				else if (statueStates[3].check(client, chatMessageManager))
 				{
 					startUpStep(statueMap.get(cityOrder.get(3)));
 				}

--- a/src/main/java/com/questhelper/helpers/quests/akingdomdivided/StonePuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/akingdomdivided/StonePuzzleStep.java
@@ -100,7 +100,7 @@ public class StonePuzzleStep extends DetailedOwnerStep
 		}
 		else
 		{
-			if (inPanelZone.check(client))
+			if (inPanelZone.check(client, chatMessageManager))
 			{
 
 				startUpStep(checkPanel);

--- a/src/main/java/com/questhelper/helpers/quests/beneathcursedsands/TombRiddle.java
+++ b/src/main/java/com/questhelper/helpers/quests/beneathcursedsands/TombRiddle.java
@@ -102,7 +102,7 @@ public class TombRiddle extends DetailedOwnerStep
 
 		if (currentNorthernEmblem != northernEmblem)
 		{
-			if (!emblems.get(northernEmblem).check(client)) {
+			if (!emblems.get(northernEmblem).check(client, chatMessageManager)) {
 				startUpStep(obtainEmblems);
 			}
 			else
@@ -112,7 +112,7 @@ public class TombRiddle extends DetailedOwnerStep
 		}
 		else if (currentCentreNorthEmblem != centreNorthEmblem)
 		{
-			if (!emblems.get(centreNorthEmblem).check(client))
+			if (!emblems.get(centreNorthEmblem).check(client, chatMessageManager))
 			{
 				startUpStep(obtainEmblems);
 			}
@@ -123,7 +123,7 @@ public class TombRiddle extends DetailedOwnerStep
 		}
 		else if (currentCentreSouthEmblem != centreSouthEmblem)
 		{
-			if (!emblems.get(centreSouthEmblem).check(client))
+			if (!emblems.get(centreSouthEmblem).check(client, chatMessageManager))
 			{
 				startUpStep(obtainEmblems);
 			}
@@ -134,7 +134,7 @@ public class TombRiddle extends DetailedOwnerStep
 		}
 		else if (currentSouthernEmblem != southernEmblem)
 		{
-			if (!emblems.get(southernEmblem).check(client))
+			if (!emblems.get(southernEmblem).check(client, chatMessageManager))
 			{
 				startUpStep(obtainEmblems);
 			}

--- a/src/main/java/com/questhelper/helpers/quests/biohazard/GiveIngredientsToHelpersStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/biohazard/GiveIngredientsToHelpersStep.java
@@ -27,7 +27,6 @@ package com.questhelper.helpers.quests.biohazard;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.steps.DetailedOwnerStep;
-import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.PuzzleWrapperStep;
 import com.questhelper.steps.QuestStep;
@@ -57,15 +56,15 @@ public class GiveIngredientsToHelpersStep extends DetailedOwnerStep
 	@Override
 	protected void updateSteps()
 	{
-		if (sulphuricBroline.check(client))
+		if (sulphuricBroline.check(client, chatMessageManager))
 		{
 			startUpStep(giveHopsBroline);
 		}
-		else if (liquidHoney.check(client))
+		else if (liquidHoney.check(client, chatMessageManager))
 		{
 			startUpStep(giveChancyHoney);
 		}
-		else if (ethenea.check(client))
+		else if (ethenea.check(client, chatMessageManager))
 		{
 			startUpStep(giveVinciEthenea);
 		}
@@ -74,9 +73,9 @@ public class GiveIngredientsToHelpersStep extends DetailedOwnerStep
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		if ((currentStep == giveHopsBroline && !sulphuricBroline.check(client))
-			|| (currentStep == giveChancyHoney && !liquidHoney.check(client))
-		    || (currentStep == giveVinciEthenea && !ethenea.check(client)))
+		if ((currentStep == giveHopsBroline && !sulphuricBroline.check(client, chatMessageManager))
+			|| (currentStep == giveChancyHoney && !liquidHoney.check(client, chatMessageManager))
+		    || (currentStep == giveVinciEthenea && !ethenea.check(client, chatMessageManager)))
 		{
 			updateSteps();
 		}
@@ -90,17 +89,17 @@ public class GiveIngredientsToHelpersStep extends DetailedOwnerStep
 		{
 			int npcID = ((NPC) event.getTarget()).getId();
 
-			if (npcID == NpcID.HOPS && sulphuricBroline.check(client))
+			if (npcID == NpcID.HOPS && sulphuricBroline.check(client, chatMessageManager))
 			{
 				lastNpcInteractedWith = npcID;
 				startUpStep(giveHopsBroline);
 			}
-			else if (npcID == NpcID.CHANCY && liquidHoney.check(client))
+			else if (npcID == NpcID.CHANCY && liquidHoney.check(client, chatMessageManager))
 			{
 				lastNpcInteractedWith = npcID;
 				startUpStep(giveChancyHoney);
 			}
-			else if (npcID == NpcID.DA_VINCI && ethenea.check(client))
+			else if (npcID == NpcID.DA_VINCI && ethenea.check(client, chatMessageManager))
 			{
 				lastNpcInteractedWith = npcID;
 				startUpStep(giveVinciEthenea);

--- a/src/main/java/com/questhelper/helpers/quests/bonevoyage/BoneVoyage.java
+++ b/src/main/java/com/questhelper/helpers/quests/bonevoyage/BoneVoyage.java
@@ -171,7 +171,7 @@ public class BoneVoyage extends BasicQuestHelper
 		sawmillProposal = new ItemRequirement("Sawmill proposal", ItemID.SAWMILL_PROPOSAL);
 		sawmillProposal.setTooltip("You can get another from the sawmill operator near Varrock");
 		sawmillAgreement = new ItemRequirement("Sawmill agreement", ItemID.SAWMILL_AGREEMENT);
-		if (client.getGameState() == GameState.LOGGED_IN && canEnterGuild.check(client))
+		if (client.getGameState() == GameState.LOGGED_IN && canEnterGuild.check(client, chatMessageManager))
 		{
 			sawmillAgreement.setTooltip("You can get another from the sawmill operator in the Woodcutting Guild");
 		}
@@ -211,7 +211,7 @@ public class BoneVoyage extends BasicQuestHelper
 			"Attempt to enter the Woodcutting Guild on Zeah to talk to the guild's sawmill operator.", sawmillProposal);
 
 		talkToOperatorInGuildGeneric = talkToOperatorInGuildFromGate;
-		if (canEnterGuild.check(client))
+		if (canEnterGuild.check(client, chatMessageManager))
 		{
 			talkToOperatorInGuildGeneric = talkToOperatorInGuild;
 		}

--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/WhispererSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/WhispererSteps.java
@@ -759,11 +759,11 @@ public class WhispererSteps extends ConditionalStep
 		super.onGameTick(event);
 		WidgetTextRequirement benchEmpty = new WidgetTextRequirement(229, 1,
 			"You search the workbench, but find nothing of interest.");
-		if (benchEmpty.check(client) && !shadowBlocker.check(client))
+		if (benchEmpty.check(client, chatMessageManager) && !shadowBlocker.check(client, chatMessageManager))
 		{
 			blockerNotInBenchOrInventory.setConfigValue("true");
 		}
-		else if (shadowBlocker.check(client))
+		else if (shadowBlocker.check(client, chatMessageManager))
 		{
 			blockerNotInBenchOrInventory.setConfigValue("false");
 		}

--- a/src/main/java/com/questhelper/helpers/quests/dragonslayerii/CryptPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/dragonslayerii/CryptPuzzle.java
@@ -154,7 +154,7 @@ public class CryptPuzzle extends DetailedOwnerStep
 
 		if (currentNorthBust != northBust)
 		{
-			if (!bustsConditions.get(northBust).check(client))
+			if (!bustsConditions.get(northBust).check(client, chatMessageManager))
 			{
 				startUpStep(getBustSteps.get(northBust));
 			}
@@ -165,7 +165,7 @@ public class CryptPuzzle extends DetailedOwnerStep
 		}
 		else if (currentEastBust != eastBust)
 		{
-			if (!bustsConditions.get(eastBust).check(client))
+			if (!bustsConditions.get(eastBust).check(client, chatMessageManager))
 			{
 				startUpStep(getBustSteps.get(eastBust));
 			}
@@ -176,7 +176,7 @@ public class CryptPuzzle extends DetailedOwnerStep
 		}
 		else if (currentSouthBust != southBust)
 		{
-			if (!bustsConditions.get(southBust).check(client))
+			if (!bustsConditions.get(southBust).check(client, chatMessageManager))
 			{
 				startUpStep(getBustSteps.get(southBust));
 			}
@@ -187,7 +187,7 @@ public class CryptPuzzle extends DetailedOwnerStep
 		}
 		else if (currentWestBust != westBust)
 		{
-			if (!bustsConditions.get(westBust).check(client))
+			if (!bustsConditions.get(westBust).check(client, chatMessageManager))
 			{
 				startUpStep(getBustSteps.get(westBust));
 			}

--- a/src/main/java/com/questhelper/helpers/quests/dreammentor/CyrisusBankConditional.java
+++ b/src/main/java/com/questhelper/helpers/quests/dreammentor/CyrisusBankConditional.java
@@ -26,11 +26,12 @@ package com.questhelper.helpers.quests.dreammentor;
 
 import com.questhelper.requirements.SimpleRequirement;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class CyrisusBankConditional extends SimpleRequirement
 {
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 
 		return CyrisusArmourSet.isReady(client);

--- a/src/main/java/com/questhelper/helpers/quests/eadgarsruse/EadgarsRuse.java
+++ b/src/main/java/com/questhelper/helpers/quests/eadgarsruse/EadgarsRuse.java
@@ -102,7 +102,7 @@ public class EadgarsRuse extends BasicQuestHelper
 		setupRequirements();
 		setupConditions();
 		setupSteps();
-		if (freedEadgar.check(client))
+		if (freedEadgar.check(client, chatMessageManager))
 		{
 			travelToEadgarPanel = new PanelDetails("Travel to Eadgar",
 				Arrays.asList(travelToTenzing, climbOverStile, climbOverRocks, enterSecretEntrance, goUpStairsPrison,

--- a/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/BalloonFlightStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/BalloonFlightStep.java
@@ -86,7 +86,7 @@ public class BalloonFlightStep extends DetailedOwnerStep
 
 	protected void updateSteps()
 	{
-		if (!flying.check(client))
+		if (!flying.check(client, chatMessageManager))
 		{
 			startUpStep(startFlight);
 			return;

--- a/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/GiveAugusteItems.java
+++ b/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/GiveAugusteItems.java
@@ -71,27 +71,27 @@ public class GiveAugusteItems extends NpcStep
 	{
 		emptyRequirements();
 
-		if (!givenRedDye.check(client))
+		if (!givenRedDye.check(client, chatMessageManager))
 		{
 			requirements.add(redDye);
 		}
 
-		if (!givenYellowDye.check(client))
+		if (!givenYellowDye.check(client, chatMessageManager))
 		{
 			requirements.add(yellowDye);
 		}
 
-		if (!givenBowl.check(client))
+		if (!givenBowl.check(client, chatMessageManager))
 		{
 			requirements.add(bowl);
 		}
 
-		if (!givenSandbags.check(client))
+		if (!givenSandbags.check(client, chatMessageManager))
 		{
 			requirements.add(sandbag8);
 		}
 
-		if (!givenSilk.check(client))
+		if (!givenSilk.check(client, chatMessageManager))
 		{
 			requirements.add(silk10);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/helpers/quests/forgettabletale/ForgettableTale.java
@@ -636,37 +636,37 @@ public class ForgettableTale extends BasicQuestHelper
 		goUpToDirector = new ObjectStep(this, ObjectID.STAIRS_6087, new WorldPoint(2895, 10210, 0),
 			"Go up to the Consortium.");
 
-		if (inPurple.check(client))
+		if (inPurple.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.PURPLE_PEWTER_DIRECTOR_5998, new WorldPoint(2869, 10195, 1),
 				"Talk to the Purple Pewter Director.");
 		}
-		else if (inYellow.check(client))
+		else if (inYellow.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.YELLOW_FORTUNE_DIRECTOR_6000, new WorldPoint(2869, 10208, 1),
 				"Talk to the Yellow Fortune Director.");
 		}
-		else if (inBlue.check(client))
+		else if (inBlue.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.BLUE_OPAL_DIRECTOR_5999, new WorldPoint(2869, 10203, 1),
 				"Talk to the Blue Opal Director.");
 		}
-		else if (inGreen.check(client))
+		else if (inGreen.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.GREEN_GEMSTONE_DIRECTOR_6021, new WorldPoint(2890, 10209, 1),
 				"Talk to the Green Gemstone Director.");
 		}
-		else if (inWhite.check(client))
+		else if (inWhite.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.WHITE_CHISEL_DIRECTOR_6022, new WorldPoint(2890, 10204, 1),
 				"Talk to the White Chisel Director.");
 		}
-		else if (inSilver.check(client))
+		else if (inSilver.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.SILVER_COG_DIRECTOR_6023, new WorldPoint(2890, 10194, 1),
 				"Talk to the Silver Cog Director.");
 		}
-		else if (inBrown.check(client))
+		else if (inBrown.check(client, chatMessageManager))
 		{
 			talkToDirector = new NpcStep(this, NpcID.BROWN_ENGINE_DIRECTOR_6024, new WorldPoint(2890, 10189, 1),
 				"Talk to the Brown Engine Director.");

--- a/src/main/java/com/questhelper/helpers/quests/ghostsahoy/DyeShipSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/ghostsahoy/DyeShipSteps.java
@@ -159,11 +159,11 @@ public class DyeShipSteps extends DetailedOwnerStep
 		}
 		if (!coloursKnown)
 		{
-			if (onDeck.check(client))
+			if (onDeck.check(client, chatMessageManager))
 			{
 				startUpStep(goUpToMast);
 			}
-			else if (onTopOfShip.check(client))
+			else if (onTopOfShip.check(client, chatMessageManager))
 			{
 				startUpStep(searchMast);
 			}
@@ -186,11 +186,11 @@ public class DyeShipSteps extends DetailedOwnerStep
 		{
 			startUpStep(dyeSkull);
 		}
-		else if (onTopOfShip.check(client))
+		else if (onTopOfShip.check(client, chatMessageManager))
 		{
 			startUpStep(goDownToMan);
 		}
-		else if (onDeck.check(client))
+		else if (onDeck.check(client, chatMessageManager))
 		{
 			startUpStep(talkToMan);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/hazeelcult/HazeelValves.java
+++ b/src/main/java/com/questhelper/helpers/quests/hazeelcult/HazeelValves.java
@@ -65,9 +65,9 @@ public class HazeelValves extends DetailedOwnerStep
 	@Override
 	protected void updateSteps()
 	{
-		if (!solved1.check(client))
+		if (!solved1.check(client, chatMessageManager))
 		{
-			if (atValve1.check(client))
+			if (atValve1.check(client, chatMessageManager))
 			{
 				startUpStep(turnValve1);
 			}
@@ -76,9 +76,9 @@ public class HazeelValves extends DetailedOwnerStep
 				startUpStep(turnValve1NoDialog);
 			}
 		}
-		else if (!solved2.check(client))
+		else if (!solved2.check(client, chatMessageManager))
 		{
-			if (atValve2.check(client))
+			if (atValve2.check(client, chatMessageManager))
 			{
 				startUpStep(turnValve2);
 			}
@@ -87,9 +87,9 @@ public class HazeelValves extends DetailedOwnerStep
 				startUpStep(turnValve2NoDialog);
 			}
 		}
-		else if (!solved3.check(client))
+		else if (!solved3.check(client, chatMessageManager))
 		{
-			if (atValve3.check(client))
+			if (atValve3.check(client, chatMessageManager))
 			{
 				startUpStep(turnValve3);
 			}
@@ -98,9 +98,9 @@ public class HazeelValves extends DetailedOwnerStep
 				startUpStep(turnValve3NoDialog);
 			}
 		}
-		else if (!solved4.check(client))
+		else if (!solved4.check(client, chatMessageManager))
 		{
-			if (atValve4.check(client))
+			if (atValve4.check(client, chatMessageManager))
 			{
 				startUpStep(turnValve4);
 			}
@@ -109,9 +109,9 @@ public class HazeelValves extends DetailedOwnerStep
 				startUpStep(turnValve4NoDialog);
 			}
 		}
-		else if (!solved5.check(client))
+		else if (!solved5.check(client, chatMessageManager))
 		{
-			if (atValve5.check(client))
+			if (atValve5.check(client, chatMessageManager))
 			{
 				startUpStep(turnValve5);
 			}
@@ -159,29 +159,29 @@ public class HazeelValves extends DetailedOwnerStep
 			return;
 		}
 
-		if (atValve1.check(client))
+		if (atValve1.check(client, chatMessageManager))
 		{
 			updateState(!turnedLeft, solved1);
 		}
-		else if (atValve2.check(client))
+		else if (atValve2.check(client, chatMessageManager))
 		{
 			updateState(!turnedLeft, solved2);
 		}
-		else if (atValve3.check(client))
+		else if (atValve3.check(client, chatMessageManager))
 		{
 			updateState(turnedLeft, solved3);
 		}
-		else if (atValve4.check(client))
+		else if (atValve4.check(client, chatMessageManager))
 		{
 			updateState(!turnedLeft, solved4);
 		}
-		else if (atValve5.check(client))
+		else if (atValve5.check(client, chatMessageManager))
 		{
 			updateState(!turnedLeft, solved5);
 		}
 
-		solved.setShouldPass(solved1.check(client) && solved2.check(client) && solved3.check(client)
-			&& solved4.check(client) && solved5.check(client));
+		solved.setShouldPass(solved1.check(client, chatMessageManager) && solved2.check(client, chatMessageManager) && solved3.check(client, chatMessageManager)
+			&& solved4.check(client, chatMessageManager) && solved5.check(client, chatMessageManager));
 
 		updateSteps();
 	}

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -109,7 +109,7 @@ public class HeroesQuest extends BasicQuestHelper
 		setupSteps();
 		Map<Integer, QuestStep> steps = new HashMap<>();
 
-		if (inBlackArmGang.check(client))
+		if (inBlackArmGang.check(client, chatMessageManager))
 		{
 			isInBlackArmGang = true;
 		}
@@ -128,7 +128,7 @@ public class HeroesQuest extends BasicQuestHelper
 		getLavaEel.addStep(blamishSlime, makeBlamishOil);
 		getLavaEel.setLockingCondition(lavaEel);
 
-		if (inBlackArmGang.check(client))
+		if (inBlackArmGang.check(client, chatMessageManager))
 		{
 			thievesArmband.setTooltip("You can get another from Katrine in the Black Arm Gang base.");
 			getThievesArmband = new ConditionalStep(this, talkToKatrine);
@@ -454,7 +454,7 @@ public class HeroesQuest extends BasicQuestHelper
 	{
 		ArrayList<String> reqs = new ArrayList<>();
 		reqs.add("Ice Queen (level 111) for ice gloves");
-		if (!inBlackArmGang.check(client))
+		if (!inBlackArmGang.check(client, chatMessageManager))
 		{
 			reqs.add("Grip (level 26)");
 		}
@@ -470,7 +470,7 @@ public class HeroesQuest extends BasicQuestHelper
 		reqs.add(harralanderUnf);
 		reqs.add(pickaxe);
 		reqs.add(iceGloves);
-		if (inBlackArmGang.check(client))
+		if (inBlackArmGang.check(client, chatMessageManager))
 		{
 			reqs.add(blackFullHelm);
 			reqs.add(blackPlatebody);
@@ -540,7 +540,7 @@ public class HeroesQuest extends BasicQuestHelper
 	public List<String> getNotes()
 	{
 		ArrayList<String> reqs = new ArrayList<>();
-		if (inBlackArmGang.check(client))
+		if (inBlackArmGang.check(client, chatMessageManager))
 		{
 			reqs.add("You will need to find another player who joined the Phoenix Gang during the Shield of Arrav quest to assist you. If one of you is an Ironman, you can use the necessary items on one another to trade them.");
 		}
@@ -564,7 +564,7 @@ public class HeroesQuest extends BasicQuestHelper
 		secondPanel.setLockingStep(getLavaEel);
 		PanelDetails thirdPanel;
 
-		if (inBlackArmGang.check(client))
+		if (inBlackArmGang.check(client, chatMessageManager))
 		{
 			thirdPanel = new PanelDetails("Get thieves' armband",
 				Arrays.asList(talkToKatrine, tryToEnterTrobertHouse, talkToTrobert, enterMansion, talkToGrip, getKeyFromGrip, pickupKey, enterTreasureRoom, searchChest, returnToKatrine),

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/BringLunarItems.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/BringLunarItems.java
@@ -72,35 +72,35 @@ public class BringLunarItems extends NpcStep
 		emptyRequirements();
 		addRequirement(sealOfPassage);
 
-		if (!handedInAmulet.check(client))
+		if (!handedInAmulet.check(client, chatMessageManager))
 		{
 			addRequirement(amulet);
 		}
-		if (!handedInBoots.check(client))
+		if (!handedInBoots.check(client, chatMessageManager))
 		{
 			addRequirement(boots);
 		}
-		if (!handedInCape.check(client))
+		if (!handedInCape.check(client, chatMessageManager))
 		{
 			addRequirement(cape);
 		}
-		if (!handedInGloves.check(client))
+		if (!handedInGloves.check(client, chatMessageManager))
 		{
 			addRequirement(gloves);
 		}
-		if (!handedInHelm.check(client))
+		if (!handedInHelm.check(client, chatMessageManager))
 		{
 			addRequirement(helm);
 		}
-		if (!handedInLegs.check(client))
+		if (!handedInLegs.check(client, chatMessageManager))
 		{
 			addRequirement(legs);
 		}
-		if (!handedInRing.check(client))
+		if (!handedInRing.check(client, chatMessageManager))
 		{
 			addRequirement(ring);
 		}
-		if (!handedInTorso.check(client))
+		if (!handedInTorso.check(client, chatMessageManager))
 		{
 			addRequirement(torso);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/AgilityDungeonSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/AgilityDungeonSteps.java
@@ -288,7 +288,7 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 	private void updateSection1Route()
 	{
 		ArrayList<WorldPoint> newRoute = new ArrayList<>();
-		if(shouldUsePath1V2.check(client))
+		if(shouldUsePath1V2.check(client, chatMessageManager))
 		{
 			newRoute.addAll(path1V2);
 		}
@@ -297,9 +297,9 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 			newRoute.addAll(path1V1);
 		}
 
-		if(shouldUsePath2V2.check(client))
+		if(shouldUsePath2V2.check(client, chatMessageManager))
 		{
-			if (shouldUsePath1V2.check(client))
+			if (shouldUsePath1V2.check(client, chatMessageManager))
 			{
 				newRoute.addAll(pathConnectingPath1V1ToV2);
 			}
@@ -307,7 +307,7 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 		}
 		else
 		{
-			if (!shouldUsePath1V2.check(client))
+			if (!shouldUsePath1V2.check(client, chatMessageManager))
 			{
 				newRoute.addAll(pathConnectingPath1V2ToV1);
 			}
@@ -315,7 +315,7 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 		}
 		newRoute.addAll(pathMaze);
 
-		if(shouldUsePath3V2.check(client))
+		if(shouldUsePath3V2.check(client, chatMessageManager))
 		{
 			newRoute.addAll(path3V2);
 		}
@@ -330,7 +330,7 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 	private void updateSection2Route()
 	{
 		ArrayList<WorldPoint> newRoute = new ArrayList<>();
-		if(shouldUsePath4V2.check(client))
+		if(shouldUsePath4V2.check(client, chatMessageManager))
 		{
 			newRoute.addAll(path4V2);
 			newRoute.addAll(workOutFifthSection(0, new ArrayList<>(), 0));
@@ -345,7 +345,7 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 
 	private void updateSection3Route()
 	{
-		if(shouldUsePath6V2.check(client))
+		if(shouldUsePath6V2.check(client, chatMessageManager))
 		{
 			goToKruk.setLinePoints(pathToKrukV2);
 			goToKruk.setWorldPoint(new WorldPoint(2548, 9225, 1));
@@ -406,8 +406,8 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 		{
 			if (currentNode.getPaths()[i] != null)
 			{
-				if (currentNode.getPaths()[i].getWrongWay().check(client)) routeSavedValues.get(currentNode.getPaths()[i]).setConfigValue("true");
-				if (routeSavedValues.get(currentNode.getPaths()[i]).check(client) && !previousIds.contains(currentNode.getPaths()[i].getIdEnd()))
+				if (currentNode.getPaths()[i].getWrongWay().check(client, chatMessageManager)) routeSavedValues.get(currentNode.getPaths()[i]).setConfigValue("true");
+				if (routeSavedValues.get(currentNode.getPaths()[i]).check(client, chatMessageManager) && !previousIds.contains(currentNode.getPaths()[i].getIdEnd()))
 				{
 					nextNodeId = currentNode.getPaths()[i].getIdEnd();
 					newPoints.addAll(currentNode.getPaths()[i].getPath());
@@ -453,71 +453,71 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 	@Subscribe
 	public void onGameTick(GameTick ignoredEvent)
 	{
-		if (!shouldUsePath1V2.check(client))
+		if (!shouldUsePath1V2.check(client, chatMessageManager))
 		{
-			if (path1SouthIsWrong.check(client)) shouldUsePath1V2.setConfigValue("true");
-			if (shouldUsePath1V2.check(client))
+			if (path1SouthIsWrong.check(client, chatMessageManager)) shouldUsePath1V2.setConfigValue("true");
+			if (shouldUsePath1V2.check(client, chatMessageManager))
 			{
 				updateSection1Route();
 			}
 		}
-		if (!shouldUsePath2V2.check(client))
+		if (!shouldUsePath2V2.check(client, chatMessageManager))
 		{
-			if (path2NorthIsWrong.check(client)) shouldUsePath2V2.setConfigValue("true");
-			if (shouldUsePath2V2.check(client))
+			if (path2NorthIsWrong.check(client, chatMessageManager)) shouldUsePath2V2.setConfigValue("true");
+			if (shouldUsePath2V2.check(client, chatMessageManager))
 			{
 				updateSection1Route();
 			}
 		}
-		if (!shouldUsePath3V2.check(client))
+		if (!shouldUsePath3V2.check(client, chatMessageManager))
 		{
-			if (path3SouthIsWrong.check(client)) shouldUsePath3V2.setConfigValue("true");
-			if (shouldUsePath3V2.check(client))
+			if (path3SouthIsWrong.check(client, chatMessageManager)) shouldUsePath3V2.setConfigValue("true");
+			if (shouldUsePath3V2.check(client, chatMessageManager))
 			{
 				updateSection1Route();
 			}
 		}
 
-		if (!shouldUsePath4V2.check(client))
+		if (!shouldUsePath4V2.check(client, chatMessageManager))
 		{
-			if (path4NorthIsWrong.check(client)) shouldUsePath4V2.setConfigValue("true");
-			if (shouldUsePath4V2.check(client))
+			if (path4NorthIsWrong.check(client, chatMessageManager)) shouldUsePath4V2.setConfigValue("true");
+			if (shouldUsePath4V2.check(client, chatMessageManager))
 			{
 				updateSection2Route();
 			}
 		}
 
-		if (!shouldntUsePath5V1.check(client))
+		if (!shouldntUsePath5V1.check(client, chatMessageManager))
 		{
-			if (path5EastIsWrong.check(client)) shouldntUsePath5V1.setConfigValue("true");
-			if (shouldntUsePath5V1.check(client))
+			if (path5EastIsWrong.check(client, chatMessageManager)) shouldntUsePath5V1.setConfigValue("true");
+			if (shouldntUsePath5V1.check(client, chatMessageManager))
 			{
 				updateSection2Route();
 			}
 		}
 
-		if (!shouldntUsePath5V2.check(client))
+		if (!shouldntUsePath5V2.check(client, chatMessageManager))
 		{
-			if (path5MiddleIsWrong.check(client)) shouldntUsePath5V2.setConfigValue("true");
-			if (shouldntUsePath5V2.check(client))
+			if (path5MiddleIsWrong.check(client, chatMessageManager)) shouldntUsePath5V2.setConfigValue("true");
+			if (shouldntUsePath5V2.check(client, chatMessageManager))
 			{
 				updateSection2Route();
 			}
 		}
 
-		if (!shouldntUsePath5V3.check(client))
+		if (!shouldntUsePath5V3.check(client, chatMessageManager))
 		{
-			if (path5WestIsWrong.check(client)) shouldntUsePath5V3.setConfigValue("true");
-			if (shouldntUsePath5V1.check(client))
+			if (path5WestIsWrong.check(client, chatMessageManager)) shouldntUsePath5V3.setConfigValue("true");
+			if (shouldntUsePath5V1.check(client, chatMessageManager))
 			{
 				updateSection2Route();
 			}
 		}
 
-		if (!shouldUsePath6V2.check(client))
+		if (!shouldUsePath6V2.check(client, chatMessageManager))
 		{
-			if (path6WestIsWrong.check(client)) shouldUsePath6V2.setConfigValue("true");
-			if (shouldUsePath6V2.check(client))
+			if (path6WestIsWrong.check(client, chatMessageManager)) shouldUsePath6V2.setConfigValue("true");
+			if (shouldUsePath6V2.check(client, chatMessageManager))
 			{
 				updateSection3Route();
 			}
@@ -530,9 +530,9 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 	@Override
 	protected void updateSteps()
 	{
-		if (inCavesSection4.check(client))
+		if (inCavesSection4.check(client, chatMessageManager))
 		{
-			if (openedShortcut.check(client))
+			if (openedShortcut.check(client, chatMessageManager))
 			{
 				startUpStep(goToKruk);
 			}
@@ -541,21 +541,21 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 				startUpStep(openShortcut);
 			}
 		}
-		else if (inKrukRoom.check(client))
+		else if (inKrukRoom.check(client,chatMessageManager ))
 		{
 			startUpStep(fightKruk);
 		}
-		else if (openedShortcut.check(client))
+		else if (openedShortcut.check(client,chatMessageManager ))
 		{
 			startUpStep(enterShortcut);
 		}
-		else if (inCavesSection3.check(client))
+		else if (inCavesSection3.check(client, chatMessageManager))
 		{
 			startUpStep(traverseDungeonThirdSection);
 		}
-		else if (inCavesSection2.check(client))
+		else if (inCavesSection2.check(client, chatMessageManager))
 		{
-			if (hasBronzeKey.check(client))
+			if (hasBronzeKey.check(client, chatMessageManager))
 			{
 				startUpStep(openBronzeDoor);
 			}
@@ -564,19 +564,19 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 				startUpStep(getKey);
 			}
 		}
-		else if (inFallArea1.check(client))
+		else if (inFallArea1.check(client, chatMessageManager))
 		{
 			startUpStep(leaveFallArea1);
 		}
-		else if (inFallArea2.check(client))
+		else if (inFallArea2.check(client, chatMessageManager))
 		{
 			startUpStep(leaveFallArea2);
 		}
-		else if (inFallArea3.check(client))
+		else if (inFallArea3.check(client, chatMessageManager))
 		{
 			startUpStep(leaveFallArea3);
 		}
-		else if (inFallArea4.check(client))
+		else if (inFallArea4.check(client, chatMessageManager))
 		{
 			startUpStep(leaveFallArea4);
 		}
@@ -591,26 +591,26 @@ public class AgilityDungeonSteps extends DetailedOwnerStep
 	{
 		if (chatMessage.getType() == ChatMessageType.GAMEMESSAGE)
 		{
-			path1SouthIsWrongChat.validateCondition(client, chatMessage);
-			path2NorthIsWrongChat.validateCondition(client, chatMessage);
-			path2NorthIsWrongChat2.validateCondition(client, chatMessage);
-			path3SouthIsWrongChat.validateCondition(client, chatMessage);
-			path4NorthIsWrongChat.validateCondition(client, chatMessage);
-			path5WestIsWrongChat.validateCondition(client, chatMessage);
-			path5MiddleIsWrongChat.validateCondition(client, chatMessage);
-			path5EastIsWrongChat.validateCondition(client, chatMessage);
-			path5MiddleToEastWrongChat.validateCondition(client, chatMessage);
-			path5MiddleToWestWrongChat.validateCondition(client, chatMessage);
-			path5EastToMiddleWrongChat.validateCondition(client, chatMessage);
-			path5WestToMiddleWrongChat.validateCondition(client, chatMessage);
-			path6WestIsWrongChat.validateCondition(client, chatMessage);
+			path1SouthIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path2NorthIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path2NorthIsWrongChat2.validateCondition(client, chatMessageManager, chatMessage);
+			path3SouthIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path4NorthIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5WestIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5MiddleIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5EastIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5MiddleToEastWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5MiddleToWestWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5EastToMiddleWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path5WestToMiddleWrongChat.validateCondition(client, chatMessageManager, chatMessage);
+			path6WestIsWrongChat.validateCondition(client, chatMessageManager, chatMessage);
 			for (MM2AgilityNodes mm2AgilityNode : fifthSectionMap)
 			{
 				for (int i = 0; i < mm2AgilityNode.getPaths().length; i++)
 				{
 					if (mm2AgilityNode.getPaths()[i] != null)
 					{
-						mm2AgilityNode.getPaths()[i].getWrongWay().validateCondition(client, chatMessage);
+						mm2AgilityNode.getPaths()[i].getWrongWay().validateCondition(client, chatMessageManager, chatMessage);
 					}
 				}
 			}

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/MM2Sabotage.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/MM2Sabotage.java
@@ -340,27 +340,27 @@ public class MM2Sabotage extends ConditionalStep
 	{
 		super.onGameTick(event);
 		int currentlyNeededExplosives = 6;
-		if (placedSatchel1.check(client))
+		if (placedSatchel1.check(client, chatMessageManager))
 		{
 			currentlyNeededExplosives--;
 		}
-		if (placedSatchel2.check(client))
+		if (placedSatchel2.check(client, chatMessageManager))
 		{
 			currentlyNeededExplosives--;
 		}
-		if (placedSatchel3.check(client))
+		if (placedSatchel3.check(client, chatMessageManager))
 		{
 			currentlyNeededExplosives--;
 		}
-		if (placedSatchel4.check(client))
+		if (placedSatchel4.check(client, chatMessageManager))
 		{
 			currentlyNeededExplosives--;
 		}
-		if (placedSatchel5.check(client))
+		if (placedSatchel5.check(client, chatMessageManager))
 		{
 			currentlyNeededExplosives--;
 		}
-		if (placedSatchel6.check(client))
+		if (placedSatchel6.check(client, chatMessageManager))
 		{
 			currentlyNeededExplosives--;
 		}

--- a/src/main/java/com/questhelper/helpers/quests/piratestreasure/RumSmugglingStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/piratestreasure/RumSmugglingStep.java
@@ -99,8 +99,8 @@ public class RumSmugglingStep extends ConditionalStep
 	@Override
 	protected void updateSteps()
 	{
-		if ((hadRumOffKaramja.check(client) && !hasRumOffKaramja.check(client))
-			|| lostRum.check(client))
+		if ((hadRumOffKaramja.check(client, chatMessageManager) && !hasRumOffKaramja.check(client, chatMessageManager))
+			|| lostRum.check(client, chatMessageManager))
 		{
 			haveShippedRum.setHasPassed(false);
 			stashedRum.setHasPassed(false);
@@ -109,9 +109,9 @@ public class RumSmugglingStep extends ConditionalStep
 			lostRum.setHasPassed(false);
 		}
 
-		if (crateSent.check(client))
+		if (crateSent.check(client, chatMessageManager))
 		{
-			haveShippedRum.check(client);
+			haveShippedRum.check(client, chatMessageManager);
 			employed.setHasPassed(false);
 			fillCrateWithBananasChat.setHasReceivedChatMessage(false);
 			filledCrateWithBananasAndRum.setHasPassed(false);

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManI.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManI.java
@@ -177,7 +177,7 @@ public class RagAndBoneManI extends BasicQuestHelper
 		AtomicInteger winesNeededQuantity = new AtomicInteger(8);
 
 		stepsForRagAndBoneManI.forEach((RagBoneState state, QuestStep step) -> {
-			if (state.hadBoneInVinegarItem(questBank).check(client))
+			if (state.hadBoneInVinegarItem(questBank).check(client, chatMessageManager))
 			{
 				winesNeededQuantity.getAndDecrement();
 			}

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
@@ -297,7 +297,7 @@ public class RagAndBoneManII extends BasicQuestHelper
 		AtomicInteger winesNeededQuantity = new AtomicInteger(27);
 
 		stepsForRagAndBoneManII.forEach((RagBoneState state, QuestStep step) -> {
-			if (state.hadBoneInVinegarItem(questBank).check(client))
+			if (state.hadBoneInVinegarItem(questBank).check(client, chatMessageManager))
 			{
 				winesNeededQuantity.getAndDecrement();
 			}

--- a/src/main/java/com/questhelper/helpers/quests/ratcatchers/RatCharming.java
+++ b/src/main/java/com/questhelper/helpers/quests/ratcatchers/RatCharming.java
@@ -59,7 +59,7 @@ public class RatCharming extends DetailedOwnerStep
 		for (int i = 0; i < noteSteps.length; i++)
 		{
 			// If not done, let's do it.
-			if (!noteRequirements[i].check(client))
+			if (!noteRequirements[i].check(client, chatMessageManager))
 			{
 				if (currentPage < i)
 				{

--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/MakeEvilStew.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/MakeEvilStew.java
@@ -91,7 +91,7 @@ public class MakeEvilStew extends DetailedOwnerStep
 		int numBrownStillNeeded = brownNeeded - brownInStew;
 		int numYellowStillNeeded = yellowNeeded - yellowInStew;
 
-		if (!inEvilDaveRoom.check(client))
+		if (!inEvilDaveRoom.check(client, chatMessageManager))
 		{
 			startUpStep(enterBasement);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/recruitmentdrive/LadyTableStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/recruitmentdrive/LadyTableStep.java
@@ -120,7 +120,7 @@ public class LadyTableStep extends DetailedOwnerStep
 	@Override
 	protected void updateSteps()
 	{
-		if (finishedRoom.check(client))
+		if (finishedRoom.check(client, chatMessageManager))
 		{
 			startUpStep(leaveRoom);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/royaltrouble/RoyalTrouble.java
+++ b/src/main/java/com/questhelper/helpers/quests/royaltrouble/RoyalTrouble.java
@@ -402,7 +402,7 @@ public class RoyalTrouble extends BasicQuestHelper
 		talkToGhrim.addDialogStep("Very well, I'll sort it out.");
 		talkToGhrim.addSubSteps(goUpToGhrim);
 
-		if (astridIsHeir.check(client))
+		if (astridIsHeir.check(client, chatMessageManager))
 		{
 			talkToPartner = new NpcStep(this, NpcID.PRINCESS_ASTRID, new WorldPoint(2502, 3867, 1), "Talk to Princess Astrid  in Miscellania castle.");
 			goUpToPartner = new ObjectStep(this, ObjectID.STAIRCASE_16675, new WorldPoint(2506, 3872, 0), "Talk to Princess Astrid in Miscellania castle.");

--- a/src/main/java/com/questhelper/helpers/quests/rumdeal/SlugSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/rumdeal/SlugSteps.java
@@ -82,7 +82,7 @@ public class SlugSteps extends DetailedOwnerStep
 		{
 			startUpStep(pullPressureLever);
 		}
-		else if (sluglings.check(client))
+		else if (sluglings.check(client, chatMessageManager))
 		{
 			startUpStep(pressureSluglings);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/sinsofthefather/ValveStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/sinsofthefather/ValveStep.java
@@ -86,7 +86,7 @@ public class ValveStep extends DetailedOwnerStep
 		{
 			if (!southDone)
 			{
-				if (atSouthValve.check(client))
+				if (atSouthValve.check(client, chatMessageManager))
 				{
 					startUpStep(setSouthValve);
 				}
@@ -97,7 +97,7 @@ public class ValveStep extends DetailedOwnerStep
 			}
 			else if (!northDone)
 			{
-				if (atNorthValve.check(client))
+				if (atNorthValve.check(client, chatMessageManager))
 				{
 					startUpStep(setNorthValve);
 				}
@@ -135,7 +135,7 @@ public class ValveStep extends DetailedOwnerStep
 			Widget widgetNumberOptions = client.getWidget(187, 3);
 			Widget widgetValveChoice = client.getWidget(229, 1);
 
-			if (atSouthValve.check(client))
+			if (atSouthValve.check(client, chatMessageManager))
 			{
 				if (widgetNumberOptions != null)
 				{
@@ -153,7 +153,7 @@ public class ValveStep extends DetailedOwnerStep
 					}
 				}
 			}
-			else if (atNorthValve.check(client))
+			else if (atNorthValve.check(client, chatMessageManager))
 			{
 				if (widgetNumberOptions != null)
 				{

--- a/src/main/java/com/questhelper/helpers/quests/swansong/FixWall.java
+++ b/src/main/java/com/questhelper/helpers/quests/swansong/FixWall.java
@@ -70,7 +70,7 @@ public class FixWall extends DetailedOwnerStep
 		ironBars.setQuantity(wallsToRepair);
 		ironSheets.setQuantity(wallsToRepair);
 
-		if (ironSheets.check(client))
+		if (ironSheets.check(client, chatMessageManager))
 		{
 			if (wall1Fixed == 0)
 			{

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
@@ -423,7 +423,7 @@ public class PuzzleStep extends QuestStep implements OwnerStep
 		boolean hasAllDiscs = true;
 		for (ItemRequirement requirement : allRequirements)
 		{
-			if (!requirement.check(client))
+			if (!requirement.check(client, chatMessageManager))
 			{
 				hasAllDiscs = false;
 				break;

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/AltarPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/AltarPuzzle.java
@@ -107,15 +107,15 @@ public class AltarPuzzle extends QuestStep implements OwnerStep
 
 	protected void updateSteps()
 	{
-		if (inBasement.check(client))
+		if (inBasement.check(client, chatMessageManager))
 		{
 			startUpStep(goUpLadder);
 		}
-		else if (inFloor1.check(client))
+		else if (inFloor1.check(client, chatMessageManager))
 		{
 			startUpStep(goUpToSecondFloor);
 		}
-		else if (inSecondFloor.check(client))
+		else if (inSecondFloor.check(client, chatMessageManager))
 		{
 			int currentW = client.getVarbitValue(7847);
 			int currentC = client.getVarbitValue(7848);

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
@@ -173,38 +173,38 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 			}
 		}
 
-		if (!fiveGallon.check(client))
+		if (!fiveGallon.check(client, chatMessageManager))
 		{
 			jugs.put("5", 0);
 		}
 
-		if (!eightGallon.check(client))
+		if (!eightGallon.check(client, chatMessageManager))
 		{
 			jugs.put("8", 0);
 		}
 
 
-		if (inBasement.check(client))
+		if (inBasement.check(client, chatMessageManager))
 		{
 			startUpStep(goUpToGroundFloor);
 		}
-		else if (inFirstFloor.check(client))
+		else if (inFirstFloor.check(client, chatMessageManager))
 		{
 			startUpStep(goDownToGroundFloor);
 		}
-		else if (inSecondFloor.check(client))
+		else if (inSecondFloor.check(client, chatMessageManager))
 		{
 			startUpStep(goDownToFirstFloor);
 		}
-		else if (missingTinderbox.check(client))
+		else if (missingTinderbox.check(client, chatMessageManager))
 		{
 			startUpStep(searchCupboardTinderbox);
 		}
-		else if (hasFilledWithFuel.check(client))
+		else if (hasFilledWithFuel.check(client, chatMessageManager))
 		{
 			startUpStep(lightFurnace);
 		}
-		else if (!fiveGallon.check(client) || !eightGallon.check(client))
+		else if (!fiveGallon.check(client, chatMessageManager) || !eightGallon.check(client, chatMessageManager))
 		{
 			startUpStep(searchCupboardJug);
 		}

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/PotionPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/PotionPuzzle.java
@@ -125,21 +125,21 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 
 	protected void updateSteps()
 	{
-		if (inBasement.check(client))
+		if (inBasement.check(client, chatMessageManager))
 		{
 			startUpStep(goUpLadder);
 		}
-		else if (inSecondFloor.check(client))
+		else if (inSecondFloor.check(client, chatMessageManager))
 		{
 			startUpStep(goDownToFirstFloor);
 		}
-		else if (inFirstFloor.check(client))
+		else if (inFirstFloor.check(client, chatMessageManager))
 		{
-			if (cleanedRefinery.check(client))
+			if (cleanedRefinery.check(client, chatMessageManager))
 			{
 				startUpStep(activateRefinery);
 			}
-			else if (!triedToActivate.check(client))
+			else if (!triedToActivate.check(client, chatMessageManager))
 			{
 				startUpStep(inspectRefinery);
 			}
@@ -156,7 +156,7 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 					fluidFound = true;
 				}
 
-				if (hasFluids[correctFluid].check(client))
+				if (hasFluids[correctFluid].check(client, chatMessageManager))
 				{
 					startUpStep(useFluidOnRefinery);
 				}
@@ -165,7 +165,7 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 					startUpStep(getFluid);
 				}
 			}
-			else if (oldNotes.check(client))
+			else if (oldNotes.check(client, chatMessageManager))
 			{
 				startUpStep(readNote);
 			}

--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/MonolithPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/MonolithPuzzle.java
@@ -282,7 +282,7 @@ public class MonolithPuzzle extends DetailedOwnerStep
 
 		if (tileHasBigMonolith(tiles, 53, 53))
 		{
-			if (inStartZone.check(client))
+			if (inStartZone.check(client, chatMessageManager))
 			{
 				startUpStep(pushSouthernMonolithUp);
 				return;
@@ -335,7 +335,7 @@ public class MonolithPuzzle extends DetailedOwnerStep
 				return;
 			}
 
-			if (!crystalChime.check(client))
+			if (!crystalChime.check(client, chatMessageManager))
 			{
 				startUpStep(inspectSingingBowl);
 				return;
@@ -347,7 +347,7 @@ public class MonolithPuzzle extends DetailedOwnerStep
 				return;
 			}
 
-			if (crystalChime.check(client))
+			if (crystalChime.check(client, chatMessageManager))
 			{
 				startUpStep(unlockTheGate);
 				return;

--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/Solution.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/Solution.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class Solution
 {
@@ -49,16 +50,19 @@ public class Solution
 	public ItemRequirement puzzle2UpperRequirement;
 	public ItemRequirement puzzle2LowerRequirement;
 
-	public static boolean inventoryHas(final List<Item> haystack, int needle) {
-		for (var item : haystack) {
-			if (item.getId() == needle) {
+	public static boolean inventoryHas(final List<Item> haystack, int needle)
+	{
+		for (var item : haystack)
+		{
+			if (item.getId() == needle)
+			{
 				return true;
 			}
 		}
 		return false;
 	}
 
-	public void load(Client client, List<Item> items, int puzzle1SolutionValue, int puzzle2SolutionValue,
+	public void load(Client client, ChatMessageManager chatMessageManager, List<Item> items, int puzzle1SolutionValue, int puzzle2SolutionValue,
 					 final HashMap<Integer, ItemRequirement> discs,
 					 final HashMap<Integer, ItemRequirement> valueToRequirement,
 					 final HashMap<Integer, List<ItemRequirements>> valueToDoubleDiscRequirement,
@@ -78,7 +82,7 @@ public class Solution
 		puzzleNeeds.clear();
 		toExchange.clear();
 
-		if (!puzzle1Requirement.check(client, false, items))
+		if (!puzzle1Requirement.check(client, chatMessageManager, false, items))
 		{
 			puzzleNeeds.add(puzzle1Requirement);
 			var singleDiscExchange = valuePossibleSingleDiscExchangesRequirements.get(puzzle1SolutionValue).stream().filter(requirement -> inventoryHas(items, requirement.getId())).collect(Collectors.toUnmodifiableList());
@@ -120,7 +124,7 @@ public class Solution
 		ItemRequirement consumed = null;
 		for (var possiblePuzzle2Solution : possiblePuzzle2Solutions)
 		{
-			if (possiblePuzzle2Solution.check(client, false, itemsAfterPuzzle1))
+			if (possiblePuzzle2Solution.check(client, chatMessageManager, false, itemsAfterPuzzle1))
 			{
 				// Found a valid puzzle2 solution
 				puzzle2UpperRequirement = possiblePuzzle2Solution.getItemRequirements().get(0);
@@ -129,7 +133,7 @@ public class Solution
 			}
 
 			// Let's check if we have one of these
-			if (possiblePuzzle2Solution.getItemRequirements().get(0).check(client, false, itemsAfterPuzzle1))
+			if (possiblePuzzle2Solution.getItemRequirements().get(0).check(client, chatMessageManager, false, itemsAfterPuzzle1))
 			{
 				// Found a partial solution
 				partialPuzzle2Solution = possiblePuzzle2Solution;
@@ -138,7 +142,7 @@ public class Solution
 				break;
 			}
 
-			if (possiblePuzzle2Solution.getItemRequirements().get(1).check(client, false, itemsAfterPuzzle1))
+			if (possiblePuzzle2Solution.getItemRequirements().get(1).check(client, chatMessageManager, false, itemsAfterPuzzle1))
 			{
 				// Found a partial solution
 				partialPuzzle2Solution = possiblePuzzle2Solution;
@@ -209,7 +213,8 @@ public class Solution
 				if (!singleDiscExchange.isEmpty())
 				{
 					looseNeeds.addAll(req1.getAllIds());
-					for (var ex : singleDiscExchange) {
+					for (var ex : singleDiscExchange)
+					{
 						looseExchanges.addAll(ex.getAllIds());
 					}
 				}
@@ -222,7 +227,8 @@ public class Solution
 				if (!singleDiscExchange.isEmpty())
 				{
 					looseNeeds.addAll(req2.getAllIds());
-					for (var ex : singleDiscExchange) {
+					for (var ex : singleDiscExchange)
+					{
 						looseExchanges.addAll(ex.getAllIds());
 					}
 				}
@@ -231,17 +237,21 @@ public class Solution
 			if (!looseNeeds.isEmpty() && !looseExchanges.isEmpty())
 			{
 				toExchange.clear();
-				for (var id : looseExchanges) {
+				for (var id : looseExchanges)
+				{
 					var itemReq = discs.get(id);
-					if (itemReq != null) {
+					if (itemReq != null)
+					{
 						toExchange.add(itemReq);
 					}
 				}
 
 				puzzleNeeds.clear();
-				for (var id : looseNeeds) {
+				for (var id : looseNeeds)
+				{
 					var itemReq = discs.get(id);
-					if (itemReq != null) {
+					if (itemReq != null)
+					{
 						puzzleNeeds.add(itemReq);
 					}
 				}

--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/YewnocksPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/YewnocksPuzzle.java
@@ -567,7 +567,7 @@ public class YewnocksPuzzle extends DetailedOwnerStep
 
 		var puzzle1SolutionValue = puzzle1SolutionValue1 + puzzle1SolutionValue2;
 		// Try to figure out a solution
-		solution.load(client, items, puzzle1SolutionValue, puzzle2SolutionValue,
+		solution.load(client, chatMessageManager, items, puzzle1SolutionValue, puzzle2SolutionValue,
 			discs,
 			valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
 	}
@@ -600,7 +600,7 @@ public class YewnocksPuzzle extends DetailedOwnerStep
 		if (solution.isGood())
 		{
 			// A good solution has been calculated with the discs the player has in their inventory
-			if (!machineOpen.check(client))
+			if (!machineOpen.check(client, chatMessageManager))
 			{
 				// Prompt the player to open the machine
 				startUpStep(clickMachine);
@@ -688,7 +688,7 @@ public class YewnocksPuzzle extends DetailedOwnerStep
 			return;
 		}
 
-		if (exchangerOpen.check(client))
+		if (exchangerOpen.check(client, chatMessageManager))
 		{
 			// Exchanger widget is open
 
@@ -760,7 +760,7 @@ public class YewnocksPuzzle extends DetailedOwnerStep
 			return;
 		}
 
-		if (machineOpen.check(client))
+		if (machineOpen.check(client, chatMessageManager))
 		{
 			// A partial solution is found, and it can be completed by using the exchanger
 			// The machine is open, prompt the user to close it then click the exchanger

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -368,7 +368,7 @@ public class QuestOverviewPanel extends JPanel
 	{
 		if (currentQuest == null) return;
 		questStepPanelList.forEach(panel -> {
-			panel.updateHighlightCheck(client, newStep, currentQuest);
+			panel.updateHighlightCheck(client, questHelperPlugin.getChatMessageManager(), newStep, currentQuest);
 		});
 
 		repaint();
@@ -751,7 +751,7 @@ public class QuestOverviewPanel extends JPanel
 		if (questStepPanelList != null)
 		{
 			questStepPanelList.forEach((questStepPanel) -> {
-				questStepPanel.updateRequirements(client, bankItems, this);
+				questStepPanel.updateRequirements(client, questHelperPlugin.getChatMessageManager(), bankItems, this);
 			});
 		}
 		revalidate();
@@ -774,21 +774,21 @@ public class QuestOverviewPanel extends JPanel
 
 				requirementPanel.getLabel().setText(itemRequirement.getSidebarText());
 
-				requirementPanel.setVisible(itemRequirement.getConditionToHide() == null || !itemRequirement.getConditionToHide().check(client));
+				requirementPanel.setVisible(itemRequirement.getConditionToHide() == null || !itemRequirement.getConditionToHide().check(client, questHelperPlugin.getChatMessageManager()));
 
 				if (itemRequirement instanceof NoItemRequirement)
 				{
-					newColor = itemRequirement.getColor(client, questHelperPlugin.getConfig()); // explicitly call this because
+					newColor = itemRequirement.getColor(client, questHelperPlugin.getChatMessageManager(), questHelperPlugin.getConfig()); // explicitly call this because
 					// NoItemRequirement overrides it
 				}
 				else
 				{
-					newColor = itemRequirement.getColorConsideringBank(client, false, bankItems, questHelperPlugin.getConfig());
+					newColor = itemRequirement.getColorConsideringBank(client, questHelperPlugin.getChatMessageManager(), false, bankItems, questHelperPlugin.getConfig());
 				}
 			}
 			else
 			{
-				newColor = requirementPanel.getRequirement().getColor(client, questHelperPlugin.getConfig());
+				newColor = requirementPanel.getRequirement().getColor(client, questHelperPlugin.getChatMessageManager(), questHelperPlugin.getConfig());
 			}
 
 			if (newColor == Color.WHITE)

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -25,7 +25,6 @@
 package com.questhelper.panel;
 
 import com.questhelper.questhelpers.QuestHelper;
-import com.questhelper.questinfo.QuestHelperQuest;
 import com.questhelper.requirements.Requirement;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -38,6 +37,7 @@ import com.questhelper.steps.QuestStep;
 import java.util.List;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.ui.ColorScheme;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -225,9 +225,9 @@ public class QuestStepPanel extends JPanel
 		lockStep.setVisible(canLock);
 	}
 
-	public void updateHighlightCheck(Client client, QuestStep newStep, QuestHelper currentQuest)
+	public void updateHighlightCheck(Client client, ChatMessageManager chatMessageManager, QuestStep newStep, QuestHelper currentQuest)
 	{
-		if (panelDetails.getHideCondition() == null || !panelDetails.getHideCondition().check(client))
+		if (panelDetails.getHideCondition() == null || !panelDetails.getHideCondition().check(client, chatMessageManager))
 		{
 			setVisible(true);
 			boolean highlighted = false;
@@ -380,17 +380,17 @@ public class QuestStepPanel extends JPanel
 		}
 	}
 
-	public void updateRequirements(Client client, List<Item> bankItems, QuestOverviewPanel questOverviewPanel)
+	public void updateRequirements(Client client, ChatMessageManager chatMessageManager, List<Item> bankItems, QuestOverviewPanel questOverviewPanel)
 	{
 		questOverviewPanel.updateRequirementPanels(client, requirementPanels, bankItems);
-		updateStepVisibility(client);
+		updateStepVisibility(client, chatMessageManager);
 	}
 
-	public void updateStepVisibility(Client client)
+	public void updateStepVisibility(Client client, ChatMessageManager chatMessageManager)
 	{
 		for (QuestStep step : steps.keySet())
 		{
-			step.setShowInSidebar(step.getConditionToHide() == null || !step.getConditionToHide().check(client));
+			step.setShowInSidebar(step.getConditionToHide() == null || !step.getConditionToHide().check(client, chatMessageManager));
 			steps.get(step).setVisible(step.isShowInSidebar());
 		}
 	}

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -54,6 +54,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.QuestState;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import com.questhelper.steps.OwnerStep;
@@ -66,6 +67,9 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 {
 	@Inject
 	protected Client client;
+
+	@Inject
+	protected ChatMessageManager chatMessageManager;
 
 	@Inject
 	@Getter
@@ -192,7 +196,7 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		}
 
 		return getGeneralRequirements().stream().filter(Objects::nonNull).allMatch(r ->
-			!r.shouldConsiderForFilter() || r.check(client));
+			!r.shouldConsiderForFilter() || r.check(client, chatMessageManager));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/AbstractRequirement.java
+++ b/src/main/java/com/questhelper/requirements/AbstractRequirement.java
@@ -28,8 +28,8 @@ import com.questhelper.QuestHelperConfig;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.ui.overlay.components.LineComponent;
 
 public abstract class AbstractRequirement implements Requirement
@@ -42,7 +42,7 @@ public abstract class AbstractRequirement implements Requirement
 
 	protected boolean shouldCountForFilter = false;
 
-	abstract public boolean check(Client client);
+	abstract public boolean check(Client client, ChatMessageManager chatMessageManager);
 
 	@Override
 	public boolean shouldConsiderForFilter()
@@ -79,23 +79,23 @@ public abstract class AbstractRequirement implements Requirement
 	}
 
 	@Override
-	public List<LineComponent> getDisplayTextWithChecks(Client client, QuestHelperConfig config)
+	public List<LineComponent> getDisplayTextWithChecks(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
-		if (getOverlayReplacement() != null && !this.check(client))
+		if (getOverlayReplacement() != null && !this.check(client, chatMessageManager))
 		{
-			return getOverlayReplacement().getDisplayTextWithChecks(client, config);
+			return getOverlayReplacement().getDisplayTextWithChecks(client, chatMessageManager, config);
 		}
-		return getOverlayDisplayText(client, config);
+		return getOverlayDisplayText(client, chatMessageManager, config);
 	}
 
-	protected List<LineComponent> getOverlayDisplayText(Client client, QuestHelperConfig config)
+	protected List<LineComponent> getOverlayDisplayText(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
-		if (!shouldDisplayText(client))
+		if (!shouldDisplayText(client, chatMessageManager))
 		{
 			return new ArrayList<>();
 		}
 
-		return Requirement.super.getDisplayTextWithChecks(client, config);
+		return Requirement.super.getDisplayTextWithChecks(client, chatMessageManager, config);
 	}
 
 	public void appendToTooltip(String text)

--- a/src/main/java/com/questhelper/requirements/ChatMessageRequirement.java
+++ b/src/main/java/com/questhelper/requirements/ChatMessageRequirement.java
@@ -33,6 +33,7 @@ import lombok.Setter;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ChatMessageRequirement extends ConditionForStep
 {
@@ -58,12 +59,12 @@ public class ChatMessageRequirement extends ConditionForStep
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return hasReceivedChatMessage;
 	}
 
-	public void validateCondition(Client client, ChatMessage chatMessage)
+	public void validateCondition(Client client, ChatMessageManager chatMessageManager, ChatMessage chatMessage)
 	{
 		if (chatMessage.getType() != ChatMessageType.GAMEMESSAGE && chatMessage.getType() == ChatMessageType.ENGINE)
 		{
@@ -74,7 +75,7 @@ public class ChatMessageRequirement extends ConditionForStep
 		{
 			if (messages.contains(chatMessage.getMessage()))
 			{
-				if (condition == null || condition.check(client))
+				if (condition == null || condition.check(client, chatMessageManager))
 				{
 					hasReceivedChatMessage = true;
 				}
@@ -82,8 +83,8 @@ public class ChatMessageRequirement extends ConditionForStep
 		}
 		else if (invalidateRequirement != null)
 		{
-			invalidateRequirement.validateCondition(client, chatMessage);
-			if (invalidateRequirement.check(client))
+			invalidateRequirement.validateCondition(client, chatMessageManager, chatMessage);
+			if (invalidateRequirement.check(client, chatMessageManager))
 			{
 				invalidateRequirement.setHasReceivedChatMessage(false);
 				setHasReceivedChatMessage(false);

--- a/src/main/java/com/questhelper/requirements/ComplexRequirement.java
+++ b/src/main/java/com/questhelper/requirements/ComplexRequirement.java
@@ -28,6 +28,7 @@ import com.questhelper.requirements.util.LogicType;
 import java.util.stream.Stream;
 import lombok.Getter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Requirement that combines multiple other {@link Requirement}s using
@@ -77,13 +78,13 @@ public class ComplexRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		if (logicType == null)
 		{
 			return false;
 		}
-		return logicType.test(Stream.of(requirements), r -> r.check(client));
+		return logicType.test(Stream.of(requirements), r -> r.check(client, chatMessageManager));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/ConfigRequirement.java
+++ b/src/main/java/com/questhelper/requirements/ConfigRequirement.java
@@ -27,6 +27,7 @@ package com.questhelper.requirements;
 import java.util.function.BooleanSupplier;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ConfigRequirement extends SimpleRequirement
 {
@@ -41,7 +42,7 @@ public class ConfigRequirement extends SimpleRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return booleanSupplier.getAsBoolean();
 	}

--- a/src/main/java/com/questhelper/requirements/ManualRequirement.java
+++ b/src/main/java/com/questhelper/requirements/ManualRequirement.java
@@ -26,6 +26,7 @@ package com.questhelper.requirements;
 
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ManualRequirement extends SimpleRequirement
 {
@@ -33,7 +34,7 @@ public class ManualRequirement extends SimpleRequirement
 	boolean shouldPass;
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return shouldPass;
 	}

--- a/src/main/java/com/questhelper/requirements/MesBoxRequirement.java
+++ b/src/main/java/com/questhelper/requirements/MesBoxRequirement.java
@@ -27,6 +27,7 @@ package com.questhelper.requirements;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class MesBoxRequirement extends ChatMessageRequirement
 {
@@ -36,7 +37,7 @@ public class MesBoxRequirement extends ChatMessageRequirement
 		super(text);
 	}
 
-	public void validateCondition(Client client, ChatMessage chatMessage)
+	public void validateCondition(Client client, ChatMessageManager chatMessageManager, ChatMessage chatMessage)
 	{
 		if (chatMessage.getType() != ChatMessageType.MESBOX)
 		{
@@ -51,7 +52,7 @@ public class MesBoxRequirement extends ChatMessageRequirement
 		{
 			if (messages.contains(chatMessage.getMessage()))
 			{
-				if (condition == null || condition.check(client))
+				if (condition == null || condition.check(client, chatMessageManager))
 				{
 					hasReceivedChatMessage = true;
 				}
@@ -59,8 +60,8 @@ public class MesBoxRequirement extends ChatMessageRequirement
 		}
 		else if (invalidateRequirement != null)
 		{
-			invalidateRequirement.validateCondition(client, chatMessage);
-			if (invalidateRequirement.check(client))
+			invalidateRequirement.validateCondition(client, chatMessageManager, chatMessage);
+			if (invalidateRequirement.check(client, chatMessageManager))
 			{
 				invalidateRequirement.setHasReceivedChatMessage(false);
 				setHasReceivedChatMessage(false);

--- a/src/main/java/com/questhelper/requirements/RegionHintArrowRequirement.java
+++ b/src/main/java/com/questhelper/requirements/RegionHintArrowRequirement.java
@@ -28,6 +28,7 @@ import com.questhelper.requirements.zone.Zone;
 import com.questhelper.steps.tools.QuestPerspective;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class RegionHintArrowRequirement extends SimpleRequirement
 {
@@ -43,7 +44,7 @@ public class RegionHintArrowRequirement extends SimpleRequirement
 		this.zone = zone;
 	}
 
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		WorldPoint hintArrowPoint = client.getHintArrowPoint();
 		if (hintArrowPoint == null)

--- a/src/main/java/com/questhelper/requirements/Requirement.java
+++ b/src/main/java/com/questhelper/requirements/Requirement.java
@@ -33,6 +33,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.overlay.components.LineComponent;
 
@@ -45,14 +46,16 @@ public interface Requirement
 {
 	/**
 	 * Check the {@link Client} that it meets this requirement.
-	 * @param client client to check
+	 *
+	 * @param client             client to check
+	 * @param chatMessageManager chat message manager to use for posting warning messages
 	 * @return true if the client meets this requirement
 	 */
-	boolean check(Client client);
+	boolean check(Client client, ChatMessageManager chatMessageManager);
 
-	default boolean checkWithConfigChange(Client client, ConfigManager configManager, String configName, String value)
+	default boolean checkWithConfigChange(Client client, ChatMessageManager chatMessageManager, String configName, String value, ConfigManager configManager)
 	{
-		if (check(client))
+		if (check(client, chatMessageManager))
 		{
 			configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, configName, value);
 			return true;
@@ -75,16 +78,17 @@ public interface Requirement
 	String getDisplayText();
 
 	/**
-	 * The {@link Color} used to render the {@link #getDisplayText()} depending on what {@link #check(Client)}
+	 * The {@link Color} used to render the {@link #getDisplayText()} depending on what {@link #check(Client, ChatMessageManager)}
 	 * returns.<br>
-	 * By default, if {@link #check(Client)} returns true, {@link Color#GREEN} is used, otherwise {@link Color#RED}.
+	 * By default, if {@link #check(Client, ChatMessageManager)} returns true, {@link Color#GREEN} is used, otherwise {@link Color#RED}.
 	 *
-	 * @param client client to check
+	 * @param client             client to check
+	 * @param chatMessageManager
 	 * @return the {@link Color} to use
 	 */
-	default Color getColor(Client client, QuestHelperConfig config)
+	default Color getColor(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
-		return check(client) ? config.passColour() : config.failColour();
+		return check(client, chatMessageManager) ? config.passColour() : config.failColour();
 	}
 
 	/**
@@ -127,14 +131,14 @@ public interface Requirement
 	default void setUrlSuffix(@Nullable String urlSuffix) {}
 	
 
-	default List<LineComponent> getDisplayTextWithChecks(Client client, QuestHelperConfig config)
+	default List<LineComponent> getDisplayTextWithChecks(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
 		List<LineComponent> lines = new ArrayList<>();
 
-		if (!shouldDisplayText(client)) return lines;
+		if (!shouldDisplayText(client, chatMessageManager)) return lines;
 
 		String text = getDisplayText();
-		Color color = getColor(client, config);
+		Color color = getColor(client, chatMessageManager, config);
 
 		lines.add(LineComponent.builder()
 			.left(text)
@@ -155,7 +159,7 @@ public interface Requirement
 	/**
 	 * @return If requirements pass, returns true
 	 */
-	default boolean shouldDisplayText(Client client)
+	default boolean shouldDisplayText(Client client, ChatMessageManager chatMessageManager)
 	{
 		return true;
 	}

--- a/src/main/java/com/questhelper/requirements/SimpleRequirement.java
+++ b/src/main/java/com/questhelper/requirements/SimpleRequirement.java
@@ -30,11 +30,12 @@ import com.questhelper.QuestHelperConfig;
 import java.awt.Color;
 import javax.annotation.Nonnull;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public abstract class SimpleRequirement extends AbstractRequirement
 {
 	@Override
-	public abstract boolean check(Client client);
+	public abstract boolean check(Client client, ChatMessageManager chatMessageManager);
 
 	@Nonnull
 	@Override
@@ -44,8 +45,8 @@ public abstract class SimpleRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public Color getColor(Client client, QuestHelperConfig config)
+	public Color getColor(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
-		return check(client) ? config.passColour() : config.failColour();
+		return check(client, chatMessageManager) ? config.passColour() : config.failColour();
 	}
 }

--- a/src/main/java/com/questhelper/requirements/conditional/ConditionForStep.java
+++ b/src/main/java/com/questhelper/requirements/conditional/ConditionForStep.java
@@ -31,6 +31,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public abstract class ConditionForStep implements InitializableRequirement
 {
@@ -44,7 +45,7 @@ public abstract class ConditionForStep implements InitializableRequirement
 	protected List<Requirement> conditions = new ArrayList<>();
 
 	@Override
-	abstract public boolean check(Client client);
+	abstract public boolean check(Client client, ChatMessageManager chatMessageManager);
 
 	@Override
 	public void initialize(Client client)

--- a/src/main/java/com/questhelper/requirements/conditional/Conditions.java
+++ b/src/main/java/com/questhelper/requirements/conditional/Conditions.java
@@ -33,6 +33,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class Conditions extends ConditionForStep
 {
@@ -121,7 +122,7 @@ public class Conditions extends ConditionForStep
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		if (onlyNeedToPassOnce && hasPassed)
 		{
@@ -133,7 +134,7 @@ public class Conditions extends ConditionForStep
 			{
 				return true;
 			}
-			return c.check(client);
+			return c.check(client, chatMessageManager);
 		}).count();
 
 		if (operation != null)

--- a/src/main/java/com/questhelper/requirements/conditional/NpcCondition.java
+++ b/src/main/java/com/questhelper/requirements/conditional/NpcCondition.java
@@ -30,6 +30,7 @@ import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.NpcChanged;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class NpcCondition extends ConditionForStep
 {
@@ -69,7 +70,7 @@ public class NpcCondition extends ConditionForStep
 		}
 	}
 
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		if (zone != null)
 		{

--- a/src/main/java/com/questhelper/requirements/conditional/ObjectCondition.java
+++ b/src/main/java/com/questhelper/requirements/conditional/ObjectCondition.java
@@ -32,6 +32,7 @@ import static net.runelite.api.Perspective.SCENE_SIZE;
 import net.runelite.api.Tile;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ObjectCondition extends ConditionForStep
 {
@@ -62,7 +63,7 @@ public class ObjectCondition extends ConditionForStep
 		this.zone = zone;
 	}
 
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		Tile[][] tiles;
 		tiles = client.getScene().getTiles()[client.getPlane()];

--- a/src/main/java/com/questhelper/requirements/item/FollowerItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/FollowerItemRequirement.java
@@ -30,6 +30,7 @@ import com.questhelper.collections.ItemCollections;
 import java.util.List;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class FollowerItemRequirement extends ItemRequirement
 {
@@ -57,8 +58,7 @@ public class FollowerItemRequirement extends ItemRequirement
 	}
 
 	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
-	{
+	public boolean check(Client client, ChatMessageManager chatMessageManager, boolean checkConsideringSlotRestrictions, List<Item> items) {
 		boolean match = client.getNpcs().stream()
 			.filter(npc -> npc.getInteracting() != null) // we need this check because Client#getLocalPlayer is Nullable
 			.filter(npc -> npc.getInteracting() == client.getLocalPlayer())
@@ -69,6 +69,6 @@ public class FollowerItemRequirement extends ItemRequirement
 			return true;
 		}
 
-		return super.check(client, checkConsideringSlotRestrictions, items);
+		return super.check(client, chatMessageManager, checkConsideringSlotRestrictions, items);
 	}
 }

--- a/src/main/java/com/questhelper/requirements/item/ItemOnTileConsideringSceneLoadRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemOnTileConsideringSceneLoadRequirement.java
@@ -13,6 +13,7 @@ import net.runelite.api.Tile;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ItemOnTileConsideringSceneLoadRequirement implements InitializableRequirement
 {
@@ -43,7 +44,7 @@ public class ItemOnTileConsideringSceneLoadRequirement implements InitializableR
 	}
 
 
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		// Scenario 1:
 		// Player has entered region, key hasn't loaded in but tile has
@@ -61,7 +62,7 @@ public class ItemOnTileConsideringSceneLoadRequirement implements InitializableR
 
 		// If scene has reloaded, do something
 
-		if (playerInRegion(client) || playerHasBeenInRegionThisLoad)
+		if (playerInRegion(client, chatMessageManager) || playerHasBeenInRegionThisLoad)
 		{
 			hasFoundItemThisLoad = checkAllTiles(client);
 		}
@@ -77,11 +78,11 @@ public class ItemOnTileConsideringSceneLoadRequirement implements InitializableR
 	}
 
 	// TODO: Consider some implementation which allows for true/false/unknown
-	private boolean playerInRegion(Client client)
+	private boolean playerInRegion(Client client, ChatMessageManager chatMessageManager)
 	{
 		// Return true for unknown
 		if (worldPoint == null) return true;
-		if (!tileLoadedReq.check(client)) return true;
+		if (!tileLoadedReq.check(client, chatMessageManager)) return true;
 
 		WorldPoint playerPoint = QuestPerspective.getRealWorldPointFromLocal(client, client.getLocalPlayer().getWorldLocation());
 		if (playerPoint == null) return false;

--- a/src/main/java/com/questhelper/requirements/item/ItemOnTileRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemOnTileRequirement.java
@@ -29,7 +29,6 @@ package com.questhelper.requirements.item;
 
 import com.questhelper.requirements.conditional.ConditionForStep;
 import com.questhelper.steps.tools.QuestPerspective;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import net.runelite.api.Client;
@@ -37,6 +36,7 @@ import net.runelite.api.Tile;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ItemOnTileRequirement extends ConditionForStep
 {
@@ -66,7 +66,7 @@ public class ItemOnTileRequirement extends ConditionForStep
 	}
 
 
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return checkAllTiles(client);
 	}

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -37,9 +37,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import lombok.Getter;
-import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ItemRequirements extends ItemRequirement
 {
@@ -87,37 +87,37 @@ public class ItemRequirements extends ItemRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
-		return check(client, false);
+		return check(client, chatMessageManager, false);
 	}
 
 	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions)
+	public boolean check(Client client, ChatMessageManager chatMessageManager, boolean checkConsideringSlotRestrictions)
 	{
-		Predicate<ItemRequirement> predicate = r -> r.check(client, checkConsideringSlotRestrictions);
+		Predicate<ItemRequirement> predicate = r -> r.check(client, chatMessageManager, checkConsideringSlotRestrictions);
 		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
 		hadItemLastCheck = logicType.compare(successes, itemRequirements.size());
 		return hadItemLastCheck;
 	}
 
 	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
+	public boolean check(Client client, ChatMessageManager chatMessageManager, boolean checkConsideringSlotRestrictions, List<Item> items)
 	{
-		Predicate<ItemRequirement> predicate = r -> r.check(client, checkConsideringSlotRestrictions, items);
+		Predicate<ItemRequirement> predicate = r -> r.check(client, chatMessageManager, checkConsideringSlotRestrictions, items);
 		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
 		hadItemLastCheck = logicType.compare(successes, itemRequirements.size());
 		return hadItemLastCheck;
 	}
 
 	@Override
-	public Color getColor(Client client, QuestHelperConfig config)
+	public Color getColor(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
-		return this.check(client, true) ? config.passColour() : config.failColour();
+		return this.check(client, chatMessageManager, true) ? config.passColour() : config.failColour();
 	}
 
 	@Override
-	public Color getColorConsideringBank(Client client, boolean checkConsideringSlotRestrictions,
+	public Color getColorConsideringBank(Client client, ChatMessageManager chatMessageManager, boolean checkConsideringSlotRestrictions,
 										 List<Item> bankItems, QuestHelperConfig config)
 	{
 		Color color = config.failColour();
@@ -125,14 +125,14 @@ public class ItemRequirements extends ItemRequirement
 		{
 			color = Color.GRAY;
 		}
-		else if (this.check(client, checkConsideringSlotRestrictions))
+		else if (this.check(client, chatMessageManager, checkConsideringSlotRestrictions))
 		{
 			color = config.passColour();
 		}
 
 		if (color == config.failColour() && bankItems != null)
 		{
-			if (check(client, false, bankItems))
+			if (check(client, chatMessageManager, false, bankItems))
 			{
 				color = Color.WHITE;
 			}
@@ -169,8 +169,8 @@ public class ItemRequirements extends ItemRequirement
 	}
 
 	@Override
-	public boolean checkBank(Client client)
+	public boolean checkBank(Client client, ChatMessageManager chatMessageManager)
 	{
-		return logicType.test(getItemRequirements().stream(), item -> item.checkBank(client) || item.check(client, false));
+		return logicType.test(getItemRequirements().stream(), item -> item.checkBank(client, chatMessageManager) || item.check(client, chatMessageManager, false));
 	}
 }

--- a/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
@@ -33,6 +33,7 @@ import java.util.List;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemID;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 
 public class KeyringRequirement extends ItemRequirement
@@ -93,20 +94,20 @@ public class KeyringRequirement extends ItemRequirement
 	}
 
 	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
+	public boolean check(Client client, ChatMessageManager chatMessageManager, boolean checkConsideringSlotRestrictions, List<Item> items)
 	{
-		boolean match = runeliteRequirement.check(client);
+		boolean match = runeliteRequirement.check(client, chatMessageManager);
 
-		if (match && keyring.check(client))
+		if (match && keyring.check(client, chatMessageManager))
 		{
 			return true;
 		}
 
-		return super.check(client, checkConsideringSlotRestrictions, items);
+		return super.check(client, chatMessageManager, checkConsideringSlotRestrictions, items);
 	}
 
 	@Override
-	public Color getColorConsideringBank(Client client, boolean checkConsideringSlotRestrictions,
+	public Color getColorConsideringBank(Client client, ChatMessageManager chatMessageManager, boolean checkConsideringSlotRestrictions,
 										 List<Item> bankItems, QuestHelperConfig config)
 	{
 		Color color = config.failColour();
@@ -114,14 +115,14 @@ public class KeyringRequirement extends ItemRequirement
 		{
 			color = Color.GRAY;
 		}
-		else if (super.check(client, checkConsideringSlotRestrictions, new ArrayList<>()))
+		else if (super.check(client, chatMessageManager, checkConsideringSlotRestrictions, new ArrayList<>()))
 		{
 			color = config.passColour();
 		}
 
 		if (color == config.failColour() && bankItems != null)
 		{
-			if (super.check(client, false, bankItems))
+			if (super.check(client, chatMessageManager, false, bankItems))
 			{
 				color = Color.WHITE;
 			}
@@ -129,7 +130,7 @@ public class KeyringRequirement extends ItemRequirement
 
 		if (color == config.failColour())
 		{
-			boolean match = runeliteRequirement.check(client);
+			boolean match = runeliteRequirement.check(client, chatMessageManager);
 
 			if (match)
 			{

--- a/src/main/java/com/questhelper/requirements/item/NoItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/NoItemRequirement.java
@@ -32,6 +32,7 @@ import java.awt.Color;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Requirement that checks if a player has no item in a specified {@link ItemSlots}.
@@ -53,15 +54,15 @@ public class NoItemRequirement extends ItemRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return slot.checkInventory(client, Objects::isNull);
 	}
 
 	@Override
-	public Color getColor(Client client, QuestHelperConfig config)
+	public Color getColor(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
-		return check(client) ? config.passColour() : config.failColour();
+		return check(client, chatMessageManager) ? config.passColour() : config.failColour();
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/location/TileIsLoadedRequirement.java
+++ b/src/main/java/com/questhelper/requirements/location/TileIsLoadedRequirement.java
@@ -33,6 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class TileIsLoadedRequirement extends AbstractRequirement
 {
@@ -51,7 +52,7 @@ public class TileIsLoadedRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		LocalPoint lp = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
 		if (lp == null) return false;

--- a/src/main/java/com/questhelper/requirements/npc/DialogRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/DialogRequirement.java
@@ -28,9 +28,9 @@ import com.questhelper.requirements.SimpleRequirement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class DialogRequirement extends SimpleRequirement
 {
@@ -60,7 +60,7 @@ public class DialogRequirement extends SimpleRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return hasSeenDialog;
 	}

--- a/src/main/java/com/questhelper/requirements/npc/FollowerRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/FollowerRequirement.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class FollowerRequirement extends AbstractRequirement
 {
@@ -51,7 +52,7 @@ public class FollowerRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.getNpcs()
 			.stream()

--- a/src/main/java/com/questhelper/requirements/npc/NoFollowerRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/NoFollowerRequirement.java
@@ -27,10 +27,8 @@
 package com.questhelper.requirements.npc;
 
 import com.questhelper.requirements.AbstractRequirement;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class NoFollowerRequirement extends AbstractRequirement
 {
@@ -42,7 +40,7 @@ public class NoFollowerRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.getVarpValue(447) == -1;
 	}

--- a/src/main/java/com/questhelper/requirements/npc/NpcHintArrowRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/NpcHintArrowRequirement.java
@@ -32,6 +32,7 @@ import java.util.List;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class NpcHintArrowRequirement extends SimpleRequirement
 {
@@ -54,7 +55,7 @@ public class NpcHintArrowRequirement extends SimpleRequirement
 		this.zone = zone;
 	}
 
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		NPC currentNPC = client.getHintArrowNpc();
 		if (currentNPC == null)

--- a/src/main/java/com/questhelper/requirements/npc/NpcInteractingRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/NpcInteractingRequirement.java
@@ -28,10 +28,10 @@
 package com.questhelper.requirements.npc;
 
 import com.questhelper.requirements.SimpleRequirement;
-import com.questhelper.requirements.conditional.ConditionForStep;
 import java.util.Arrays;
 import java.util.List;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class NpcInteractingRequirement extends SimpleRequirement
 {
@@ -43,7 +43,7 @@ public class NpcInteractingRequirement extends SimpleRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.getNpcs().stream()
 			.filter(npc -> npc.getInteracting() != null)

--- a/src/main/java/com/questhelper/requirements/npc/NpcInteractingWithNpcRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/NpcInteractingWithNpcRequirement.java
@@ -27,11 +27,8 @@
 package com.questhelper.requirements.npc;
 
 import com.questhelper.requirements.SimpleRequirement;
-import com.questhelper.requirements.conditional.ConditionForStep;
-import java.util.Arrays;
-import java.util.List;
 import net.runelite.api.Client;
-import net.runelite.api.NPC;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class NpcInteractingWithNpcRequirement extends SimpleRequirement
 {
@@ -45,7 +42,7 @@ public class NpcInteractingWithNpcRequirement extends SimpleRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.getNpcs().stream()
 			.filter(npc -> npc.getInteracting() != null)

--- a/src/main/java/com/questhelper/requirements/npc/NpcRequirement.java
+++ b/src/main/java/com/questhelper/requirements/npc/NpcRequirement.java
@@ -34,6 +34,7 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class NpcRequirement extends AbstractRequirement
 {
@@ -122,7 +123,7 @@ public class NpcRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		List<NPC> found = client.getNpcs().stream()
 			.filter(npc -> npc.getId() == npcID)

--- a/src/main/java/com/questhelper/requirements/player/CombatLevelRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/CombatLevelRequirement.java
@@ -31,6 +31,7 @@ import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Operation;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Checks if the player's combat level meets the required level
@@ -65,7 +66,7 @@ public class CombatLevelRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		Player player = client.getLocalPlayer();
 		return player != null && operation.check(player.getCombatLevel(), requiredLevel);

--- a/src/main/java/com/questhelper/requirements/player/FreeInventorySlotRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/FreeInventorySlotRequirement.java
@@ -28,14 +28,13 @@
 package com.questhelper.requirements.player;
 
 import com.questhelper.requirements.AbstractRequirement;
-import java.util.Arrays;
 import java.util.Locale;
-import java.util.stream.Stream;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Requirement that checks if a player has a required number of slots free in a given
@@ -62,7 +61,7 @@ public class FreeInventorySlotRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		ItemContainer container = client.getItemContainer(getInventoryID());
 

--- a/src/main/java/com/questhelper/requirements/player/InInstanceRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/InInstanceRequirement.java
@@ -29,11 +29,12 @@ package com.questhelper.requirements.player;
 
 import com.questhelper.requirements.SimpleRequirement;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class InInstanceRequirement extends SimpleRequirement
 {
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.isInInstancedRegion();
 	}

--- a/src/main/java/com/questhelper/requirements/player/IronmanRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/IronmanRequirement.java
@@ -27,6 +27,7 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.util.Utils;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class IronmanRequirement extends AbstractRequirement
 {
@@ -38,7 +39,7 @@ public class IronmanRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.getLocalPlayer() != null &&
 			Utils.getAccountType(client).isAnyIronman() == shouldBeIronman;

--- a/src/main/java/com/questhelper/requirements/player/PrayerPointRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/PrayerPointRequirement.java
@@ -3,6 +3,7 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class PrayerPointRequirement extends AbstractRequirement
 {
@@ -14,7 +15,7 @@ public class PrayerPointRequirement extends AbstractRequirement
 
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return client.getBoostedSkillLevel(Skill.PRAYER) >= level;
 	}

--- a/src/main/java/com/questhelper/requirements/player/PrayerRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/PrayerRequirement.java
@@ -29,6 +29,7 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import net.runelite.api.Client;
 import net.runelite.api.Prayer;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Requirement that checks if a specified {@link Prayer} is active
@@ -51,7 +52,7 @@ public class PrayerRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		int currentPrayer = client.getVarbitValue(prayer.getVarbit());
 		return currentPrayer == 1;

--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -35,6 +35,8 @@ import java.awt.Color;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
+import net.runelite.client.chat.ChatMessageManager;
+
 import static net.runelite.api.Skill.THIEVING;
 
 /**
@@ -109,7 +111,7 @@ public class SkillRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		int skillLevel = canBeBoosted ? Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill)) :
 			client.getRealSkillLevel(skill);
@@ -187,7 +189,7 @@ public class SkillRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public Color getColor(Client client, QuestHelperConfig config)
+	public Color getColor(Client client, ChatMessageManager chatMessageManager, QuestHelperConfig config)
 	{
 		switch (checkBoosted(client, config)){
 			case 1:

--- a/src/main/java/com/questhelper/requirements/player/SpecialAttackRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SpecialAttackRequirement.java
@@ -29,26 +29,27 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.SpecialAttack;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class SpecialAttackRequirement extends AbstractRequirement
 {
-    private static final int SPECIALATTACK_VARP = 301;
-    private final SpecialAttack specialAttack;
+	private static final int SPECIALATTACK_VARP = 301;
+	private final SpecialAttack specialAttack;
 
-    public SpecialAttackRequirement(SpecialAttack specialAttack)
-    {
-        this.specialAttack = specialAttack;
-    }
+	public SpecialAttackRequirement(SpecialAttack specialAttack)
+	{
+		this.specialAttack = specialAttack;
+	}
 
-    @Override
-    public boolean check(Client client)
-    {
-        return specialAttack.check(client, SPECIALATTACK_VARP);
-    }
+	@Override
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
+	{
+		return specialAttack.check(client, SPECIALATTACK_VARP);
+	}
 
-    @Override
-    public String getDisplayText()
-    {
-        return "You must turn " + specialAttack.getName() + " special attack.";
-    }
+	@Override
+	public String getDisplayText()
+	{
+		return "You must turn " + specialAttack.getName() + " special attack.";
+	}
 }

--- a/src/main/java/com/questhelper/requirements/player/SpellbookRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SpellbookRequirement.java
@@ -29,6 +29,7 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Spellbook;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class SpellbookRequirement extends AbstractRequirement
 {
@@ -41,7 +42,7 @@ public class SpellbookRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return spellBook.check(client, SPELLBOOK_VARBIT);
 	}

--- a/src/main/java/com/questhelper/requirements/player/WarriorsGuildAccessRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/WarriorsGuildAccessRequirement.java
@@ -27,6 +27,7 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class WarriorsGuildAccessRequirement extends AbstractRequirement
 {
@@ -36,7 +37,7 @@ public class WarriorsGuildAccessRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		int attLevel = client.getRealSkillLevel(Skill.ATTACK);
 		int strLevel = client.getRealSkillLevel(Skill.STRENGTH);

--- a/src/main/java/com/questhelper/requirements/player/WeightRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/WeightRequirement.java
@@ -29,6 +29,7 @@ package com.questhelper.requirements.player;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Operation;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Checks if the player meets a weight check
@@ -64,7 +65,7 @@ public class WeightRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return operation.check(client.getWeight(), weight);
 	}

--- a/src/main/java/com/questhelper/requirements/quest/QuestPointRequirement.java
+++ b/src/main/java/com/questhelper/requirements/quest/QuestPointRequirement.java
@@ -32,6 +32,7 @@ import com.questhelper.requirements.util.Operation;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.VarPlayer;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Requirement that checks if a player has a required number of quest points.
@@ -68,7 +69,7 @@ public class QuestPointRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return operation.check(client.getVarpValue(VarPlayer.QUEST_POINTS), requiredQuestPoints);
 	}

--- a/src/main/java/com/questhelper/requirements/quest/QuestRequirement.java
+++ b/src/main/java/com/questhelper/requirements/quest/QuestRequirement.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.QuestState;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Requirement that checks if a {@link net.runelite.api.Quest} has a certain state.
@@ -101,7 +102,7 @@ public class QuestRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		if (minimumVarValue != null)
 		{

--- a/src/main/java/com/questhelper/requirements/runelite/PlayerQuestStateRequirement.java
+++ b/src/main/java/com/questhelper/requirements/runelite/PlayerQuestStateRequirement.java
@@ -28,6 +28,7 @@ import com.questhelper.questinfo.PlayerQuests;
 import com.questhelper.requirements.util.Operation;
 import com.questhelper.runeliteobjects.RuneliteConfigSetter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 
 public class PlayerQuestStateRequirement extends RuneliteRequirement
@@ -58,7 +59,7 @@ public class PlayerQuestStateRequirement extends RuneliteRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		String value = getConfigValue();
 		if (operation == null) return expectedValue.equals(value);

--- a/src/main/java/com/questhelper/requirements/runelite/RuneliteRequirement.java
+++ b/src/main/java/com/questhelper/requirements/runelite/RuneliteRequirement.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 
 public class RuneliteRequirement extends AbstractRequirement
@@ -101,16 +102,16 @@ public class RuneliteRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		String value = getConfigValue();
 		return expectedValue.equals(value);
 	}
 
-	public void validateCondition(Client client)
+	public void validateCondition(Client client, ChatMessageManager chatMessageManager)
 	{
 		requirements.forEach((value, req) -> {
-			if (req.check(client)) setConfigValue(value);
+			if (req.check(client, chatMessageManager)) setConfigValue(value);
 		});
 	}
 

--- a/src/main/java/com/questhelper/requirements/util/RequirementBuilder.java
+++ b/src/main/java/com/questhelper/requirements/util/RequirementBuilder.java
@@ -30,6 +30,7 @@ import com.questhelper.requirements.Requirement;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Builder for building non-standard simple {@link Requirement}s.<br>
@@ -78,7 +79,7 @@ public final class RequirementBuilder
 	}
 
 	/**
-	 * Define a new check predicate that is used in {@link Requirement#check(Client)}
+	 * Define a new check predicate that is used in {@link Requirement#check(Client, ChatMessageManager)}
 	 *
 	 * @param requirementPredicate predicate to use
 	 * @return this
@@ -97,7 +98,7 @@ public final class RequirementBuilder
 		return new Requirement()
 		{
 			@Override
-			public boolean check(Client client)
+			public boolean check(Client client, ChatMessageManager chatMessageManager)
 			{
 				return requirementPredicate.test(client);
 			}

--- a/src/main/java/com/questhelper/requirements/var/VarbitRequirement.java
+++ b/src/main/java/com/questhelper/requirements/var/VarbitRequirement.java
@@ -34,6 +34,7 @@ import java.util.Locale;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
+import net.runelite.client.chat.ChatMessageManager;
 
 /**
  * Checks if a player's varbit value is meets the required value as determined by the
@@ -143,7 +144,7 @@ public class VarbitRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		if (bitPosition >= 0)
 		{
@@ -166,4 +167,5 @@ public class VarbitRequirement extends AbstractRequirement
 		}
 		return varbitID + " must be + " + operation.name().toLowerCase(Locale.ROOT) + " " + requiredValue;
 	}
+
 }

--- a/src/main/java/com/questhelper/requirements/var/VarbitRequirement.java
+++ b/src/main/java/com/questhelper/requirements/var/VarbitRequirement.java
@@ -31,7 +31,9 @@ import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Operation;
 import java.math.BigInteger;
 import java.util.Locale;
+import com.questhelper.util.Utils;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.client.chat.ChatMessageManager;
@@ -41,6 +43,7 @@ import net.runelite.client.chat.ChatMessageManager;
  * {@link Operation}
  */
 @Getter
+@Slf4j
 public class VarbitRequirement extends AbstractRequirement
 {
 	private final int varbitID;
@@ -51,6 +54,8 @@ public class VarbitRequirement extends AbstractRequirement
 	// bit positions
 	private boolean bitIsSet = false;
 	private int bitPosition = -1;
+
+	private boolean hasFiredWarning = false;
 
 	/**
 	 * Check if the player's varbit value meets the required level using the given
@@ -146,12 +151,23 @@ public class VarbitRequirement extends AbstractRequirement
 	@Override
 	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
-		if (bitPosition >= 0)
-		{
-			return bitIsSet == BigInteger.valueOf(client.getVarbitValue(varbitID)).testBit(bitPosition);
-		}
+		try {
+			var varbitValue = client.getVarbitValue(varbitID);
+			if (bitPosition >= 0)
+			{
+				return bitIsSet == BigInteger.valueOf(varbitValue).testBit(bitPosition);
+			}
 
-		return operation.check(client.getVarbitValue(varbitID), requiredValue);
+			return operation.check(varbitValue, requiredValue);
+		} catch (IndexOutOfBoundsException e) {
+			if (!hasFiredWarning) {
+				var message = String.format("Error reading varbit %d, please report this in the Quest Helper discord.", varbitID);
+				log.warn(message);
+				Utils.addChatMessage(chatMessageManager, message);
+				hasFiredWarning = true;
+			}
+			return false;
+		}
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/var/VarplayerRequirement.java
+++ b/src/main/java/com/questhelper/requirements/var/VarplayerRequirement.java
@@ -29,10 +29,10 @@ package com.questhelper.requirements.var;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Operation;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import net.runelite.api.Client;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class VarplayerRequirement extends AbstractRequirement
 {
@@ -152,7 +152,7 @@ public class VarplayerRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		int varpValue = client.getVarpValue(varplayerId);
 		if (bitPosition >= 0)

--- a/src/main/java/com/questhelper/requirements/widget/WidgetPresenceRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetPresenceRequirement.java
@@ -32,6 +32,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class WidgetPresenceRequirement extends SimpleRequirement
 {
@@ -60,7 +61,7 @@ public class WidgetPresenceRequirement extends SimpleRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		if (onlyNeedToPassOnce && hasPassed)
 		{

--- a/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
@@ -35,6 +35,7 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class WidgetTextRequirement extends SimpleRequirement
 {
@@ -101,7 +102,7 @@ public class WidgetTextRequirement extends SimpleRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		return checkWidget(client);
 	}

--- a/src/main/java/com/questhelper/requirements/zone/ZoneRequirement.java
+++ b/src/main/java/com/questhelper/requirements/zone/ZoneRequirement.java
@@ -36,6 +36,7 @@ import com.questhelper.requirements.AbstractRequirement;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ZoneRequirement extends AbstractRequirement
 {
@@ -93,7 +94,7 @@ public class ZoneRequirement extends AbstractRequirement
 	}
 
 	@Override
-	public boolean check(Client client)
+	public boolean check(Client client, ChatMessageManager chatMessageManager)
 	{
 		Player player = client.getLocalPlayer();
 		if (player != null && zones != null)

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ExtendedRuneliteObject.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ExtendedRuneliteObject.java
@@ -67,6 +67,7 @@ public class ExtendedRuneliteObject
 	@Getter
 	protected final RuneLiteObject runeliteObject;
 	protected final Client client;
+	protected final ChatMessageManager chatMessageManager;
 	protected final ClientThread clientThread;
 
 	// TODO: Some requirements kinda require an external tracking element, so may need to shove into a ConditionalStep or some weirdness?
@@ -156,9 +157,10 @@ public class ExtendedRuneliteObject
 	@Getter
 	private boolean active = true;
 
-	protected ExtendedRuneliteObject(Client client, ClientThread clientThread, WorldPoint worldPoint, Model model, int animation)
+	protected ExtendedRuneliteObject(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, Model model, int animation)
 	{
 		this.client = client;
+		this.chatMessageManager = chatMessageManager;
 		this.clientThread = clientThread;
 		runeliteObject = client.createRuneLiteObject();
 		this.model = model;
@@ -174,9 +176,9 @@ public class ExtendedRuneliteObject
 		activate();
 	}
 
-	protected ExtendedRuneliteObject(Client client, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
+	protected ExtendedRuneliteObject(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
 	{
-		this(client, clientThread, worldPoint, createModel(client, model).cloneColors().light(), animation);
+		this(client, chatMessageManager, clientThread, worldPoint, createModel(client, model).cloneColors().light(), animation);
 	}
 
 	private static ModelData createModel(Client client, int[] data)
@@ -277,7 +279,7 @@ public class ExtendedRuneliteObject
 
 		updateLocation(lp);
 
-		if ((displayReq == null || displayReq.check(client))
+		if ((displayReq == null || displayReq.check(client, chatMessageManager))
 			&& visible)
 		{
 			if (objectToRemove != null)
@@ -563,7 +565,7 @@ public class ExtendedRuneliteObject
 		{
 			Requirement requirement = dialogTree.getKey();
 			RuneliteDialogStep runeliteDialogStep = dialogTree.getValue();
-			if (requirement == null || requirement.check(client))
+			if (requirement == null || requirement.check(client, chatMessageManager))
 			{
 				if (runeliteDialogStep.isPlayer())
 				{

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeGraphicsObject.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeGraphicsObject.java
@@ -27,24 +27,25 @@ package com.questhelper.runeliteobjects.extendedruneliteobjects;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class FakeGraphicsObject extends ExtendedRuneliteObject
 {
 	ExtendedRuneliteObject objectToSpawnAfter;
-	protected FakeGraphicsObject(Client client, ClientThread clientThread, WorldPoint worldPoint,
+	protected FakeGraphicsObject(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint,
 								 int[] model, int animation, ExtendedRuneliteObject objectToSpawnAfter)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		objectType = RuneliteObjectTypes.GRAPHICS_OBJECT;
 		this.objectToSpawnAfter = objectToSpawnAfter;
 		runeliteObject.setShouldLoop(false);
 		runeliteObject.setActive(false);
 	}
 
-	protected FakeGraphicsObject(Client client, ClientThread clientThread, WorldPoint worldPoint,
+	protected FakeGraphicsObject(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint,
 								 int[] model, int animation)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		objectType = RuneliteObjectTypes.GRAPHICS_OBJECT;
 		this.objectToSpawnAfter = null;
 		runeliteObject.setShouldLoop(false);

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeItem.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeItem.java
@@ -30,12 +30,13 @@ import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class FakeItem extends ExtendedRuneliteObject
 {
-	protected FakeItem(Client client, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
+	protected FakeItem(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		objectType = RuneliteObjectTypes.ITEM;
 		nameColor = "FFA07A";
 	}

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeNpc.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeNpc.java
@@ -29,6 +29,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Model;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class FakeNpc extends ExtendedRuneliteObject
 {
@@ -39,23 +40,23 @@ public class FakeNpc extends ExtendedRuneliteObject
 
 	@Setter
 	boolean alwaysFacePlayer;
-	protected FakeNpc(Client client, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
+	protected FakeNpc(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		objectType = RuneliteObjectTypes.NPC;
 	}
 
-	protected FakeNpc(Client client, ClientThread clientThread, WorldPoint worldPoint, Model model, int animation)
+	protected FakeNpc(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, Model model, int animation)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		this.idleAnimation = animation;
 		objectType = RuneliteObjectTypes.NPC;
 	}
 
 
-	protected FakeNpc(Client client, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation, int idleAnimation)
+	protected FakeNpc(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation, int idleAnimation)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		objectType = RuneliteObjectTypes.NPC;
 		this.idleAnimation = idleAnimation;
 	}

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeObject.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/FakeObject.java
@@ -27,12 +27,13 @@ package com.questhelper.runeliteobjects.extendedruneliteobjects;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class FakeObject extends ExtendedRuneliteObject
 {
-	protected FakeObject(Client client, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
+	protected FakeObject(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, int[] model, int animation)
 	{
-		super(client, clientThread, worldPoint, model, animation);
+		super(client, chatMessageManager, clientThread, worldPoint, model, animation);
 		objectType = RuneliteObjectTypes.OBJECT;
 		nameColor = "00FFFF";
 	}

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ReplacedNpc.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ReplacedNpc.java
@@ -35,6 +35,7 @@ import net.runelite.api.Perspective;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 
 public class ReplacedNpc extends FakeNpc
 {
@@ -52,9 +53,9 @@ public class ReplacedNpc extends FakeNpc
 	@Getter
 	private final List<WidgetReplacement> widgetReplacements = new ArrayList<>();
 
-	protected ReplacedNpc(Client client, ClientThread clientThread, WorldPoint worldPoint, int[] model, int npcIDToReplace)
+	protected ReplacedNpc(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, WorldPoint worldPoint, int[] model, int npcIDToReplace)
 	{
-		super(client, clientThread, worldPoint, model, 808);
+		super(client, chatMessageManager, clientThread, worldPoint, model, 808);
 		this.npcIDToReplace = npcIDToReplace;
 //		disable();
 	}

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/RuneliteObjectManager.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/RuneliteObjectManager.java
@@ -162,7 +162,7 @@ public class RuneliteObjectManager
 
 	public FakeNpc createFakeNpc(String groupID, int[] model, WorldPoint wp, int animation)
 	{
-		FakeNpc extendedRuneliteObject = new FakeNpc(client, clientThread, wp, model, animation, animation);
+		FakeNpc extendedRuneliteObject = new FakeNpc(client, chatMessageManager, clientThread, wp, model, animation, animation);
 		// Should this be here or a separate 'activate' step?
 		extendedRuneliteObject.activate();
 
@@ -174,7 +174,7 @@ public class RuneliteObjectManager
 
 	public FakeNpc createFakeNpc(String groupID, Model model, WorldPoint wp, int animation)
 	{
-		FakeNpc extendedRuneliteObject = new FakeNpc(client, clientThread, wp, model, animation);
+		FakeNpc extendedRuneliteObject = new FakeNpc(client, chatMessageManager, clientThread, wp, model, animation);
 		// Should this be here or a separate 'activate' step?
 		extendedRuneliteObject.activate();
 
@@ -187,7 +187,7 @@ public class RuneliteObjectManager
 	public ReplacedNpc createReplacedNpc(int[] model, WorldPoint wp, int npcIDToReplace)
 	{
 		String groupID = "global";
-		ReplacedNpc extendedRuneliteObject = new ReplacedNpc(client, clientThread, wp, model, npcIDToReplace);
+		ReplacedNpc extendedRuneliteObject = new ReplacedNpc(client, chatMessageManager, clientThread, wp, model, npcIDToReplace);
 		// Should this be here or a separate 'activate' step?
 		for (NPC clientNpc : client.getNpcs())
 		{
@@ -206,7 +206,7 @@ public class RuneliteObjectManager
 
 	public ReplacedNpc createReplacedNpc(String groupID, int[] model, WorldPoint wp, int npcIDToReplace)
 	{
-		ReplacedNpc extendedRuneliteObject = new ReplacedNpc(client, clientThread, wp, model, npcIDToReplace);
+		ReplacedNpc extendedRuneliteObject = new ReplacedNpc(client, chatMessageManager, clientThread, wp, model, npcIDToReplace);
 		// Should this be here or a separate 'activate' step?
 		for (NPC clientNpc : client.getNpcs())
 		{
@@ -225,7 +225,7 @@ public class RuneliteObjectManager
 
 	public FakeItem createFakeItem(String groupID, int[] model, WorldPoint wp, int animation)
 	{
-		FakeItem extendedRuneliteObject = new FakeItem(client, clientThread, wp, model, animation);
+		FakeItem extendedRuneliteObject = new FakeItem(client, chatMessageManager, clientThread, wp, model, animation);
 		// Should this be here or a separate 'activate' step?
 		extendedRuneliteObject.activate();
 
@@ -237,7 +237,7 @@ public class RuneliteObjectManager
 
 	public FakeGraphicsObject createGraphicsFakeObject(String groupID, int[] model, WorldPoint wp, int animation, ExtendedRuneliteObject obj)
 	{
-		FakeGraphicsObject extendedRuneliteObject = new FakeGraphicsObject(client, clientThread, wp, model, animation, obj);
+		FakeGraphicsObject extendedRuneliteObject = new FakeGraphicsObject(client, chatMessageManager, clientThread, wp, model, animation, obj);
 		// Should this be here or a separate 'activate' step?
 		extendedRuneliteObject.activate();
 
@@ -249,7 +249,7 @@ public class RuneliteObjectManager
 
 	public FakeGraphicsObject createGraphicsFakeObject(String groupID, int[] model, WorldPoint wp, int animation)
 	{
-		FakeGraphicsObject extendedRuneliteObject = new FakeGraphicsObject(client, clientThread, wp, model, animation);
+		FakeGraphicsObject extendedRuneliteObject = new FakeGraphicsObject(client, chatMessageManager, clientThread, wp, model, animation);
 		// Should this be here or a separate 'activate' step?
 		extendedRuneliteObject.activate();
 
@@ -261,7 +261,7 @@ public class RuneliteObjectManager
 
 	public FakeObject createFakeObject(String groupID, int[] model, WorldPoint wp, int animation)
 	{
-		FakeObject extendedRuneliteObject = new FakeObject(client, clientThread, wp, model, animation);
+		FakeObject extendedRuneliteObject = new FakeObject(client, chatMessageManager, clientThread, wp, model, animation);
 		// Should this be here or a separate 'activate' step?
 		extendedRuneliteObject.activate();
 
@@ -287,7 +287,7 @@ public class RuneliteObjectManager
 						if (replacedNpc.getNpc() == npc)
 						{
 							Point p = client.getMouseCanvasPosition();
-							boolean passesRequirementToShowReplacement = replacedNpc.getDisplayReq() == null || replacedNpc.getDisplayReq().check(client);
+							boolean passesRequirementToShowReplacement = replacedNpc.getDisplayReq() == null || replacedNpc.getDisplayReq().check(client, chatMessageManager);
 							// is hovered
 							if (!passesRequirementToShowReplacement) return true;
 							if (!replacedNpc.getEntries().isEmpty())
@@ -853,7 +853,7 @@ public class RuneliteObjectManager
 				}
 
 				boolean isVisible = extendedRuneliteObject.isVisible();
-				boolean shouldDisplayReqPassed = extendedRuneliteObject.getDisplayReq() == null || extendedRuneliteObject.getDisplayReq().check(client);
+				boolean shouldDisplayReqPassed = extendedRuneliteObject.getDisplayReq() == null || extendedRuneliteObject.getDisplayReq().check(client, chatMessageManager);
 
 				if (extendedRuneliteObject.objectType == RuneliteObjectTypes.NPC &&
 					(!shouldDisplayReqPassed || isNpcOnTile(extendedRuneliteObject) || isPlayerOnTile(extendedRuneliteObject, playerPosition)))
@@ -884,7 +884,7 @@ public class RuneliteObjectManager
 
 	public void replaceWidgetsForReplacedNpcs(ReplacedNpc object, WidgetLoaded event)
 	{
-		if (object.getDisplayReq() != null && !object.getDisplayReq().check(client)) return;
+		if (object.getDisplayReq() != null && !object.getDisplayReq().check(client, chatMessageManager)) return;
 
 		for (WidgetReplacement widgetReplacement : object.getWidgetReplacements())
 		{

--- a/src/main/java/com/questhelper/statemanagement/AchievementDiaryStepManager.java
+++ b/src/main/java/com/questhelper/statemanagement/AchievementDiaryStepManager.java
@@ -34,6 +34,7 @@ import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
@@ -65,9 +66,9 @@ public class AchievementDiaryStepManager
 		killedWater = new RuneliteRequirement(configManager, "kandarin-easy-killed-water", "true");
 	}
 
-	public static void check(Client client)
+	public static void check(Client client, ChatMessageManager chatMessageManager)
 	{
-		if (!inWorkshop.check(client))
+		if (!inWorkshop.check(client, chatMessageManager))
 		{
 			killedFire.setConfigValue("false");
 			killedEarth.setConfigValue("false");

--- a/src/main/java/com/questhelper/statemanagement/GameStateManager.java
+++ b/src/main/java/com/questhelper/statemanagement/GameStateManager.java
@@ -36,6 +36,7 @@ import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 
@@ -44,6 +45,9 @@ public class GameStateManager
 {
 	@Inject
 	Client client;
+
+	@Inject
+	ChatMessageManager chatMessageManager;
 
 	@Inject
 	ConfigManager configManager;
@@ -88,7 +92,7 @@ public class GameStateManager
 
 		if (chatMessage.getMessage().contains("Achievement Diary Stage Task - "))
 		{
-			AchievementDiaryStepManager.check(client);
+			AchievementDiaryStepManager.check(client, chatMessageManager);
 		}
 	}
 

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -195,7 +195,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 		{
 			for (RuneliteRequirement runeliteCondition : runeliteConditions)
 			{
-				runeliteCondition.validateCondition(client);
+				runeliteCondition.validateCondition(client, chatMessageManager);
 			}
 			updateSteps();
 		}
@@ -221,7 +221,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	@Subscribe
 	public void onChatMessage(ChatMessage chatMessage)
 	{
-		chatConditions.forEach(step -> step.validateCondition(client, chatMessage));
+		chatConditions.forEach(step -> step.validateCondition(client, chatMessageManager, chatMessage));
 
 		if (chatMessage.getType() == ChatMessageType.DIALOG)
 		{
@@ -254,7 +254,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 		for (Requirement conditions : steps.keySet())
 		{
 			boolean stepIsLocked = steps.get(conditions).isLocked();
-			if (conditions != null && conditions.check(client) && !stepIsLocked)
+			if (conditions != null && conditions.check(client, chatMessageManager) && !stepIsLocked)
 			{
 				startUpStep(steps.get(conditions));
 				return;

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -511,7 +511,7 @@ public class DetailedQuestStep extends QuestStep
 		requirementsStream
 			.distinct()
 			.filter(Objects::nonNull)
-			.map(req -> req.getDisplayTextWithChecks(client, questHelper.getConfig()))
+			.map(req -> req.getDisplayTextWithChecks(client, chatMessageManager, questHelper.getConfig()))
 			.flatMap(Collection::stream)
 			.forEach(line -> tmpComponent.getChildren().add(line));
 
@@ -608,7 +608,7 @@ public class DetailedQuestStep extends QuestStep
 
 	private boolean isValidRenderRequirementInInventory(ItemRequirement requirement, Widget item)
 	{
-		return requirement.shouldHighlightInInventory(client) && requirement.getAllIds().contains(item.getItemId());
+		return requirement.shouldHighlightInInventory(client, chatMessageManager) && requirement.getAllIds().contains(item.getItemId());
 	}
 
 	@Subscribe
@@ -792,9 +792,9 @@ public class DetailedQuestStep extends QuestStep
 		return isItemRequirement(requirement)
 			&& requirementIsItem((ItemRequirement) requirement)
 			&& requirementContainsID((ItemRequirement) requirement, ids)
-			&& ((ItemRequirement) requirement).shouldRenderItemHighlights(client)
-			&& ((!considerBankForItemHighlight && !requirement.check(client)) ||
+			&& ((ItemRequirement) requirement).shouldRenderItemHighlights(client, chatMessageManager)
+			&& ((!considerBankForItemHighlight && !requirement.check(client, chatMessageManager)) ||
 			(considerBankForItemHighlight &&
-				!((ItemRequirement) requirement).check(client, false, questBank.getBankItems())));
+				!((ItemRequirement) requirement).check(client, chatMessageManager, false, questBank.getBankItems())));
 	}
 }

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -61,6 +61,7 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
@@ -72,6 +73,9 @@ public abstract class QuestStep implements Module
 {
 	@Inject
 	protected Client client;
+
+	@Inject
+	protected ChatMessageManager chatMessageManager;
 
 	@Inject
 	protected ClientThread clientThread;
@@ -457,7 +461,7 @@ public abstract class QuestStep implements Module
 
 	public boolean isLocked()
 	{
-		boolean autoLocked = lockingCondition != null && lockingCondition.check(client);
+		boolean autoLocked = lockingCondition != null && lockingCondition.check(client, chatMessageManager);
 		unlockable = !autoLocked;
 		if (autoLocked)
 		{

--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -47,17 +47,22 @@ public class Utils
 	 */
 	public AccountType getAccountType(@NotNull Client client)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN) return AccountType.NORMAL;
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return AccountType.NORMAL;
+		}
 		return AccountType.get(client.getVarbitValue(Varbits.ACCOUNT_TYPE));
 	}
 
 	/**
 	 * Unpack a widget ID (Component) into a widget group ID (Interface) and widget child ID
+	 *
 	 * @param componentId the {@link Component}
 	 * @return the corresponding Interface & Child ID
 	 */
 	@Component
-	public Pair<Integer, Integer> unpackWidget(@Component int componentId) {
+	public Pair<Integer, Integer> unpackWidget(@Component int componentId)
+	{
 		return Pair.of(componentId >> 16, componentId & 0xFFFF);
 	}
 

--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -27,13 +27,17 @@ package com.questhelper.util;
 
 import com.questhelper.domain.AccountType;
 import lombok.experimental.UtilityClass;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Varbits;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.client.util.ColorUtil;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import net.runelite.api.annotations.Component;
-import net.runelite.api.annotations.Interface;
+import java.awt.*;
 
 @UtilityClass
 public class Utils
@@ -64,6 +68,18 @@ public class Utils
 	public Pair<Integer, Integer> unpackWidget(@Component int componentId)
 	{
 		return Pair.of(componentId >> 16, componentId & 0xFFFF);
+	}
+
+	public void addChatMessage(ChatMessageManager chatMessageManager, String message)
+	{
+		var formatted = String.format("[%s] %s", ColorUtil.wrapWithColorTag("Quest Helper", Color.CYAN), message);
+
+		chatMessageManager.queue(
+			QueuedMessage.builder()
+				.type(ChatMessageType.CONSOLE)
+				.runeLiteFormattedMessage(formatted)
+				.build()
+		);
 	}
 
 }

--- a/src/test/java/com/questhelper/helpers/quests/thepathofglouphrie/SolutionTest.java
+++ b/src/test/java/com/questhelper/helpers/quests/thepathofglouphrie/SolutionTest.java
@@ -116,7 +116,7 @@ public class SolutionTest extends MockedTest
 	@ArgumentsSource(Solvable.class)
 	public void testSolvable(List<Item> items, int puzzle1SolutionValue, int puzzle2SolutionValue)
 	{
-		solution.load(client, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
+		solution.load(client, chatMessageManager, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
 
 		assertTrue(solution.isGood());
 	}
@@ -125,7 +125,7 @@ public class SolutionTest extends MockedTest
 	@ArgumentsSource(NotSolvable.class)
 	public void testNotSolvable(List<Item> items, int puzzle1SolutionValue, int puzzle2SolutionValue)
 	{
-		solution.load(client, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
+		solution.load(client, chatMessageManager, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
 
 		assertFalse(solution.isGood());
 	}
@@ -137,7 +137,7 @@ public class SolutionTest extends MockedTest
 								final List<Integer> expectedExchanges,
 								final List<Integer> expectedExchangesFor)
 	{
-		solution.load(client, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
+		solution.load(client, chatMessageManager, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
 
 		assertFalse(solution.isGood());
 


### PR DESCRIPTION
Previously, if a varbit failed to read (e.g. if the varbit had been deleted), we didn't handle the exception causing the helper & client to misbehave.
Now, we catch the exception & post a message in chat instructing the user to notify us via the Quest Helper discord.
To be able to achieve this, I have changed the signature of `check` to contain the `ChatMessageManager`

To test this, open the Kourend medium diary helper & skip the steps until you get to the bluegill step, it should show up like the image below

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/b719ac6e-b79a-4af0-b36f-7a4cb249b4e1)

Questions:
 - Is the color for the chat message ok?
