### PR TITLE
Fix: Karamja diary reward changes - Access to Shilo Village Mine

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaHard.java
@@ -349,8 +349,7 @@ public class KaramjaHard extends ComplexStateQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-			new UnlockReward("Unlimited Teleports to the underground Shilo Village mine"),
-			new UnlockReward("Access to the underground Shilo Village mine"));
+			new UnlockReward("Unlimited Teleports to the underground Shilo Village mine"));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaMedium.java
@@ -392,8 +392,9 @@ public class KaramjaMedium extends BasicQuestHelper
 	public List<UnlockReward> getUnlockRewards()
 	{
 		return Arrays.asList(
-			new UnlockReward("Increased Agility Experience when redeeming Agility tickets"),
-			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena when wearing Karamja gloves"));
+			new UnlockReward("Increased Agility Experience when redeeming Agility tickets when wearing Karamja gloves"),
+			new UnlockReward("10% increased Agility experience earned from Brimhaven Agility Arena when wearing Karamja gloves"), 
+			new UnlockReward("Access to the underground portion of the Shilo Village mine"));
 	}
 
 	@Override


### PR DESCRIPTION
There was a change to the Karamja diaries in May 2024:
  
  Access to the underground portion of the Shilo Village mine is now granted upon completion of the Medium Karamja Diary. 
  
  https://oldschool.runescape.wiki/w/Karamja_Diary

I also added that the medium diary reward for bonus xp for redeeming tickets only applies when wearing the Karamja gloves, as stated in the wiki.

