### PR TITLE
feat: store Account Type (e.g. ironman) in PlayerStateManager

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -40,7 +40,7 @@ import com.questhelper.questinfo.QuestHelperQuest;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.runeliteobjects.Cheerer;
 import com.questhelper.runeliteobjects.GlobalFakeObjects;
-import com.questhelper.statemanagement.GameStateManager;
+import com.questhelper.statemanagement.PlayerStateManager;
 import com.questhelper.runeliteobjects.RuneliteConfigSetter;
 import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectManager;
 import com.google.inject.Module;
@@ -169,7 +169,7 @@ public class QuestHelperPlugin extends Plugin
 
 	@Getter
 	@Inject
-	GameStateManager gameStateManager;
+	PlayerStateManager playerStateManager;
 
 	@Inject
 	public SkillIconManager skillIconManager;
@@ -205,9 +205,9 @@ public class QuestHelperPlugin extends Plugin
 		questBankManager.startUp(injector, eventBus);
 		eventBus.register(worldMapAreaManager);
 
-		injector.injectMembers(gameStateManager);
-		eventBus.register(gameStateManager);
-		gameStateManager.startUp();
+		injector.injectMembers(playerStateManager);
+		eventBus.register(playerStateManager);
+		playerStateManager.startUp();
 
 		eventBus.register(runeliteObjectManager);
 		runeliteObjectManager.startUp();
