### PR TITLE
fix: quests not initializing on first load if starting from empty profile

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -227,7 +227,7 @@ public class QuestHelperPlugin extends Plugin
 
 		clientToolbar.addNavigation(navButton);
 
-		clientThread.invokeLater(() -> {
+		clientThread.invokeAtTickEnd(() -> {
 			if (client.getGameState() == GameState.LOGGED_IN)
 			{
 				questManager.setupRequirements();


### PR DESCRIPTION
Fixes #1638

reproduction steps described in the linked issue
