### PR TITLE
feat: highlight spell widget based on spell name

### DIFF
--- a/src/main/java/com/questhelper/steps/AbstractWidgetHighlight.java
+++ b/src/main/java/com/questhelper/steps/AbstractWidgetHighlight.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Zoinkwiz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.steps;
+
+import com.questhelper.QuestHelperPlugin;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
+
+public abstract class AbstractWidgetHighlight
+{
+	public abstract void highlightChoices(Graphics2D graphics, Client client, QuestHelperPlugin questHelper);
+
+	protected void highlightWidget(Graphics2D graphics, QuestHelperPlugin questHelper, Widget widgetToHighlight)
+	{
+		if (widgetToHighlight == null) {
+			return;
+		}
+
+		graphics.setColor(new Color(questHelper.getConfig().targetOverlayColor().getRed(),
+			questHelper.getConfig().targetOverlayColor().getGreen(),
+			questHelper.getConfig().targetOverlayColor().getBlue(), 65));
+		graphics.fill(widgetToHighlight.getBounds());
+		graphics.setColor(questHelper.getConfig().targetOverlayColor());
+		graphics.draw(widgetToHighlight.getBounds());
+	}
+}

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -412,7 +412,7 @@ public class DetailedQuestStep extends QuestStep
 		}
 
 		renderInventory(graphics);
-		for (WidgetHighlights widgetHighlights : widgetsToHighlight)
+		for (AbstractWidgetHighlight widgetHighlights : widgetsToHighlight)
 		{
 			widgetHighlights.highlightChoices(graphics, client, plugin);
 		}

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -368,6 +368,11 @@ public abstract class QuestStep implements Module
 		widgetsToHighlight.clear();
 	}
 
+	public void addSpellHighlight(String spellName)
+	{
+		widgetsToHighlight.add(new SpellWidgetHighlight(spellName));
+	}
+
 	public void addWidgetHighlight(int groupID, int childID)
 	{
 		widgetsToHighlight.add(new WidgetHighlight(groupID, childID));

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -133,7 +133,7 @@ public abstract class QuestStep implements Module
 	protected WidgetChoiceSteps widgetChoices = new WidgetChoiceSteps();
 
 	@Getter
-	protected List<WidgetHighlights> widgetsToHighlight = new ArrayList<>();
+	protected List<AbstractWidgetHighlight> widgetsToHighlight = new ArrayList<>();
 
 	@Getter
 	private final List<QuestStep> substeps = new ArrayList<>();
@@ -370,17 +370,17 @@ public abstract class QuestStep implements Module
 
 	public void addWidgetHighlight(int groupID, int childID)
 	{
-		widgetsToHighlight.add(new WidgetHighlights(groupID, childID));
+		widgetsToHighlight.add(new WidgetHighlight(groupID, childID));
 	}
 
 	public void addWidgetHighlight(int groupID, int childID, int childChildID)
 	{
-		widgetsToHighlight.add(new WidgetHighlights(groupID, childID, childChildID));
+		widgetsToHighlight.add(new WidgetHighlight(groupID, childID, childChildID));
 	}
 
 	public void addWidgetHighlightWithItemIdRequirement(int groupID, int childID, int itemID, boolean checkChildren)
 	{
-		widgetsToHighlight.add(new WidgetHighlights(groupID, childID, itemID, checkChildren));
+		widgetsToHighlight.add(new WidgetHighlight(groupID, childID, itemID, checkChildren));
 	}
 
 	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, @NonNull List<String> additionalText, @NonNull List<Requirement> additionalRequirements)

