### PR TITLE
fix: Add item already had check for background highlighting

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/allneededitems/AllNeededItems.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/allneededitems/AllNeededItems.java
@@ -53,7 +53,7 @@ public class AllNeededItems extends ComplexStateQuestHelper
 		step1.hideRequirements = true;
 		step1.considerBankForItemHighlight = true;
 		step1.iconToUseForNeededItems = SpriteID.TAB_QUESTS;
-		step1.setBackgroundWorldTooltipText("Highlighted due to the config setting 'Highlight missing items'.");
+		step1.setBackgroundWorldTooltipText("Highlighted due to the config setting 'Highlight missing items' in Quest Helper.");
 
 		return step1;
 	}

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -887,6 +887,7 @@ public class DetailedQuestStep extends QuestStep
 		return requirements.stream().anyMatch((item) ->  item instanceof ItemRequirement &&
 			type == MenuAction.GROUND_ITEM_THIRD_OPTION &&
 			((ItemRequirement) item).getAllIds().contains(itemID) &&
+			!((ItemRequirement) item).check(client, false, questBank.getBankItems()) &&
 			option.equals("Take"));
 	}
 }


### PR DESCRIPTION
This should ensure the background helper overlay text should only appear where the normal item highlighting does.