### PR TITLE
fix: Set item tooltip overlay to be a tooltip type

### DIFF
--- a/src/main/java/com/questhelper/overlays/QuestHelperTooltipOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperTooltipOverlay.java
@@ -28,6 +28,7 @@ import com.questhelper.QuestHelperPlugin;
 import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
 import javax.inject.Inject;
 import java.awt.*;
 
@@ -41,6 +42,8 @@ public class QuestHelperTooltipOverlay extends OverlayPanel
 	{
 		setPriority(PRIORITY_HIGHEST);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setDragTargetable(false);
+		setPosition(OverlayPosition.TOOLTIP);
 
 		this.questHelperPlugin = questHelperPlugin;
 		this.client = client;

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -848,7 +848,7 @@ public class DetailedQuestStep extends QuestStep
 			int menuEntryHeight = 15;
 			int headerHeight = menuEntryHeight + 3;
 
-			for (int i = 0; i < currentMenuEntries.length; i++)
+			for (int i = currentMenuEntries.length - 1; i >= 0; i--)
 			{
 				MenuEntry hoveredEntry = currentMenuEntries[i];
 
@@ -862,8 +862,18 @@ public class DetailedQuestStep extends QuestStep
 				if (mousePosition.getX() > menuX && mousePosition.getX() < menuX + menuWidth &&
 					mousePosition.getY() > entryTopY && mousePosition.getY() <= entryBottomY)
 				{
-					panelComponent.setPreferredLocation(new java.awt.Point(menuX + menuWidth, entryTopY - menuEntryHeight - ComponentConstants.STANDARD_BORDER));
 					panelComponent.getChildren().add(LineComponent.builder().left(tooltipText).build());
+					double infoPanelWidth = panelComponent.getBounds().getWidth();
+					int viewportWidth = client.getViewportWidth();
+					if (menuX + menuWidth + infoPanelWidth > viewportWidth)
+					{
+						panelComponent.setPreferredLocation(new java.awt.Point(menuX - (int) infoPanelWidth, entryTopY));
+					}
+					else
+					{
+						panelComponent.setPreferredLocation(new java.awt.Point(menuX + menuWidth, entryTopY));
+					}
+
 					break;
 				}
 			}


### PR DESCRIPTION
This ensures it won't get shifted by other overlay placements.