### PR TITLE
Fix: Add hammer as requirement for smithing step

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessHard.java
@@ -361,7 +361,7 @@ public class WildernessHard extends ComplexStateQuestHelper
 		allSteps.add(trollSteps);
 
 		PanelDetails scimSteps = new PanelDetails("Adamant Scimitar in Resource Area", Arrays.asList(moveToResource,
-			addyScim), new SkillRequirement(Skill.SMITHING, 75), barsOrPick);
+			addyScim), new SkillRequirement(Skill.SMITHING, 75), barsOrPick, hammer);
 		scimSteps.setDisplayCondition(notAddyScim);
 		scimSteps.setLockingStep(addyScimTask);
 		allSteps.add(scimSteps);


### PR DESCRIPTION
Trivial.
lmk if there is anything else I need to add. It was already part of the total requirements but was never put into the panel.

# Current
![image](https://github.com/Zoinkwiz/quest-helper/assets/54869170/847377aa-5e08-4a7b-850d-5702dacb2452)
