### PR TITLE
Remove event name changing in the QuestBankTab

### DIFF
--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -220,12 +220,6 @@ public class QuestBankTab
 		if ("getSearchingTagTab".equals(eventName))
 		{
 			intStack[intStackSize - 1] = questBankTabInterface.isQuestTabActive() ? 1 : 0;
-			if (questBankTabInterface.isQuestTabActive())
-			{
-				// As we're on the quest helper tab, we don't need to check again for tab tags
-				// Change the name of the event so as to not proc another check
-				event.setEventName("getSearchingQuestHelperTab");
-			}
 		}
 	}
 


### PR DESCRIPTION
Tried wracking my brain for why this was important when I added it, but even the comment doesn't help me lol. Everything 'seems' to work properly without it, and it avoids any potential future issues. I have a hunch it might've been something to do with the quest filtering functionality sometimes getting overrided by a normal bank tab, but I've not seen that happen without it 🤷 .

It'd be great if I could get a second pair of eyes on it just to make sure nothing is out of place.