### PR TITLE
RFD Awowogei: giant snake -> Big Snake

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDAwowogei.java
+++ b/src/main/java/com/questhelper/helpers/quests/recipefordisaster/RFDAwowogei.java
@@ -227,7 +227,7 @@ public class RFDAwowogei extends BasicQuestHelper
 		goToCrashIsland = new NpcStep(this, NpcID.LUMDO_1454, new WorldPoint(2802, 2706, 0), "Travel to Crash Island with Lumdo.", combatGear);
 		enterCrashHole = new ObjectStep(this, ObjectID.PIT_15572, new WorldPoint(2922, 2722, 0), "Enter the hole on Crash Island. Protect melee when entering as you'll be attacked straight away by snakes.", combatGear, protectMelee);
 		enterCrashHole.addDialogStep("Yes, I'm as hard as nails.");
-		killSnake = new NpcStep(this, NpcID.BIG_SNAKE, new WorldPoint(3019, 5485, 0), "Kill a giant snake for its corpse. Kill a few in case you burn it.", snakeCorpse);
+		killSnake = new NpcStep(this, NpcID.BIG_SNAKE, new WorldPoint(3019, 5485, 0), "Kill a Big Snake for its corpse. Kill a few in case you burn it.", snakeCorpse);
 		leaveSnakeHole = new ObjectStep(this, ObjectID.ROPE_15571, new WorldPoint(3024, 5489, 0), "Leave the hole.");
 		returnToApeAtoll = new NpcStep(this, NpcID.LUMDO_1454, new WorldPoint(2892, 2723, 0), "Travel back to Ape Atoll with Lumdo.");
 


### PR DESCRIPTION
I have no strong feelings on whether the game's odd grammar is to be followed in the helper, but I looked up "giant snake" on the wiki and it took me to the Royal Trouble snake. So I think this snake should be changed to the appropriate name for Recipe for Disaster.