### PR TITLE
Project Rebalance Achievement Diary Agility Shortcut Changes

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
@@ -313,8 +313,7 @@ public class DesertHard extends ComplexStateQuestHelper
 	{
 		return Arrays.asList(
 			new UnlockReward("Pharaoh's sceptre can hold up to 50 charges"),
-			new UnlockReward("Access to the big window shortcut in Al Kharid Palace that takes you to the south of the palace, " +
-				"just north of the Shantay Pass, requiring 70 Agility"),
+			new UnlockReward("Access to the shortcut just north of the Shantay Pass, requiring 70 Agility"),
 			new UnlockReward("Unlocked the ability to toggle the Camulet teleport location between the inside and outside of Enakhra's Temple"),
 			new UnlockReward("All carpet rides are free"),
 			new UnlockReward("Zahur will create unfinished potions for 200 coins per potion from a vial of water and a clean herb. Items can be noted or unnoted"),

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
@@ -313,7 +313,6 @@ public class DesertHard extends ComplexStateQuestHelper
 	{
 		return Arrays.asList(
 			new UnlockReward("Pharaoh's sceptre can hold up to 50 charges"),
-			new UnlockReward("Access to the shortcut just north of the Shantay Pass, requiring 70 Agility"),
 			new UnlockReward("Unlocked the ability to toggle the Camulet teleport location between the inside and outside of Enakhra's Temple"),
 			new UnlockReward("All carpet rides are free"),
 			new UnlockReward("Zahur will create unfinished potions for 200 coins per potion from a vial of water and a clean herb. Items can be noted or unnoted"),

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
@@ -317,7 +317,8 @@ public class DesertHard extends ComplexStateQuestHelper
 			new UnlockReward("All carpet rides are free"),
 			new UnlockReward("Zahur will create unfinished potions for 200 coins per potion from a vial of water and a clean herb. Items can be noted or unnoted"),
 			new UnlockReward("Zahur will now clean noted grimy herbs for 200 coins each"),
-			new UnlockReward("Ropes placed at both the Kalphite Lair entrance and the Kalphite Queen tunnel entrance become permanent")
+			new UnlockReward("Ropes placed at both the Kalphite Lair entrance and the Kalphite Queen tunnel entrance become permanent"),
+			new UnlockReward("The Rellekka Rooftop Course will give additional experience upon completion")
 		);
 	}
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikHard.java
@@ -307,7 +307,9 @@ public class FremennikHard extends ComplexStateQuestHelper
 			new UnlockReward("Ability to change enchanted lyre teleport destination to Waterbirth Island."),
 			new UnlockReward("Aviansies in the God Wars Dungeon will drop noted adamantite bars."),
 			new UnlockReward("Stony Basalt teleport destination can be changed to the roof of Troll Stronghold"),
-			new UnlockReward("Access to 2 new Lunar Spells, Charge Dragonstone and Tan Leather"));
+			new UnlockReward("Access to 2 new Lunar Spells, Charge Dragonstone and Tan Leather"),
+			new UnlockReward("The Rellekka Rooftop Course will give additional experience upon completion")
+		);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikHard.java
@@ -306,7 +306,6 @@ public class FremennikHard extends ComplexStateQuestHelper
 		return Arrays.asList(
 			new UnlockReward("Ability to change enchanted lyre teleport destination to Waterbirth Island."),
 			new UnlockReward("Aviansies in the God Wars Dungeon will drop noted adamantite bars."),
-			new UnlockReward("Shortcut to roof on the Troll Stronghold"),
 			new UnlockReward("Stony Basalt teleport destination can be changed to the roof of Troll Stronghold"),
 			new UnlockReward("Access to 2 new Lunar Spells, Charge Dragonstone and Tan Leather"));
 	}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikMedium.java
