### PR TITLE
Fix: Goblin Diplomacy Item Reqs for GE/Bank

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/goblindiplomacy/GoblinDiplomacy.java
+++ b/src/main/java/com/questhelper/helpers/quests/goblindiplomacy/GoblinDiplomacy.java
@@ -121,6 +121,7 @@ public class GoblinDiplomacy extends BasicQuestHelper
 		goblinMailTwo = new ItemRequirement("Goblin mail", ItemID.GOBLIN_MAIL, 2);
 
 		goblinMail = new ItemRequirement("Goblin mail", ItemID.GOBLIN_MAIL);
+		goblinMail.canBeObtainedDuringQuest();
 		goblinMail.setTooltip("You can get goblin mail by killing goblins around goblin village.");
 		goblinMail.setHighlightInInventory(true);
 

--- a/src/main/java/com/questhelper/helpers/quests/goblindiplomacy/GoblinDiplomacy.java
+++ b/src/main/java/com/questhelper/helpers/quests/goblindiplomacy/GoblinDiplomacy.java
@@ -210,7 +210,7 @@ public class GoblinDiplomacy extends BasicQuestHelper
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
 		PanelDetails getArmours = new PanelDetails("Prepare goblin mail",
-			Arrays.asList(goUpLadder, getCrate2, getCrate3, dyeBlue, dyeOrange), blueDye, orangeDye);
+			Arrays.asList(goUpLadder, getCrate2, getCrate3, dyeBlue, dyeOrange), blueDye, orangeDye, goblinMailThree);
 		allSteps.add(getArmours);
 
 		allSteps.add(new PanelDetails("Present the armours", Arrays.asList(talkToGeneral1, talkToGeneral2, talkToGeneral3)));


### PR DESCRIPTION
The GE/Bank item search only includes item requirements that are part of a requirement in the panel steps. 

If we add the goblin mail as part of the requirements for the step "Prepare goblin mail" then it will show in the GE/bank. 

![image](https://github.com/user-attachments/assets/930d20f0-00e0-49b7-9e11-124e93381e0c)

![image](https://github.com/user-attachments/assets/1dfaffa2-0c27-4622-8b42-46e8957d8e6f)