--- a/src/main/java/com/questhelper/steps/SpellWidgetHighlight.java
+++ b/src/main/java/com/questhelper/steps/SpellWidgetHighlight.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, pajlada <https://github.com/pajlada>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.steps;
+
+import com.questhelper.QuestHelperPlugin;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.InterfaceID;
+import net.runelite.client.util.Text;
+import java.awt.*;
+
+/**
+ * Highlight a spell in the spellbook with a given spell name
+ * <p>
+ * Use this over a raw group id + child id highlight combination for spells where possible since
+ * spells being moved from Jagex may change the child id
+ */
+public class SpellWidgetHighlight extends AbstractWidgetHighlight
+{
+	/**
+	 * The InterfaceID.SPELLBOOK child that contains the list of spell widgets
+	 */
+	private static final int SPELLBOOK_SPELL_LIST_CHILD_ID = 3;
+
+	/**
+	 * The name of the spell to search for without tags (e.g. "Ardougne Teleport")
+	 */
+	private final String spellName;
+
+	/**
+	 * Internal state for whether to perform a full search next time the spellbook is visible
+	 */
+	private boolean redoSearch = true;
+
+	/**
+	 * The final full component ID of the spell widget
+	 */
+	private Integer spellComponentId = null;
+
+	public SpellWidgetHighlight(String spellName)
+	{
+		this.spellName = spellName;
+	}
+
+	@Override
+	public void highlightChoices(Graphics2D graphics, Client client, QuestHelperPlugin questHelper)
+	{
+		var spellbookWidget = client.getWidget(InterfaceID.SPELLBOOK, SpellWidgetHighlight.SPELLBOOK_SPELL_LIST_CHILD_ID);
+		if (spellbookWidget == null || spellbookWidget.isHidden())
+		{
+			redoSearch = true;
+			return;
+		}
+
+		if (redoSearch)
+		{
+			spellComponentId = null;
+			var staticChildren = spellbookWidget.getStaticChildren();
+			if (staticChildren != null)
+			{
+				for (var widget : staticChildren)
+				{
+					if (Text.removeTags(widget.getName()).equals(spellName))
+					{
+						spellComponentId = widget.getId();
+						break;
+					}
+				}
+
+				redoSearch = false;
+			}
+		}
+
+		if (spellComponentId != null)
+		{
+			var spellWidget = client.getWidget(spellComponentId);
+			if (spellWidget == null || spellWidget.isHidden())
+			{
+				// Widget is not visible
+				return;
+			}
+
+			// NOTE: This is overly cautious, we confirm that the widget we're about to highlight matches
+			// the spell name we're searching for. So far, this has never fired
+			if (!Text.removeTags(spellWidget.getName()).equals(spellName))
+			{
+				spellComponentId = null;
+				redoSearch = true;
+				return;
+			}
+
+			highlightWidget(graphics, questHelper, spellWidget);
+		}
+	}
+}

--- a/src/main/java/com/questhelper/steps/WidgetHighlight.java
+++ b/src/main/java/com/questhelper/steps/WidgetHighlight.java
@@ -25,13 +25,12 @@
 package com.questhelper.steps;
 
 import com.questhelper.QuestHelperPlugin;
-import java.awt.Color;
-import java.awt.Graphics2D;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
+import java.awt.*;
 
