### PR TITLE
Fix broken requirement inits

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinElite.java
@@ -252,7 +252,7 @@ public class KandarinElite extends ComplexStateQuestHelper
 	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
-		setupGeneralRequirements();
+		initializeRequirements();
 
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new SkillRequirement(Skill.AGILITY, 60, true));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
@@ -305,7 +305,7 @@ public class KandarinHard extends ComplexStateQuestHelper
 	@Override
 	public List<Requirement> getGeneralRequirements()
 	{
-		setupGeneralRequirements();
+		initializeRequirements();
 		ArrayList<Requirement> req = new ArrayList<>();
 
 		req.add(new SkillRequirement(Skill.AGILITY, 60, true));

--- a/src/main/java/com/questhelper/helpers/quests/royaltrouble/RoyalTrouble.java
+++ b/src/main/java/com/questhelper/helpers/quests/royaltrouble/RoyalTrouble.java
@@ -227,6 +227,8 @@ public class RoyalTrouble extends BasicQuestHelper
 		coal1 = new ItemRequirement("Coal", ItemID.COAL, 1);
 		coal1.setHighlightInInventory(true);
 
+		pickaxe = new ItemRequirement("A pickaxe", ItemCollections.PICKAXES).isNotConsumed();
+
 		if (client.getRealSkillLevel(Skill.MINING) >= 30)
 		{
 			coalOrPickaxe = new ItemRequirements(LogicType.OR, "Either 5 coal or a pickaxe", coal5, pickaxe);
@@ -241,7 +243,6 @@ public class RoyalTrouble extends BasicQuestHelper
 			coalOrPickaxe = coal5;
 		}
 
-		pickaxe = new ItemRequirement("A pickaxe", ItemCollections.PICKAXES).isNotConsumed();
 		combatGear = new ItemRequirement("Combat gear", -1, -1).isNotConsumed();
 		combatGear.setDisplayItemId(BankSlotIcons.getCombatGear());
 		prayerPotions = new ItemRequirement("Prayer potions", ItemCollections.PRAYER_POTIONS, -1);


### PR DESCRIPTION
This is due to a report from nightfirecat on the Runelite Discord, of the condition for the quest requirements not being initialized in a certain scenario.

I wasn't able to reproduce it, but this should ensure that it shouldn't be possible at the very least.