### PR TITLE
Use any crossbow for ThePathOfGlouphrie.

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/ThePathOfGlouphrie.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/ThePathOfGlouphrie.java
@@ -181,10 +181,7 @@ public class ThePathOfGlouphrie extends BasicQuestHelper
 	{
 		/// Required items
 		var rovingElvesNotStarted = new QuestRequirement(QuestHelperQuest.ROVING_ELVES, QuestState.NOT_STARTED);
-		crossbow = new ItemRequirement("Any crossbow", ItemID.CROSSBOW).isNotConsumed();
-		crossbow.addAlternates(ItemID.BRONZE_CROSSBOW, ItemID.IRON_CROSSBOW, ItemID.STEEL_CROSSBOW,
-			ItemID.MITHRIL_CROSSBOW, ItemID.ADAMANT_CROSSBOW, ItemID.RUNE_CROSSBOW, ItemID.DRAGON_CROSSBOW,
-			ItemID.BLURITE_CROSSBOW, ItemID.DORGESHUUN_CROSSBOW, ItemID.ARMADYL_CROSSBOW, ItemID.ZARYTE_CROSSBOW);
+		crossbow = new ItemRequirement("Any crossbow", ItemCollections.CROSSBOWS).isNotConsumed();
 		mithGrapple = new ItemRequirement("Mith grapple", ItemID.MITH_GRAPPLE_9419).isNotConsumed();
 		// NOTE: This does NOT have a step attached
 		// I didn't have any character available that hadn't started the Roving Elves quest


### PR DESCRIPTION
The list was manually adding alternatives and missed the dragon hunter crossbow. Rather than appending it manually, I opted to reuse the `ItemCollections.CROSSBOWS`.