@@ -244,7 +244,7 @@ public class QuestHelperPlugin extends Plugin
 	{
 		runeliteObjectManager.shutDown();
 
-		eventBus.unregister(gameStateManager);
+		eventBus.unregister(playerStateManager);
 		eventBus.unregister(runeliteObjectManager);
 		eventBus.unregister(worldMapAreaManager);
 		questOverlayManager.shutDown();

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -35,12 +35,9 @@ import com.questhelper.managers.QuestManager;
 import com.questhelper.managers.QuestMenuHandler;
 import com.questhelper.managers.QuestOverlayManager;
 import com.questhelper.panel.QuestHelperPanel;
-import com.questhelper.questhelpers.QuestDetails;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.questinfo.QuestHelperQuest;
-import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
-import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.runeliteobjects.Cheerer;
 import com.questhelper.runeliteobjects.GlobalFakeObjects;
 import com.questhelper.statemanagement.GameStateManager;
@@ -50,14 +47,12 @@ import com.google.inject.Module;
 import com.questhelper.util.worldmap.WorldMapAreaManager;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.swing.SwingUtilities;
@@ -71,8 +66,6 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.MenuEntry;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.WorldType;
 import net.runelite.api.events.ChatMessage;
@@ -90,7 +83,6 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ClientShutdown;
 import net.runelite.client.events.ConfigChanged;
-import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SkillIconManager;
@@ -240,7 +232,7 @@ public class QuestHelperPlugin extends Plugin
 		clientThread.invokeLater(() -> {
 			if (client.getGameState() == GameState.LOGGED_IN)
 			{
-				setupRequirements();
+				questManager.setupRequirements();
 				questManager.setupOnLogin();
 				GlobalFakeObjects.createNpcs(client, runeliteObjectManager, configManager, config);
 			}
@@ -304,7 +296,7 @@ public class QuestHelperPlugin extends Plugin
 		{
 			profileChanged = false;
 			questManager.shutDownQuest(true);
-			setupRequirements();
+			questManager.setupRequirements();
 			newVersionManager.updateChatWithNotificationIfNewVersion();
 			GlobalFakeObjects.createNpcs(client, runeliteObjectManager, configManager, config);
 			questBankManager.setUnknownInitialState();
@@ -316,14 +308,6 @@ public class QuestHelperPlugin extends Plugin
 	private void onRuneScapeProfileChanged(RuneScapeProfileChanged ev)
 	{
 		profileChanged = true;
-	}
-
-	private void setupRequirements()
-	{
-		for (QuestHelperQuest questHelperQuest : QuestHelperQuest.values())
-		{
-			questHelperQuest.getQuestHelper().setupRequirements();
-		}
 	}
 
 	@Subscribe

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -296,11 +296,13 @@ public class QuestHelperPlugin extends Plugin
 		{
 			profileChanged = false;
 			questManager.shutDownQuest(true);
-			questManager.setupRequirements();
-			newVersionManager.updateChatWithNotificationIfNewVersion();
 			GlobalFakeObjects.createNpcs(client, runeliteObjectManager, configManager, config);
+			newVersionManager.updateChatWithNotificationIfNewVersion();
 			questBankManager.setUnknownInitialState();
-			clientThread.invokeLater(() -> questManager.setupOnLogin());
+			clientThread.invokeAtTickEnd(() -> {
+				questManager.setupRequirements();
+				questManager.setupOnLogin();
+			});
 		}
 	}
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
@@ -258,7 +258,7 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		grapYan2 = new ObjectStep(this, ObjectID.WALL_17048, new WorldPoint(2556, 3075, 1),
 			"Jump off the opposite side!");
 
-		if (questHelperPlugin.getGameStateManager().getAccountType() == AccountType.ULTIMATE_IRONMAN)
+		if (questHelperPlugin.getPlayerStateManager().getAccountType() == AccountType.ULTIMATE_IRONMAN)
 		{
 			claimSand = new ObjectStep(this, ObjectID.SANDPIT, new WorldPoint(2543, 3104, 0),
 				"Fill a bucket with sand using Bert's sand pit.", bucket);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import com.questhelper.util.Utils;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -259,7 +258,7 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		grapYan2 = new ObjectStep(this, ObjectID.WALL_17048, new WorldPoint(2556, 3075, 1),
 			"Jump off the opposite side!");
 
-		if (Utils.getAccountType(client) == AccountType.ULTIMATE_IRONMAN)
+		if (questHelperPlugin.getGameStateManager().getAccountType() == AccountType.ULTIMATE_IRONMAN)
 		{
 			claimSand = new ObjectStep(this, ObjectID.SANDPIT, new WorldPoint(2543, 3104, 0),
 				"Fill a bucket with sand using Bert's sand pit.", bucket);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
@@ -262,7 +262,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 
 		tpEnakhra = new DetailedQuestStep(this, "Teleport to Enakhra's Temple with the Camulet.", camulet);
 
-		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			tpPollnivneach = new DetailedQuestStep(this, "Move your house to Pollnivneach, then enter your house " +
 				"there.", coins.quantity(7500));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import com.questhelper.util.Utils;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -263,7 +262,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 
 		tpEnakhra = new DetailedQuestStep(this, "Teleport to Enakhra's Temple with the Camulet.", camulet);
 
-		if (Utils.getAccountType(client).isAnyIronman())
+		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 		{
 			tpPollnivneach = new DetailedQuestStep(this, "Move your house to Pollnivneach, then enter your house " +
 				"there.", coins.quantity(7500));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
@@ -51,7 +51,6 @@ import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
-import com.questhelper.util.Utils;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 
@@ -396,7 +395,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		generalRequirements.add(new SkillRequirement(Skill.AGILITY, 42, true));
 		generalRequirements.add(new SkillRequirement(Skill.CRAFTING, 40, true));
 		generalRequirements.add(new SkillRequirement(Skill.DEFENCE, 20));
-		if (Utils.getAccountType(client).isAnyIronman())
+		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 		{
 			// 47 Farming is required to get a Watermelon for the "Brain not included" step
 			generalRequirements.add(new SkillRequirement(Skill.FARMING, 47, true));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
@@ -395,7 +395,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		generalRequirements.add(new SkillRequirement(Skill.AGILITY, 42, true));
 		generalRequirements.add(new SkillRequirement(Skill.CRAFTING, 40, true));
 		generalRequirements.add(new SkillRequirement(Skill.DEFENCE, 20));
-		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			// 47 Farming is required to get a Watermelon for the "Brain not included" step
 			generalRequirements.add(new SkillRequirement(Skill.FARMING, 47, true));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
@@ -402,7 +402,7 @@ public class VarrockHard extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50));
 		reqs.add(new SkillRequirement(Skill.FARMING, 68, true));
 		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60));
-		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			reqs.add(new SkillRequirement(Skill.HUNTER, 69, true));
 		}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
@@ -46,7 +46,6 @@ import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.*;
 
-import com.questhelper.util.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -403,7 +402,7 @@ public class VarrockHard extends ComplexStateQuestHelper
 		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50));
 		reqs.add(new SkillRequirement(Skill.FARMING, 68, true));
 		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60));