@@ -438,9 +438,7 @@ public class FremennikMedium extends ComplexStateQuestHelper
 	@Override
 	public List<UnlockReward> getUnlockRewards()
 	{
-		return Arrays.asList(
-			new UnlockReward("Shortcut jump between Miscellania dock and Etceteria."),
-			new UnlockReward("Improved rate of gaining approval on Miscellania."));
+		return Arrays.asList(new UnlockReward("Improved rate of gaining approval on Miscellania."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaElite.java
@@ -198,7 +198,6 @@ public class KaramjaElite extends ComplexStateQuestHelper
 			new UnlockReward("Free usage of Shilo Village's furnace"),
 			new UnlockReward("Free cart rides on Hajedy's cart system"),
 			new UnlockReward("Free access to the Hardwood Grove"),
-			new UnlockReward("Access to the stepping stones shortcut leading to the red dragons in Brimhaven Dungeon"),
 			new UnlockReward("Red and Metal in Brimhaven Dungeon will drop noted dragonhide and bars"),
 			new UnlockReward("One free resurrection per day in the Fight Caves (Not the Inferno)"),
 			new UnlockReward("Double Tokkul from TzHaar Fight Caves, Inferno and Ket-Rak's Challenges"));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
@@ -393,8 +393,7 @@ public class KaramjaMedium extends BasicQuestHelper
 	{
 		return Arrays.asList(
 			new UnlockReward("Increased Agility Experience when redeeming Agility tickets"),
-			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena"),
-			new UnlockReward("Access to the stepping stone shortcut across the river of Shilo Village"));
+			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena")
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
@@ -393,7 +393,7 @@ public class KaramjaMedium extends BasicQuestHelper
 	{
 		return Arrays.asList(
 			new UnlockReward("Increased Agility Experience when redeeming Agility tickets"),
-			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena")
+			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
@@ -393,7 +393,7 @@ public class KaramjaMedium extends BasicQuestHelper
 	{
 		return Arrays.asList(
 			new UnlockReward("Increased Agility Experience when redeeming Agility tickets"),
-			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena"));
+			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena when wearing Karamja gloves"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -378,7 +378,6 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		return Arrays.asList(
 			new UnlockReward("50% run energy replenish 4 times a day from Explorer's ring"),
 			new UnlockReward("Unlimited teleports to cabbage patch near Falador farm for Explorer's ring"),
-			new UnlockReward("Access to a shortcut from Lumbridge Swamp to the desert"),
 			new UnlockReward("10% increased experience from Tears of Guthix")
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
@@ -312,8 +312,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 	{
 		return Arrays.asList(
 			new UnlockReward("50% run energy replenish 3 times a day from Explorer's ring"),
-			new UnlockReward("Three daily teleports to cabbage patch near Falador farm for Explorer's ring"),
-			new UnlockReward("Access to Draynor Village wall shortcut")
+			new UnlockReward("Three daily teleports to cabbage patch near Falador farm for Explorer's ring")
 		);
 	}
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaHard.java
@@ -382,7 +382,6 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 			new UnlockReward("Robin offers 26 free buckets of slime and 26 pots of bonemeal in exchange for bones each day"),
 			new UnlockReward("Double Mort myre fungi when casting Bloom"),
 			new UnlockReward("50% more Prayer experience from burning shade remains"),
-			new UnlockReward("Access to a shortcut across the estuary on Mos Le'Harmless"),
 			new UnlockReward("50% more runes from the Barrows chest"),
 			new UnlockReward("7.5% more Slayer experience in the Slayer Tower while on a Slayer task")
 		);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessElite.java
@@ -330,7 +330,7 @@ public class WildernessElite extends ComplexStateQuestHelper
 			new UnlockReward("Unlimited free teleports to the Fountain of Rune on the Wilderness Sword 4"),
 			new UnlockReward("Free entry to the Resource Area"),
 			new UnlockReward("All dragon bones drops in the Wilderness are noted. (Note: This does not include the King Black Dragon, as his lair is not Wilderness affected.)"),
-			new UnlockReward("	Noted lava dragon bones can be toggled by speaking to the Lesser Fanatic."),
+			new UnlockReward("Noted lava dragon bones can be toggled by speaking to the Lesser Fanatic."),
 			new UnlockReward("50 random free runes from Lundail once per day"),
 			new UnlockReward("Increased dark crab catch rate")
 		);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessMedium.java
@@ -321,8 +321,7 @@ public class WildernessMedium extends ComplexStateQuestHelper
 			new UnlockReward("Increases the chance of a successful yield from ents by 15%"),
 			new UnlockReward("20% off entry to Resource Area (6000gp)"),
 			new UnlockReward("Can have 4 ecumenical keys at a time"),
-			new UnlockReward("20 random free runes from Lundail once per day"),
-			new UnlockReward("Access to the shortcut in the Deep Wilderness Dungeon (requires Agility 46 )")
+			new UnlockReward("20 random free runes from Lundail once per day")
 		);
 	}
 


### PR DESCRIPTION
https://secure.runescape.com/m=news/project-rebalance-skilling--poll-81-mta-changes?oldschool=1

Achievement Diary requirements were removed from some agility shortcuts. This PR brings the achievement diaries up to date. 
