### PR TITLE
fix: Fixed Guthix rest checks for WGS

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/HerblorePuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/HerblorePuzzle.java
@@ -131,8 +131,8 @@ public class HerblorePuzzle extends ConditionalStep
 			if (dolmenType.getCompleteState() != -1)
 			{
 				conditions[i].getConditions().clear();
-				conditions[i].getConditions().add(nor(
-					new VarbitRequirement(StatueLocation.values()[i].getVarbitID(), dolmenType.getCompleteState())));
+				conditions[i].getConditions().add(
+					new VarbitRequirement(StatueLocation.values()[i].getVarbitID(), dolmenType.getCompleteState()));
 			}
 			steps[i].setWorldPoint(statueLocation.getLocation());
 			steps[i].addAlternateObjects(dolmenType.getObjectID(), dolmenType.getObjectID() + 1);


### PR DESCRIPTION
The overarching condition already has NOR in it, so by noring inside a NOR'd Condition it was presumably negating itself. I hope this fixes it.

Hopefully we can test this though before merging though.