-public class WidgetHighlights
+public class WidgetHighlight extends AbstractWidgetHighlight
 {
 	@Getter
 	protected final int groupId;
@@ -45,7 +44,7 @@ public class WidgetHighlights
 
 	protected final boolean checkChildren;
 
-	public WidgetHighlights(int groupId, int childId)
+	public WidgetHighlight(int groupId, int childId)
 	{
 		this.groupId = groupId;
 		this.childId = childId;
@@ -53,7 +52,7 @@ public class WidgetHighlights
 		this.checkChildren = false;
 	}
 
-	public WidgetHighlights(int groupId, int childId, int childChildId)
+	public WidgetHighlight(int groupId, int childId, int childChildId)
 	{
 		this.groupId = groupId;
 		this.childId = childId;
@@ -61,7 +60,7 @@ public class WidgetHighlights
 		this.checkChildren = false;
 	}
 
-	public WidgetHighlights(int groupId, int childId, int itemIdRequirement, boolean checkChildren)
+	public WidgetHighlight(int groupId, int childId, int itemIdRequirement, boolean checkChildren)
 	{
 		this.groupId = groupId;
 		this.childId = childId;
@@ -70,6 +69,7 @@ public class WidgetHighlights
 		this.checkChildren = checkChildren;
 	}
 
+	@Override
 	public void highlightChoices(Graphics2D graphics, Client client, QuestHelperPlugin questHelper)
 	{
 		Widget widgetToHighlight = client.getWidget(groupId, childId);
@@ -79,7 +79,7 @@ public class WidgetHighlights
 		highlightChoices(widgetToHighlight, graphics, questHelper);
 	}
 
-	public void highlightChoices(Widget parentWidget, Graphics2D graphics, QuestHelperPlugin questHelper)
+	private void highlightChoices(Widget parentWidget, Graphics2D graphics, QuestHelperPlugin questHelper)
 	{
 		if (parentWidget == null) return;
 
@@ -104,18 +104,14 @@ public class WidgetHighlights
 			}
 		}
 
-		highlightChoice(graphics, questHelper, parentWidget);
+		highlightWidget(graphics, questHelper, parentWidget);
 	}
 
-	private void highlightChoice(Graphics2D graphics, QuestHelperPlugin questHelper, Widget widgetToHighlight)
+	@Override
+	protected void highlightWidget(Graphics2D graphics, QuestHelperPlugin questHelper, Widget widgetToHighlight)
 	{
 		if (widgetToHighlight == null || (itemIdRequirement != null && widgetToHighlight.getItemId() != itemIdRequirement)) return;
 
-		graphics.setColor(new Color(questHelper.getConfig().targetOverlayColor().getRed(),
-			questHelper.getConfig().targetOverlayColor().getGreen(),
-			questHelper.getConfig().targetOverlayColor().getBlue(), 65));
-		graphics.fill(widgetToHighlight.getBounds());
-		graphics.setColor(questHelper.getConfig().targetOverlayColor());
-		graphics.draw(widgetToHighlight.getBounds());
+		super.highlightWidget(graphics, questHelper, widgetToHighlight);
 	}
 }


### PR DESCRIPTION
I went with the OOP approach of making the existing `WidgetHighlights` into an abstract class (now `AbstractWidgetHighlight`), moving the old implementation to `WidgetHighlight`.

`SpellWidgetHighlight` extends `AbstractWidgetHighlight` and adds the `addSpellHighlight` function to quest steps.

Example usage:
```java
castNormalSpellbookSpell = new ObjectStep(this, ObjectID.ANCIENT_GATE_2930, new WorldPoint(2763, 9314, 0), "Cast a charge orb spell on the ancient gate.", normalSpellbook);
castNormalSpellbookSpell.addSpellHighlight("Camelot Teleport");
```

The implementation of `SpellWidgetHighlight` is stateful in its approach to ensure we don't look for the spell more than necessary.
Right now, a spell search only takes place once every time the spellbook is opened. Theoretically, this might not even be necessary, as we might just need to do it once in total.
https://github.com/Zoinkwiz/quest-helper/pull/1578/files#diff-1e58a657a71bcd5ce13d4f0cd7a6657f49e5acc831ce50d45c2a8197876a9f6eR72 could be removed to only search once, but I have not tried that out

Every time the widget is highlighted, I confirm the spell name is actually what we're looking for https://github.com/Zoinkwiz/quest-helper/pull/1578/files#diff-1e58a657a71bcd5ce13d4f0cd7a6657f49e5acc831ce50d45c2a8197876a9f6eR104-R111 in case the component id is reused for something else. I never noticed this failing, but I thought I'd leave it here to rather be safe than sorry.

There are one potentially sticky portions: We hardcode the child ID of the spell list, since it's not something RuneLite themselves use we won't get this auto updated.