### PR TITLE
Feat add assistance level groupings

### DIFF
--- a/src/main/java/com/questhelper/config/AssistanceLevel.java
+++ b/src/main/java/com/questhelper/config/AssistanceLevel.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.config;
+
+import com.questhelper.QuestHelperConfig;
+import net.runelite.client.config.ConfigManager;
+
+public class AssistanceLevel
+{
+	public static void setToMinimumAssistance(ConfigManager configManager)
+	{
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", false);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.NONE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.NONE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.NONE);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.NONE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
+	}
+
+	public static void setToMediumAssistance(ConfigManager configManager)
+	{
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", true);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.NONE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.NONE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.NONE);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.NONE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
+	}
+
+	public static void setToFullAssistance(ConfigManager configManager)
+	{
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", true);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.OUTLINE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.OUTLINE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.OUTLINE);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.OUTLINE);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", true);
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", true);
+	}
+}

--- a/src/main/java/com/questhelper/config/AssistanceLevel.java
+++ b/src/main/java/com/questhelper/config/AssistanceLevel.java
@@ -29,6 +29,8 @@ import net.runelite.client.config.ConfigManager;
 
 public class AssistanceLevel
 {
+	public static final String ASSISTANCE_LEVEL_KEY = "assistanceLevel";
+
 	public static void setToMinimumAssistance(ConfigManager configManager)
 	{
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
@@ -46,6 +48,8 @@ public class AssistanceLevel
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", false);
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, ASSISTANCE_LEVEL_KEY, "minimum");
 	}
 
 	public static void setToMediumAssistance(ConfigManager configManager)
@@ -65,6 +69,8 @@ public class AssistanceLevel
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, ASSISTANCE_LEVEL_KEY, "medium");
 	}
 
 	public static void setToFullAssistance(ConfigManager configManager)
@@ -84,5 +90,7 @@ public class AssistanceLevel
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", true);
 		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", true);
+
+		configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, ASSISTANCE_LEVEL_KEY, "full");
 	}
 }