-		if (Utils.getAccountType(client).isAnyIronman())
+		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 		{
 			reqs.add(new SkillRequirement(Skill.HUNTER, 69, true));
 		}

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import com.questhelper.util.Utils;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -938,7 +937,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 
 		enterDeathAltarBarrier = new ObjectStep(this, NullObjectID.NULL_9788, new WorldPoint(1865, 4639, 0), "Enter the barrier to the death altar to the west.");
 
-		if (Utils.getAccountType(client).isAnyIronman())
+		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 		{
 			if (client.getRealSkillLevel(Skill.SLAYER) > 85)
 			{

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -937,7 +937,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 
 		enterDeathAltarBarrier = new ObjectStep(this, NullObjectID.NULL_9788, new WorldPoint(1865, 4639, 0), "Enter the barrier to the death altar to the west.");
 
-		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			if (client.getRealSkillLevel(Skill.SLAYER) > 85)
 			{

--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
@@ -54,7 +54,6 @@ import com.questhelper.steps.QuestStep;
 
 import java.util.*;
 
-import com.questhelper.util.Utils;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -306,7 +305,7 @@ public class RFDPiratePete extends BasicQuestHelper
 	{
 		ArrayList<Requirement> generalReqs = new ArrayList<>();
 		generalReqs.add(new SkillRequirement(Skill.COOKING, 31));
-		if (Utils.getAccountType(client).isAnyIronman())
+		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 		{
 			generalReqs.add(new ComplexRequirement(LogicType.OR, "42 Crafting or started Rum Deal for a fishbowl",
 				new SkillRequirement(Skill.CRAFTING, 42, true),

--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDPiratePete.java
@@ -305,7 +305,7 @@ public class RFDPiratePete extends BasicQuestHelper
 	{
 		ArrayList<Requirement> generalReqs = new ArrayList<>();
 		generalReqs.add(new SkillRequirement(Skill.COOKING, 31));
-		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			generalReqs.add(new ComplexRequirement(LogicType.OR, "42 Crafting or started Rum Deal for a fishbowl",
 				new SkillRequirement(Skill.CRAFTING, 42, true),

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
@@ -56,7 +56,6 @@ import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.QuestStep;
-import com.questhelper.util.Utils;
 import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
@@ -338,7 +337,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			if (Utils.getAccountType(client).isAnyIronman())
+			if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 			{
 				splitLogs8.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 				splitLogs4.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
@@ -557,7 +556,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 	public void setupPanels()
 	{
-		if (Utils.getAccountType(client).isAnyIronman())
+		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
 		{
 			prepareForRepairPanel = new PanelDetails("Helping Mawnis", Arrays.asList(talkToMawnis, talkToMawnisWithLogs, repairBridge1, talkToMawnisAfterRepair), rope8, axe, knife);
 			prepareForCombatPanel = new PanelDetails("Preparing to fight", Arrays.asList(getYakArmour, makeShield), needle, thread, coins15, bronzeNail, hammer, rope);

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
@@ -337,7 +337,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+			if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 			{
 				splitLogs8.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
 				splitLogs4.setTooltip("Cut down the arctic pines nearby, and split them on the woodcutting stump in central Neitiznot");
@@ -556,7 +556,7 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 	public void setupPanels()
 	{
-		if (questHelperPlugin.getGameStateManager().getAccountType().isAnyIronman())
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			prepareForRepairPanel = new PanelDetails("Helping Mawnis", Arrays.asList(talkToMawnis, talkToMawnisWithLogs, repairBridge1, talkToMawnisAfterRepair), rope8, axe, knife);
 			prepareForCombatPanel = new PanelDetails("Preparing to fight", Arrays.asList(getYakArmour, makeShield), needle, thread, coins15, bronzeNail, hammer, rope);

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -93,7 +93,6 @@ public class QuestManager
 	private QuestHelperPanel panel;
 	private QuestStep lastStep = null;
 
-
 	public Map<String, QuestHelper> backgroundHelpers = new HashMap<>();
 	public SortedMap<QuestHelperQuest, List<ItemRequirement>> itemRequirements = new TreeMap<>();
 	public SortedMap<QuestHelperQuest, List<ItemRequirement>> itemRecommended = new TreeMap<>();
@@ -527,6 +526,14 @@ public class QuestManager
 		else
 		{
 			startUpBackgroundQuest(QuestHelperQuest.CHECK_ITEMS.getName());
+		}
+	}
+
+	public void setupRequirements()
+	{
+		for (QuestHelperQuest questHelperQuest : QuestHelperQuest.values())
+		{
+			questHelperQuest.getQuestHelper().setupRequirements();
 		}
 	}
 }

--- a/src/main/java/com/questhelper/statemanagement/GameStateManager.java
+++ b/src/main/java/com/questhelper/statemanagement/GameStateManager.java
@@ -132,12 +132,7 @@ public class GameStateManager
 				return;
 			}
 
-			if (newAccountType != accountType) {
-				accountType = newAccountType;
-
-				// NOTE: This currently means that any non-ironman account has all quest requirements setup twice
-				questManager.setupRequirements();
-			}
+			accountType = newAccountType;
 		}
 	}
 }

--- a/src/main/java/com/questhelper/statemanagement/PlayerStateManager.java
+++ b/src/main/java/com/questhelper/statemanagement/PlayerStateManager.java
@@ -45,7 +45,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 
 @Singleton
-public class GameStateManager
+public class PlayerStateManager
 {
 	@Inject
 	Client client;

--- a/src/test/java/com/questhelper/MockedTest.java
+++ b/src/test/java/com/questhelper/MockedTest.java
@@ -26,8 +26,10 @@
 package com.questhelper;
 
 import com.google.inject.testing.fieldbinder.Bind;
+import com.questhelper.domain.AccountType;
 import com.questhelper.managers.QuestOverlayManager;
 import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectManager;
+import com.questhelper.statemanagement.PlayerStateManager;
 import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.callback.Hooks;
@@ -41,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import javax.inject.Named;
 import java.util.concurrent.ScheduledExecutorService;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -76,6 +79,9 @@ public abstract class MockedTest extends MockedTestBase
 	protected Hooks hooks = Mockito.mock(Hooks.class);
 
 	@Bind
+	protected PlayerStateManager playerStateManager = Mockito.mock(PlayerStateManager.class);
+
+	@Bind
 	protected QuestHelperPlugin questHelperPlugin = Mockito.mock(QuestHelperPlugin.class);
 
 	@Bind
@@ -99,6 +105,9 @@ public abstract class MockedTest extends MockedTestBase
 	protected void setUp()
 	{
 		super.setUp();
+
+		when(questHelperPlugin.getPlayerStateManager()).thenReturn(playerStateManager);
+		when(playerStateManager.getAccountType()).thenReturn(AccountType.NORMAL);
 
 		// init client mocks
 		// when(client.getWorldType()).thenReturn(EnumSet.noneOf(WorldType.class));


### PR DESCRIPTION
This fixes an issue where the requirements were being built off the client thread & tried to access the account type to make certain decisions. Now those decisions can be made based on the last cached value.

The meaty change takes place in https://github.com/Zoinkwiz/quest-helper/pull/1557/files#diff-6cb742383761b936054e8727d98f95eae56260b27b01e53d3f09e5615f1bf46eR297-R305 where the order & timing of some of the initializations are made.

Some unrelated changes I've made:
1. `GameStateManager` renamed to `PlayerStateManager` (as discussed in #development)
2. `setupRequirements` that iterates over all quest helpers & refreshes their requirements has been moved from `QuestHelperPlugin` to `QuestManager`. This makes it a bit easier to access from places like `PlayerStateManager`

You can test this on a single character by using the `::setvarb 1777` command (e.g. `::setvarb 1777 0` to fake yourself into a normal account, and `::setvarb 1777 1` to fake yourself into an ironman, you just need to re-open the helper afterwards.

I've tested this & made sure that the Falador Medium Diary shows 47 Farming as the requirement when I'm on my UIM, and logging onto my main sometimes shows the main Farming requirement of 23 instead.

Known issues:
If you are an iron, have the Falador Medium Diary helper up, and de-iron, the quest helper won't update. I think this is fine