### PR TITLE
fix: Corrected west->east order in Lunar Diplomacy Memory Puzzle

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/MemoryChallenge.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/MemoryChallenge.java
@@ -121,10 +121,10 @@ public class MemoryChallenge extends DetailedQuestStep
 
 	private void setupPaths()
 	{
-		int current1 = client.getVarbitValue(2415);
-		int current2 = client.getVarbitValue(2414);
-		int current3 = client.getVarbitValue(2413);
-		int current4 = client.getVarbitValue(2412);
+		int current1 = client.getVarbitValue(2412);
+		int current2 = client.getVarbitValue(2413);
+		int current3 = client.getVarbitValue(2414);
+		int current4 = client.getVarbitValue(2415);
 
 		if (current1 == column1 &&
 			current2 == column2 &&
@@ -150,10 +150,10 @@ public class MemoryChallenge extends DetailedQuestStep
 
 		for (int row = 0; row < ROWS; row++)
 		{
-			grid[row][0] = (west >> (ROWS - 1 - row)) & 1;
-			grid[row][1] = (middleWest >> (ROWS - 1 - row)) & 1;
-			grid[row][2] = (middleEast >> (ROWS - 1 - row)) & 1;
-			grid[row][3] = (east >> (ROWS - 1 - row)) & 1;
+			grid[ROWS - 1 - row][0] = (west >> (ROWS - 1 - row)) & 1;
+			grid[ROWS - 1 - row][1] = (middleWest >> (ROWS - 1 - row)) & 1;
+			grid[ROWS - 1 - row][2] = (middleEast >> (ROWS - 1 - row)) & 1;
+			grid[ROWS - 1 - row][3] = (east >> (ROWS - 1 - row)) & 1;
 		}
 
 		return grid;

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/MemoryChallenge.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/MemoryChallenge.java
@@ -121,10 +121,10 @@ public class MemoryChallenge extends DetailedQuestStep
 
 	private void setupPaths()
 	{
-		int current1 = client.getVarbitValue(2412);
-		int current2 = client.getVarbitValue(2413);
-		int current3 = client.getVarbitValue(2414);
-		int current4 = client.getVarbitValue(2415);
+		int current1 = client.getVarbitValue(2415);
+		int current2 = client.getVarbitValue(2414);
+		int current3 = client.getVarbitValue(2413);
+		int current4 = client.getVarbitValue(2412);
 
 		if (current1 == column1 &&
 			current2 == column2 &&


### PR DESCRIPTION
I think this is right, looking at what the values stored were for the varbits used for the columns of the memory puzzle. However, ideally we do test this first.