--- a/src/main/java/com/questhelper/managers/QuestMenuHandler.java
+++ b/src/main/java/com/questhelper/managers/QuestMenuHandler.java
@@ -40,7 +40,6 @@ import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.util.Text;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.awt.*;
 import java.util.Arrays;
 
 /**

--- a/src/main/java/com/questhelper/panel/AssistLevelPanel.java
+++ b/src/main/java/com/questhelper/panel/AssistLevelPanel.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.panel;
+
+import com.questhelper.QuestHelperConfig;
+import com.questhelper.QuestHelperPlugin;
+import com.questhelper.config.AssistanceLevel;
+import com.questhelper.managers.QuestManager;
+import com.questhelper.questhelpers.QuestHelper;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.DynamicGridLayout;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+
+public class AssistLevelPanel extends JPanel
+{
+	private final FixedWidthPanel mainPanel;
+	private ConfigManager configManager;
+	private QuestHelperPanel questHelperPanel;
+
+	public AssistLevelPanel()
+	{
+		super(false);
+
+		setLayout(new BorderLayout());
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		// Title
+		JPanel titlePanel = new FixedWidthPanel();
+		titlePanel.setLayout(new BorderLayout());
+
+		JLabel title = new JLabel();
+		title.setText("<html>Choose Assist Level</html>");
+		title.setForeground(Color.WHITE);
+		title.setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 0));
+
+		titlePanel.add(title, BorderLayout.CENTER);
+
+		// Main content
+		mainPanel = new FixedWidthPanel();
+		mainPanel.setBorder(new EmptyBorder(8, 10, 10, 10));
+		mainPanel.setLayout(new DynamicGridLayout(0, 1, 0, 5));
+		mainPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		mainPanel.add(titlePanel, BorderLayout.NORTH);
+
+		JPanel northPanel = new FixedWidthPanel();
+		northPanel.setLayout(new BorderLayout());
+		northPanel.add(titlePanel, BorderLayout.NORTH);
+		northPanel.add(mainPanel, BorderLayout.CENTER);
+
+		JScrollPane scrollPane = new JScrollPane(northPanel);
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		add(scrollPane, BorderLayout.CENTER);
+	}
+
+	public void rebuild(QuestHelper questHelper, ConfigManager configManager, QuestHelperPanel questHelperPanel)
+	{
+		this.configManager = configManager;
+		this.questHelperPanel = questHelperPanel;
+
+		mainPanel.removeAll();
+
+		mainPanel.add(createFullAssistPanel(questHelper), BorderLayout.NORTH);
+		mainPanel.add(createMediumAssistPanel(questHelper), BorderLayout.CENTER);
+		mainPanel.add(createMinimumAssistPanel(questHelper), BorderLayout.SOUTH);
+	}
+
+
+	private JPanel createMinimumAssistPanel(QuestHelper questHelper)
+	{
+		JPanel minAssistPanel = new JPanel();
+		minAssistPanel.setLayout(new BorderLayout());
+
+		JLabel title = new JLabel();
+		title.setText("<html>Minimum Assistance</html>");
+		title.setForeground(Color.WHITE);
+		title.setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 0));
+
+		JLabel description = new JLabel();
+		description.setText("<html>This disables most overlay-based help, and hides puzzle solutions. This is a good option if you just want the sidebar with helpful information, as it will still track where you are in the quest, and show items needed.</html>");
+		description.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		JButton select = new JButton();
+		select.setText("Use minimum assistance");
+		select.setPreferredSize(new Dimension(200, 50));
+		select.addActionListener(ev -> {
+			AssistanceLevel.setToMinimumAssistance(configManager);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level", "true");
+			questHelperPanel.setSelectedQuest(questHelper);
+		});
+
+		JPanel buttonPanel = new JPanel();
+		buttonPanel.setLayout(new FlowLayout(FlowLayout.CENTER));
+		buttonPanel.add(select);
+
+		minAssistPanel.add(title, BorderLayout.NORTH);
+		minAssistPanel.add(description, BorderLayout.CENTER);
+		minAssistPanel.add(buttonPanel, BorderLayout.SOUTH);
+
+		return minAssistPanel;
+	}
+
+	private JPanel createMediumAssistPanel(QuestHelper questHelper)
+	{
+		JPanel medAssistPanel = new JPanel();
+		medAssistPanel.setLayout(new BorderLayout());
+
+		JLabel title = new JLabel();
+		title.setText("<html>Medium Assistance</html>");
+		title.setForeground(Color.WHITE);
+		title.setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 0));
+
+		JLabel description = new JLabel();
+		description.setText(
+			"<html>This enables most overlay-based help, but hides puzzle solutions. This is a good option if you want to still have guidance, but still solve certain parts for yourself.</p></html>");
+		description.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		JButton select = new JButton();
+		select.setText("Use medium assistance");
+		select.setPreferredSize(new Dimension(200, 50));
+		select.addActionListener(ev -> {
+			AssistanceLevel.setToMediumAssistance(configManager);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level", "true");
+			questHelperPanel.setSelectedQuest(questHelper);
+		});
+
+		JPanel buttonPanel = new JPanel();
+		buttonPanel.setLayout(new FlowLayout(FlowLayout.CENTER));
+		buttonPanel.add(select);
+
+		medAssistPanel.add(title, BorderLayout.NORTH);
+		medAssistPanel.add(description, BorderLayout.CENTER);
+		medAssistPanel.add(buttonPanel, BorderLayout.SOUTH);
+
+		return medAssistPanel;
+	}
+
+	private JPanel createFullAssistPanel(QuestHelper questHelper)
+	{
+		JPanel fullAssistPanel = new JPanel();
+		fullAssistPanel.setLayout(new BorderLayout());
+
+		JLabel title = new JLabel();
+		title.setText("<html>Full Assistance</html>");
+		title.setForeground(Color.WHITE);
+		title.setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 0));
+
+		JLabel description = new JLabel();
+		description.setText(
+			"<html>Gives you the full helper experience, highlighting objects & dialogue options, puzzler solvers, and with arrows so you know where to go.</html>");
+		description.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		JButton select = new JButton();
+		select.setText("Use full assistance");
+		select.setPreferredSize(new Dimension(200, 50));
+		select.addActionListener(ev -> {
+			AssistanceLevel.setToFullAssistance(configManager);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level", "true");
+			questHelperPanel.setSelectedQuest(questHelper);
+		});
+
+		JPanel buttonPanel = new JPanel();
+		buttonPanel.setLayout(new FlowLayout(FlowLayout.CENTER));
+		buttonPanel.add(select);
+
+		fullAssistPanel.add(title, BorderLayout.NORTH);
+		fullAssistPanel.add(description, BorderLayout.CENTER);
+		fullAssistPanel.add(buttonPanel, BorderLayout.SOUTH);
+
+		return fullAssistPanel;
+	}
+}

--- a/src/main/java/com/questhelper/panel/AssistLevelPanel.java
+++ b/src/main/java/com/questhelper/panel/AssistLevelPanel.java
@@ -25,9 +25,7 @@
 package com.questhelper.panel;
 
 import com.questhelper.QuestHelperConfig;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.config.AssistanceLevel;
-import com.questhelper.managers.QuestManager;
 import com.questhelper.questhelpers.QuestHelper;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.ColorScheme;
@@ -35,6 +33,7 @@ import net.runelite.client.ui.DynamicGridLayout;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import static com.questhelper.config.AssistanceLevel.ASSISTANCE_LEVEL_KEY;
 
 public class AssistLevelPanel extends JPanel
 {
@@ -42,6 +41,11 @@ public class AssistLevelPanel extends JPanel
 	private ConfigManager configManager;
 	private QuestHelperPanel questHelperPanel;
 
+	private final Color ACTIVE_COLOUR = ColorScheme.BRAND_ORANGE;
+	private final Color INACTIVE_COLOUR = ColorScheme.DARKER_GRAY_COLOR;
+
+	private JButton[] buttons = new JButton[3];
+	
 	public AssistLevelPanel()
 	{
 		super(false);
@@ -111,6 +115,7 @@ public class AssistLevelPanel extends JPanel
 			AssistanceLevel.setToMinimumAssistance(configManager);
 			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level", "true");
 			questHelperPanel.setSelectedQuest(questHelper);
+			highlightPanel(select);
 		});
 
 		JPanel buttonPanel = new JPanel();
@@ -120,6 +125,10 @@ public class AssistLevelPanel extends JPanel
 		minAssistPanel.add(title, BorderLayout.NORTH);
 		minAssistPanel.add(description, BorderLayout.CENTER);
 		minAssistPanel.add(buttonPanel, BorderLayout.SOUTH);
+
+		select.setBackground(getButtonColor("minimum"));
+
+		buttons[0] = select;
 
 		return minAssistPanel;
 	}
@@ -146,6 +155,7 @@ public class AssistLevelPanel extends JPanel
 			AssistanceLevel.setToMediumAssistance(configManager);
 			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level", "true");
 			questHelperPanel.setSelectedQuest(questHelper);
+			highlightPanel(select);
 		});
 
 		JPanel buttonPanel = new JPanel();
@@ -155,6 +165,10 @@ public class AssistLevelPanel extends JPanel
 		medAssistPanel.add(title, BorderLayout.NORTH);
 		medAssistPanel.add(description, BorderLayout.CENTER);
 		medAssistPanel.add(buttonPanel, BorderLayout.SOUTH);
+
+		select.setBackground(getButtonColor("medium"));
+
+		buttons[1] = select;
 
 		return medAssistPanel;
 	}
@@ -181,6 +195,8 @@ public class AssistLevelPanel extends JPanel
 			AssistanceLevel.setToFullAssistance(configManager);
 			configManager.setConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level", "true");
 			questHelperPanel.setSelectedQuest(questHelper);
+
+			highlightPanel(select);
 		});
 
 		JPanel buttonPanel = new JPanel();
@@ -191,6 +207,38 @@ public class AssistLevelPanel extends JPanel
 		fullAssistPanel.add(description, BorderLayout.CENTER);
 		fullAssistPanel.add(buttonPanel, BorderLayout.SOUTH);
 
+		select.setBackground(getButtonColor("full"));
+
+		buttons[2] = select;
+
 		return fullAssistPanel;
+	}
+
+	private Color getButtonColor(String assistLevel)
+	{
+		String assistLevelActive = configManager.getConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, ASSISTANCE_LEVEL_KEY);
+
+		if (assistLevel.equals(assistLevelActive))
+		{
+			return ACTIVE_COLOUR;
+		}
+
+		return INACTIVE_COLOUR;
+	}
+
+
+	private void highlightPanel(JButton highlightButton)
+	{
+		for (JButton jButton : buttons)
+		{
+			if (jButton == highlightButton)
+			{
+				jButton.setBackground(ACTIVE_COLOUR);
+			}
+			else
+			{
+				jButton.setBackground(INACTIVE_COLOUR);
+			}
+		}
 	}
 }

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -249,6 +249,8 @@ public class QuestHelperPanel extends PluginPanel
 
 		titlePanel.add(viewControls, BorderLayout.EAST);
 
+		JPanel assistPanel = setupAssistPanel();
+
 		JLabel questsCompletedLabel = new JLabel();
 		questsCompletedLabel.setForeground(Color.GRAY);
 		questsCompletedLabel.setText("<html><body style='text-align:left'>Please log in to see available quests" +
@@ -308,6 +310,9 @@ public class QuestHelperPanel extends PluginPanel
 		orderDropdown = makeNewDropdown(QuestHelperConfig.QuestOrdering.values(), "orderListBy");
 		JPanel orderPanel = makeDropdownPanel(orderDropdown, "Ordering");
 		orderPanel.setPreferredSize(new Dimension(PANEL_WIDTH, DROPDOWN_HEIGHT));
+
+		JPanel assistanceToggles = new JPanel();
+
 
 		// Skill filtering
 		SkillFilterPanel skillFilterPanel = new SkillFilterPanel(questHelperPlugin.skillIconManager, questHelperPlugin.getConfigManager());
@@ -370,7 +375,8 @@ public class QuestHelperPanel extends PluginPanel
 		JPanel introDetailsPanel = new JPanel();
 		introDetailsPanel.setLayout(new BorderLayout());
 		introDetailsPanel.add(titlePanel, BorderLayout.NORTH);
-		introDetailsPanel.add(searchQuestsPanel, BorderLayout.CENTER);
+		introDetailsPanel.add(assistPanel, BorderLayout.CENTER);
+		introDetailsPanel.add(searchQuestsPanel, BorderLayout.SOUTH);
 
 		add(introDetailsPanel, BorderLayout.NORTH);
 		add(scrollableContainer, BorderLayout.CENTER);
@@ -453,6 +459,117 @@ public class QuestHelperPanel extends PluginPanel
 				questListPanel.add(listItem);
 			}
 		});
+	}
+
+	JButton activeDifficulty = null;
+
+	private JButton makeButton(String text)
+	{
+		JButton minimalAssist = new JButton();
+		SwingUtil.removeButtonDecorations(minimalAssist);
+		minimalAssist.setText(text.substring(0, 3));
+//		minimalAssist.setIcon(PATREON_ICON);
+		minimalAssist.setToolTipText(text);
+		minimalAssist.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		minimalAssist.setUI(new BasicButtonUI());
+		minimalAssist.addMouseListener(new java.awt.event.MouseAdapter()
+		{
+			public void mouseEntered(java.awt.event.MouseEvent evt)
+			{
+				if (activeDifficulty != minimalAssist)
+				{
+					minimalAssist.setBackground(ColorScheme.DARK_GRAY_HOVER_COLOR);
+				}
+			}
+
+			public void mouseClicked(java.awt.event.MouseEvent evt)
+			{
+				minimalAssist.setBackground(ColorScheme.BRAND_ORANGE);
+				if (activeDifficulty != null) activeDifficulty.setBackground(ColorScheme.DARK_GRAY_COLOR);
+				activeDifficulty = minimalAssist;
+			}
+
+			public void mouseExited(java.awt.event.MouseEvent evt)
+			{
+				if (activeDifficulty != minimalAssist)
+				{
+					minimalAssist.setBackground(ColorScheme.DARK_GRAY_COLOR);
+				}
+			}
+		});
+
+		return minimalAssist;
+	}
+
+	public JPanel setupAssistPanel()
+	{
+		final JPanel assistLevelPanel = new JPanel(new GridLayout(1, 3, 10, 0));
+		assistLevelPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		// Min assist button
+		JButton minimalAssist = makeButton("Minimum Assistance");
+		minimalAssist.addActionListener((ev) -> {
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", false);
+
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.NONE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.NONE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.NONE);
+
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.NONE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
+		});
+		assistLevelPanel.add(minimalAssist);
+
+		// Min assist button
+		JButton midAssist = makeButton("Medium Assistance");
+		midAssist.addActionListener((ev) -> {
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", true);
+
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.NONE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.NONE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.NONE);
+
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.NONE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
+		});
+		assistLevelPanel.add(midAssist);
+
+		// Min assist button
+		JButton maxAssist = makeButton("Max Assistance");
+		maxAssist.addActionListener((ev) -> {
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", true);
+
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.OUTLINE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.OUTLINE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.OUTLINE);
+
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.OUTLINE);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", true);
+			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", true);
+		});
+		assistLevelPanel.add(maxAssist);
+
+		return assistLevelPanel;
 	}
 
 	public void refresh(List<QuestHelper> questHelpers, boolean loggedOut,

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -74,7 +74,7 @@ public class QuestHelperPanel extends PluginPanel
 
 	private final QuestOverviewPanel questOverviewPanel;
 	private final FixedWidthPanel questOverviewWrapper = new FixedWidthPanel();
-
+	private final AssistLevelPanel assistLevelPanel = new AssistLevelPanel();
 	private final JPanel allQuestsCompletedPanel = new JPanel();
 	private final JPanel searchQuestsPanel;
 
@@ -88,7 +88,7 @@ public class QuestHelperPanel extends PluginPanel
 	private final FixedWidthPanel questListWrapper = new FixedWidthPanel();
 	private final JScrollPane scrollableContainer;
 	public static final int DROPDOWN_HEIGHT = 26;
-	//	private boolean settingsPanelActive = false;
+	private boolean settingsPanelActive = false;
 	public boolean questActive = false;
 
 	private final ArrayList<QuestSelectPanel> questSelectPanels = new ArrayList<>();
@@ -141,44 +141,45 @@ public class QuestHelperPanel extends PluginPanel
 
 		// Settings
 		// TODO: Removed until the Runelite API allows for a link to the actual config panel
-//		JButton settingsBtn = new JButton();
-//		SwingUtil.removeButtonDecorations(settingsBtn);
-//		settingsBtn.setIcon(SETTINGS_ICON);
-//		settingsBtn.setToolTipText("Change your settings");
-//		settingsBtn.setBackground(ColorScheme.DARK_GRAY_COLOR);
-//		settingsBtn.setUI(new BasicButtonUI());
-//		settingsBtn.addActionListener((ev) -> {
-//			if (settingsPanelActive)
-//			{
-//				settingsBtn.setBackground(ColorScheme.LIGHT_GRAY_COLOR);
-//				deactivateSettings();
-//			}
-//			else
-//			{
-//				settingsBtn.setBackground(ColorScheme.DARK_GRAY_COLOR);
-//				activateSettings();
-//			}
-//		});
-//		settingsBtn.addMouseListener(new java.awt.event.MouseAdapter()
-//		{
-//			public void mouseEntered(java.awt.event.MouseEvent evt)
-//			{
-//				settingsBtn.setBackground(ColorScheme.DARK_GRAY_HOVER_COLOR);
-//			}
-//
-//			public void mouseExited(java.awt.event.MouseEvent evt)
-//			{
-//				if (settingsPanelActive)
-//				{
-//					settingsBtn.setBackground(ColorScheme.LIGHT_GRAY_COLOR);
-//				}
-//				else
-//				{
-//					settingsBtn.setBackground(ColorScheme.DARK_GRAY_COLOR);
-//				}
-//			}
-//		});
-//		viewControls.add(settingsBtn);
+		JButton settingsBtn = new JButton();
+		SwingUtil.removeButtonDecorations(settingsBtn);
+		settingsBtn.setIcon(SETTINGS_ICON);
+		settingsBtn.setToolTipText("Change your settings");
+		settingsBtn.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		settingsBtn.setUI(new BasicButtonUI());
+		settingsBtn.addActionListener((ev) -> {
+			assistLevelPanel.rebuild(null, configManager, this);
+			if (settingsPanelActive)
+			{
+				settingsBtn.setBackground(ColorScheme.LIGHT_GRAY_COLOR);
+				deactivateSettings();
+			}
+			else
+			{
+				settingsBtn.setBackground(ColorScheme.DARK_GRAY_COLOR);
+				activateSettings();
+			}
+		});
+		settingsBtn.addMouseListener(new java.awt.event.MouseAdapter()
+		{
+			public void mouseEntered(java.awt.event.MouseEvent evt)
+			{
+				settingsBtn.setBackground(ColorScheme.DARK_GRAY_HOVER_COLOR);
+			}
+
+			public void mouseExited(java.awt.event.MouseEvent evt)
+			{
+				if (settingsPanelActive)
+				{
+					settingsBtn.setBackground(ColorScheme.LIGHT_GRAY_COLOR);
+				}
+				else
+				{
+					settingsBtn.setBackground(ColorScheme.DARK_GRAY_COLOR);
+				}
+			}
+		});
+		viewControls.add(settingsBtn);
 
 		// Discord button
 		JButton discordBtn = new JButton();
@@ -248,8 +249,6 @@ public class QuestHelperPanel extends PluginPanel
 
 
 		titlePanel.add(viewControls, BorderLayout.EAST);
-
-		JPanel assistPanel = setupAssistPanel();
 
 		JLabel questsCompletedLabel = new JLabel();
 		questsCompletedLabel.setForeground(Color.GRAY);
@@ -375,7 +374,6 @@ public class QuestHelperPanel extends PluginPanel
 		JPanel introDetailsPanel = new JPanel();
 		introDetailsPanel.setLayout(new BorderLayout());
 		introDetailsPanel.add(titlePanel, BorderLayout.NORTH);
-		introDetailsPanel.add(assistPanel, BorderLayout.CENTER);
 		introDetailsPanel.add(searchQuestsPanel, BorderLayout.SOUTH);
 
 		add(introDetailsPanel, BorderLayout.NORTH);
@@ -501,77 +499,6 @@ public class QuestHelperPanel extends PluginPanel
 		return minimalAssist;
 	}
 
-	public JPanel setupAssistPanel()
-	{
-		final JPanel assistLevelPanel = new JPanel(new GridLayout(1, 3, 10, 0));
-		assistLevelPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-
-		// Min assist button
-		JButton minimalAssist = makeButton("Minimum Assistance");
-		minimalAssist.addActionListener((ev) -> {
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", false);
-
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.NONE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.NONE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.NONE);
-
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.NONE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
-		});
-		assistLevelPanel.add(minimalAssist);
-
-		// Min assist button
-		JButton midAssist = makeButton("Medium Assistance");
-		midAssist.addActionListener((ev) -> {
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", true);
-
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.NONE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.NONE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.NONE);
-
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.NONE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", false);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", false);
-		});
-		assistLevelPanel.add(midAssist);
-
-		// Min assist button
-		JButton maxAssist = makeButton("Max Assistance");
-		maxAssist.addActionListener((ev) -> {
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoStartQuests", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "autoOpenSidebar", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showOverlayPanel", true);
-
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showTextHighlight", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showSymbolOverlay", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleNpcs", QuestHelperConfig.NpcHighlightStyle.OUTLINE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleObjects", QuestHelperConfig.ObjectHighlightStyle.OUTLINE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleGroundItems", QuestHelperConfig.GroundItemHighlightStyle.OUTLINE);
-
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "highlightStyleInventoryItems", QuestHelperConfig.InventoryItemHighlightStyle.OUTLINE);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showMiniMapArrow", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWorldLines", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "showWidgetHints", true);
-			configManager.setConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "solvePuzzles", true);
-		});
-		assistLevelPanel.add(maxAssist);
-
-		return assistLevelPanel;
-	}
-
 	public void refresh(List<QuestHelper> questHelpers, boolean loggedOut,
 						Map<QuestHelperQuest, QuestState> completedQuests, QuestHelperConfig.QuestFilter... questFilters)
 	{
@@ -597,7 +524,7 @@ public class QuestHelperPanel extends PluginPanel
 				for (QuestHelper questHelper : filterList)
 				{
 					QuestState questState = completedQuests.getOrDefault(questHelper.getQuest(), QuestState.NOT_STARTED);
-					questSelectPanels.add(new QuestSelectPanel(questHelperPlugin, questManager, this, questHelper, questState));
+					questSelectPanels.add(new QuestSelectPanel(questHelperPlugin, this, questHelper, questState));
 				}
 			}
 		}
@@ -606,7 +533,7 @@ public class QuestHelperPanel extends PluginPanel
 			for (QuestHelper questHelper : questHelpers)
 			{
 				QuestState questState = completedQuests.getOrDefault(questHelper.getQuest(), QuestState.NOT_STARTED);
-				questSelectPanels.add(new QuestSelectPanel(questHelperPlugin, questManager, this, questHelper, questState));
+				questSelectPanels.add(new QuestSelectPanel(questHelperPlugin, this, questHelper, questState));
 			}
 		}
 
@@ -680,9 +607,9 @@ public class QuestHelperPanel extends PluginPanel
 
 	private void activateSettings()
 	{
-//		settingsPanelActive = true;
+		settingsPanelActive = true;
 
-//		scrollableContainer.setViewportView(configPanel);
+		scrollableContainer.setViewportView(assistLevelPanel);
 		searchQuestsPanel.setVisible(false);
 
 		repaint();
@@ -691,7 +618,7 @@ public class QuestHelperPanel extends PluginPanel
 
 	private void deactivateSettings()
 	{
-//		settingsPanelActive = false;
+		settingsPanelActive = false;
 		if (questActive && searchBar.getText().isEmpty())
 		{
 			scrollableContainer.setViewportView(questOverviewWrapper);
@@ -704,6 +631,26 @@ public class QuestHelperPanel extends PluginPanel
 
 		repaint();
 		revalidate();
+	}
+
+	public void setSelectedQuest(QuestHelper questHelper)
+	{
+		if (questHelper == null)
+		{
+			deactivateSettings();
+		}
+
+		if ("true".equals(configManager.getConfiguration(QuestHelperConfig.QUEST_BACKGROUND_GROUP, "selected-assist-level")))
+		{
+			searchQuestsPanel.setVisible(true);
+			questManager.setSidebarSelectedQuest(questHelper);
+		}
+		else
+		{
+			assistLevelPanel.rebuild(questHelper, configManager, this);
+			scrollableContainer.setViewportView(assistLevelPanel);
+			searchQuestsPanel.setVisible(false);
+		}
 	}
 
 	public void emptyBar()

--- a/src/main/java/com/questhelper/panel/QuestSelectPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestSelectPanel.java
@@ -50,14 +50,11 @@ public class QuestSelectPanel extends JPanel
 	@Getter
 	private final QuestHelper questHelper;
 
-	private final QuestManager questManager;
-
 	private static final ImageIcon START_ICON = Icon.START.getIcon();
 
-	public QuestSelectPanel(QuestHelperPlugin questHelperPlugin, QuestManager questManager, QuestHelperPanel questHelperPanel, QuestHelper questHelper, QuestState questState)
+	public QuestSelectPanel(QuestHelperPlugin questHelperPlugin, QuestHelperPanel questHelperPanel, QuestHelper questHelper, QuestState questState)
 	{
 		this.questHelper = questHelper;
-		this.questManager = questManager;
 
 		keywords.addAll(questHelper.getQuest().getKeywords());
 
@@ -76,7 +73,7 @@ public class QuestSelectPanel extends JPanel
 			startButton.setIcon(START_ICON);
 			startButton.addActionListener(e ->
 			{
-				questManager.setSidebarSelectedQuest(questHelper);
+				questHelperPanel.setSelectedQuest(questHelper);
 				questHelperPanel.emptyBar();
 			});
 			add(startButton, BorderLayout.LINE_END);
@@ -86,7 +83,6 @@ public class QuestSelectPanel extends JPanel
 	public QuestSelectPanel(String text)
 	{
 		this.questHelper = null;
-		this.questManager = null;
 
 		setLayout(new BorderLayout(3, 3));
 		setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH, 30));


### PR DESCRIPTION
This PR is intended to make it easier for players to get started with Quest Helper in a customised to desired use way. It adds three tiers of assistance, minimum, medium, and full assistance.

When you first click on a quest after this update is live in the sidebar, you will be prompted to select an assistance level.

![Screenshot 2024-09-03 141422](https://github.com/user-attachments/assets/a8b1f242-97b0-4bda-99e2-586848afffd0)

When you select one, you will be taken to the normal quest page.

If you hit the cog at the top of the sidebar, it will let you access this page again to adjust the level of assistance you're getting.

Currently this prompt won't occur if you activate the helper via the in-game quest list, or if the quest helper is activated automatically. I think we may want these both captured, but I want to make sure we don't result in more confusion from people say not knowing about the sidebar, and then not being sure why their helper hasn't started up.