### PR TITLE
AllNeededItems: specify in tooltip that "Highlight missing items" behavior is a Quest Helper config setting

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/allneededitems/AllNeededItems.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/allneededitems/AllNeededItems.java
@@ -53,7 +53,7 @@ public class AllNeededItems extends ComplexStateQuestHelper
 		step1.hideRequirements = true;
 		step1.considerBankForItemHighlight = true;
 		step1.iconToUseForNeededItems = SpriteID.TAB_QUESTS;
-		step1.setBackgroundWorldTooltipText("Highlighted due to the config setting 'Highlight missing items' in Quest Helper.");
+		step1.setBackgroundWorldTooltipText("Highlighted due to the Quest Helper config setting 'Highlight missing items' in Quest Helper.");
 
 		return step1;
 	}


### PR DESCRIPTION
This tooltip has definitely cut back of the number of messages in RuneLite support related to "Highlight missing items" being enabled, but there is still occasional traffic about it.

This PR changes the message to say that it's specifically a Quest Helper setting, rather than just saying it's a config setting.