### PR TITLE
fix: Only try to setup highlights in sidebar once quest is loaded

### DIFF
--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -156,7 +156,7 @@ public class QuestManager
 			{
 				panel.updateSteps();
 				QuestStep currentStep = selectedQuest.getCurrentStep().getSidePanelStep();
-				if (currentStep != null && currentStep != lastStep)
+				if (currentStep != null && currentStep != lastStep && panel.questActive)
 				{
 					lastStep = currentStep;
 					panel.updateHighlight(client, currentStep);


### PR DESCRIPTION
There was an issue of the quest being counted as loaded in QuestManager, but that not having yet propagated to the panels. This adds a check to wait for them to be ready to be updated.