### PR TITLE
feat: Require premade blurb for Death Plateau

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deathplateau/DeathPlateau.java
+++ b/src/main/java/com/questhelper/helpers/quests/deathplateau/DeathPlateau.java
@@ -65,7 +65,7 @@ public class DeathPlateau extends BasicQuestHelper
 	ItemRequirement gamesNecklace;
 
 	//Items Required
-	ItemRequirement asgarnianAle, premadeBlurbOrCoins, coins, bread, trout, ironBar, iou, iouHighlight, redStone, blueStone,
+	ItemRequirement asgarnianAle, premadeBlurb, coins, bread, trout, ironBar, iou, iouHighlight, redStone, blueStone,
 		yellowStone, pinkStone, greenStone, certificate, climbingBoots, spikedBoots, secretMap, combination;
 
 	Requirement inCastleDownstairs, inCastleUpstairs, inBarDownstairs, inBarUpstairs, inHaroldsRoom,
@@ -150,13 +150,9 @@ public class DeathPlateau extends BasicQuestHelper
 	{
 		asgarnianAle = new ItemRequirement("Asgarnian ale", ItemID.ASGARNIAN_ALE);
 
-		ItemRequirement premadeBlurb = new ItemRequirement("Premade blurb' sp.", ItemID.PREMADE_BLURB_SP);
+		premadeBlurb = new ItemRequirement("Premade blurb' sp.", ItemID.PREMADE_BLURB_SP);
 		premadeBlurb.addAlternates(ItemID.BLURBERRY_SPECIAL);
-		ItemRequirement coins500 = new ItemRequirement("Coins", ItemCollections.COINS, 500);
-
-		premadeBlurbOrCoins = new ItemRequirements(LogicType.OR,
-			"Premade blurb' sp. (or a Blurberry special, or 500 coins to gamble with)",
-			premadeBlurb, coins500);
+		premadeBlurb.setTooltip("You can buy one from bar on the east side of the Grand Tree on the 1st floor");
 		coins = new ItemRequirement("Coins", ItemCollections.COINS, 60);
 		bread = new ItemRequirement("Bread (UNNOTED)", ItemID.BREAD, 10);
 		trout = new ItemRequirement("Trout (UNNOTED)", ItemID.TROUT, 10);
@@ -241,14 +237,14 @@ public class DeathPlateau extends BasicQuestHelper
 		talkToEohric2 = new NpcStep(this, NpcID.EOHRIC, new WorldPoint(2900, 3566, 1), "Talk to Eohric.");
 		talkToEohric2.addSubSteps(goToEohric2);
 
-		takeAsgarnianAle = new DetailedQuestStep(this, new WorldPoint(2906, 3538, 0), "Take an Asgarnian ale from the bar.", coins, asgarnianAle, premadeBlurbOrCoins);
+		takeAsgarnianAle = new DetailedQuestStep(this, new WorldPoint(2906, 3538, 0), "Take an Asgarnian ale from the bar.", coins, asgarnianAle, premadeBlurb);
 
-		goToHaroldStairs2 = new ObjectStep(this, ObjectID.STAIRCASE_15645, new WorldPoint(2915, 3540, 0), "Talk to Harold.", coins, asgarnianAle, premadeBlurbOrCoins);
-		goToHaroldDoor2 = new ObjectStep(this, ObjectID.DOOR_3747, new WorldPoint(2906, 3543, 1), "Talk to Harold.", coins, asgarnianAle, premadeBlurbOrCoins);
-		talkToHarold2 = new NpcStep(this, NpcID.HAROLD, new WorldPoint(2906, 3540, 1), "Talk to Harold.", coins, asgarnianAle, premadeBlurbOrCoins);
+		goToHaroldStairs2 = new ObjectStep(this, ObjectID.STAIRCASE_15645, new WorldPoint(2915, 3540, 0), "Talk to Harold.", coins, asgarnianAle, premadeBlurb);
+		goToHaroldDoor2 = new ObjectStep(this, ObjectID.DOOR_3747, new WorldPoint(2906, 3543, 1), "Talk to Harold.", coins, asgarnianAle, premadeBlurb);
+		talkToHarold2 = new NpcStep(this, NpcID.HAROLD, new WorldPoint(2906, 3540, 1), "Talk to Harold.", coins, asgarnianAle, premadeBlurb);
 		talkToHarold2.addSubSteps(goToHaroldStairs2, goToHaroldDoor2);
 
-		giveHaroldBlurberry = new NpcStep(this, NpcID.HAROLD, new WorldPoint(2906, 3540, 1), "Talk to Harold to give him a Blurberry Special.", coins, premadeBlurbOrCoins);
+		giveHaroldBlurberry = new NpcStep(this, NpcID.HAROLD, new WorldPoint(2906, 3540, 1), "Talk to Harold to give him a Blurberry Special.", coins, premadeBlurb);
 		giveHaroldBlurberry.addDialogStep(3, "Can I buy you a drink?");
 
 		gambleWithHarold = new NpcStep(this, NpcID.HAROLD, new WorldPoint(2906, 3540, 1), "Gamble with Harold (101 coins to immediately bankrupt him).", coins);
@@ -304,7 +300,7 @@ public class DeathPlateau extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(coins, premadeBlurbOrCoins, ironBar, bread, trout);
+		return Arrays.asList(coins, premadeBlurb, ironBar, bread, trout);
 	}
 
 	@Override
@@ -343,7 +339,7 @@ public class DeathPlateau extends BasicQuestHelper
 	public List<PanelDetails> getPanels()
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
-		allSteps.add(new PanelDetails("The equipment room", Arrays.asList(talkToDenulth1, talkToEohric1, talkToHarold1, talkToEohric2, takeAsgarnianAle, talkToHarold2, giveHaroldBlurberry, gambleWithHarold, readIou, placeStones), coins, premadeBlurbOrCoins));
+		allSteps.add(new PanelDetails("The equipment room", Arrays.asList(talkToDenulth1, talkToEohric1, talkToHarold1, talkToEohric2, takeAsgarnianAle, talkToHarold2, giveHaroldBlurberry, gambleWithHarold, readIou, placeStones), coins, premadeBlurb));
 		allSteps.add(new PanelDetails("Get spiked boots", Arrays.asList(enterSabaCave, talkToSaba, talkToTenzing1, talkToDunstan1, talkToDunstan2), ironBar));
 		allSteps.add(new PanelDetails("The secret path", Arrays.asList(talkToTenzing2, goNorth, talkToDenulth3), bread, trout));
 		return allSteps;


### PR DESCRIPTION
Technically you can get lucky with gambling and win without it, but there is too much chance for us to direct a player to not use it.

fixes #1685.