### PR TITLE
fix: Correctly updated KC in barrows helper

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/BarrowsHelper.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/hisfaithfulservants/BarrowsHelper.java
@@ -277,6 +277,7 @@ public class BarrowsHelper extends ComplexStateQuestHelper
 			// Got chest
 			else if (lastKc != currentKc)
 			{
+				lastKc = currentKc;
 				escapeCrypt.setShouldPass(true);
 				// set leave to true
 			}


### PR DESCRIPTION
This means the route will update correctly upon re-entering the crypts for another run.