### PR TITLE
feat: Warn on failed varbit reads (without big refactor)

### DIFF
--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -47,17 +47,22 @@ public class Utils
 	 */
 	public AccountType getAccountType(@NotNull Client client)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN) return AccountType.NORMAL;
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return AccountType.NORMAL;
+		}
 		return AccountType.get(client.getVarbitValue(Varbits.ACCOUNT_TYPE));
 	}
 
 	/**
 	 * Unpack a widget ID (Component) into a widget group ID (Interface) and widget child ID
+	 *
 	 * @param componentId the {@link Component}
 	 * @return the corresponding Interface & Child ID
 	 */
 	@Component
-	public Pair<Integer, Integer> unpackWidget(@Component int componentId) {
+	public Pair<Integer, Integer> unpackWidget(@Component int componentId)
+	{
 		return Pair.of(componentId >> 16, componentId & 0xFFFF);
 	}
 

--- a/src/main/java/com/questhelper/util/Utils.java
+++ b/src/main/java/com/questhelper/util/Utils.java
@@ -27,15 +27,19 @@ package com.questhelper.util;
 
 import com.questhelper.domain.AccountType;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Varbits;
+import net.runelite.client.util.ColorUtil;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import net.runelite.api.annotations.Component;
-import net.runelite.api.annotations.Interface;
+import java.awt.*;
 
 @UtilityClass
+@Slf4j
 public class Utils
 {
 	/**
@@ -64,6 +68,18 @@ public class Utils
 	public Pair<Integer, Integer> unpackWidget(@Component int componentId)
 	{
 		return Pair.of(componentId >> 16, componentId & 0xFFFF);
+	}
+
+	public void addChatMessage(Client client, String message)
+	{
+		if (!client.isClientThread()) {
+			log.warn("Chat message tried to be added from outside of GUI thread. The message was: {}", message);
+			return;
+		}
+
+		var formatted = String.format("[%s] %s", ColorUtil.wrapWithColorTag("Quest Helper", Color.CYAN), message);
+
+		client.addChatMessage(ChatMessageType.CONSOLE, "", formatted, "");
 	}
 
 }


### PR DESCRIPTION
Previously, if a varbit failed to read (e.g. if the varbit had been deleted), we didn't handle the exception causing the helper & client to misbehave.
Now, we catch the exception & post a message in chat instructing the user to notify us via the Quest Helper discord.
This uses `client.addChatMessage` which can only be called from the client thread. The varbit check function is only ever called from there, so for this use this is ok.

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/875be675-5e59-49ce-9f6c-fc4f0be79a48)


To test this, open the Kourend medium diary helper & skip the steps until you get to the bluegill step, it should show up like the image below

Questions:
 - Is the color for the chat message ok?

