### PR TITLE
feat: list numbers of active skill filters next to the dropdown

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -218,7 +218,7 @@ public class QuestHelperPlugin extends Plugin
 
 		final BufferedImage icon = Icon.QUEST_ICON.getImage();
 
-		panel = new QuestHelperPanel(this, questManager);
+		panel = new QuestHelperPanel(this, questManager, configManager);
 		questManager.startUp(panel);
 		navButton = NavigationButton.builder()
 			.tooltip("Quest Helper")
@@ -339,6 +339,7 @@ public class QuestHelperPlugin extends Plugin
 		if (event.getGroup().equals(QuestHelperConfig.QUEST_BACKGROUND_GROUP))
 		{
 			clientThread.invokeLater(questManager::updateQuestList);
+			SwingUtilities.invokeLater(panel::refreshSkillFiltering);
 		}
 
 		if (!event.getGroup().equals(QuestHelperConfig.QUEST_HELPER_GROUP))

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -88,7 +88,7 @@ public class QuestHelperPanel extends PluginPanel
 	private final FixedWidthPanel questListWrapper = new FixedWidthPanel();
 	private final JScrollPane scrollableContainer;
 	public static final int DROPDOWN_HEIGHT = 26;
-//	private boolean settingsPanelActive = false;
+	//	private boolean settingsPanelActive = false;
 	public boolean questActive = false;
 
 	private final ArrayList<QuestSelectPanel> questSelectPanels = new ArrayList<>();
@@ -602,18 +602,24 @@ public class QuestHelperPanel extends PluginPanel
 	/**
 	 * Refreshes the label showing the active skill filters
 	 */
-	public void refreshSkillFiltering() {
+	public void refreshSkillFiltering()
+	{
 		var numFilteredSkills = 0;
-		for (var skill : Skill.values()) {
+		for (var skill : Skill.values())
+		{
 			var isFiltered = "true".equals(configManager.getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "skillfilter" + skill.getName()));
-			if (isFiltered) {
+			if (isFiltered)
+			{
 				numFilteredSkills += 1;
 			}
 		}
 
-		if (numFilteredSkills == 0) {
+		if (numFilteredSkills == 0)
+		{
 			skillExpandButton.setText("");
-		} else {
+		}
+		else
+		{
 			skillExpandButton.setText(String.format("%d active", numFilteredSkills));
 		}
 	}


### PR DESCRIPTION
I've noticed some support tickets coming in regarding quests not being visible, and often the cause is that the user has accidentally, or just forgotten, that they've enabled some skill filter.

This PR aims to make it easier both for users & for support members to identify this by showing how many (if any) skill filters are enabled next to the "Skill filtering" setting

### No skill filter active, menu collapsed

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/34c1d9b8-8107-469e-8307-7fe38dfef723)

### No skill filter active, menu expanded

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/8014370e-89b7-4b8a-bbf2-58ef94ae8b28)

### 3 skill filters active, menu collapsed

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/785d07de-2321-4419-8fcf-aa965aebc60b)

### 3 skill filters active, menu expanded

![image](https://github.com/Zoinkwiz/quest-helper/assets/962989/4c4d5635-caec-4d22-b23e-5d69cc169adc)
