### PR TITLE
Updated size of widget overlay

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/betweenarock/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/betweenarock/PuzzleStep.java
@@ -210,6 +210,12 @@ public class PuzzleStep extends DetailedQuestStep
 			Widget widget = client.getWidget(114, entry.getKey());
 			if (widget != null)
 			{
+				if (widget.getId() == 7471130)
+				{
+					widget.setOriginalWidth(15);
+					widget.setOriginalHeight(15);
+					widget.revalidate();
+				}
 				graphics.setColor(new Color(getQuestHelper().getConfig().targetOverlayColor().getRed(),
 					getQuestHelper().getConfig().targetOverlayColor().getGreen(),
 					getQuestHelper().getConfig().targetOverlayColor().getBlue(), 65));


### PR DESCRIPTION
The width and height of the widget overlay were set to 36 instead of 15. I added a condition to check for the widget id 7471130 and then update its width and height to 15. Resolves [#632 ](https://github.com/Zoinkwiz/quest-helper/issues/632)