### PR TITLE
fix: Kings Random quest should have animate rock scroll as required

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/kingsransom/KingsRansom.java
+++ b/src/main/java/com/questhelper/helpers/quests/kingsransom/KingsRansom.java
@@ -414,7 +414,7 @@ public class KingsRansom extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(grabOrLockpick, granite, blackKnightHelm, blackKnightBody, blackKnightLeg, bronzeMed, ironChain);
+		return Arrays.asList(grabOrLockpick, granite, blackKnightHelm, blackKnightBody, blackKnightLeg, bronzeMed, ironChain, animateRock);
 	}
 
 	@Override


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/King%27s_Ransom

It can be obtained before the quest, so should be listed in the required items for the quest and not just the panel step.