### PR TITLE
fix: quest journal sync widget ID changes

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/barbariantraining/BarbarianTraining.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/barbariantraining/BarbarianTraining.java
@@ -59,6 +59,7 @@ import java.util.*;
 
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class BarbarianTraining extends BasicQuestHelper
 {
@@ -272,7 +273,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Certainly. Take the rod from under my bed and fish in the lake. When you have caught a few fish, I am sure you will be ready to talk more with me."),
 				new DialogRequirement("Alas, I do not sense that you have been successful in your fishing yet. The look in your eyes is not that of the osprey."),
-				new WidgetTextRequirement(119, 3, true, "fish with a new")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "fish with a new")
 			)
 		);
 
@@ -281,7 +282,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("... and I thought fishing was a safe way to pass the time."),
 				new DialogRequirement("I see you need encouragement in learning the ways of fishing without a harpoon."),
-				new WidgetTextRequirement(119, 3, true, "fish with my")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "fish with my")
 			)
 		);
 
@@ -290,7 +291,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Remember to be calm, and good luck."),
 				new DialogRequirement("I see you have yet to be successful in planting a seed with your fists."),
-				new WidgetTextRequirement(119, 3, true, "plant a seed with")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "plant a seed with")
 			)
 		);
 
@@ -299,7 +300,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("May the spirits guide you into success."),
 				new DialogRequirement("You have not yet attempted to plant a tree. Why not?"),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smash pots after")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smash pots after")
 			)
 		);
 
@@ -308,7 +309,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("The spirits will aid you. The power they supply will guide your hands. Go and benefit from their guidance upon oak logs."),
 				new DialogRequirement("By now you know my response."),
-				new WidgetTextRequirement(119, 3, true, "light a fire with")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "light a fire with")
 			)
 		);
 
@@ -317,7 +318,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Dive into the whirlpool in the lake to the east. The spirits will use their abilities to ensure you arrive in the correct location. Be warned, their influence fades, so you must find y"),
 				new DialogRequirement("I will repeat myself fully, since this is quite complex. Listen well."),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to <col=800000>create pyre ships")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to <col=800000>create pyre ships")
 			)
 		);
 
@@ -326,7 +327,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Have I become so predictable? But yes, I do indeed require a potion. It is of the highest importance that you bring me a lesser attack potion combined with fish roe."),
 				new DialogRequirement("Do you have my potion?"),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to make a <col=800000>new type")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to make a <col=800000>new type")
 			)
 		);
 
@@ -335,7 +336,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Note well that you will require wood for the spear shafts. The quality of wood must be similar to that of the metal involved."),
 				new DialogRequirement("You do not exude the presence of one who has poured his soul into manufacturing spears."),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smith spears")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smith spears")
 			)
 		);
 
@@ -344,7 +345,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Indeed. You may use our special anvil for this spear type too. The ways of black and dragon hastae are beyond our knowledge, however."),
 				new DialogRequirement("Take some wood and metal and make a spear upon the<br>nearby anvil, then you may return to me. As an<br>example, you may use bronze bars with normal logs or<br>iron bars with oak logs."),
-				new WidgetTextRequirement(119, 3, true, " has tasked me with learning how to <col=800000>smith a hasta")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, " has tasked me with learning how to <col=800000>smith a hasta")
 			)
 		);
 
@@ -353,7 +354,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_FISHING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Patience young one. These are fish which are fat with eggs rather than fat of flesh. It is these eggs that are the thing to make use of."),
-				new WidgetTextRequirement(119, 3, true, "I managed to catch a fish with the new rod!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to catch a fish with the new rod!")
 			),
 			"Finished Barbarian Fishing"
 		);
@@ -362,7 +363,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_HARPOON.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("I mean that when you eventually die and find peace, at least the spirits you encounter will be your friends. Alas for you adventurous sort, the natural ways of passing are close to imp"),
-				new WidgetTextRequirement(119, 3, true, "I managed to fish with my hands!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to fish with my hands!")
 			),
 			"Finished Barbarian Harpooning"
 		);
@@ -371,7 +372,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_SEED_PLANTING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("No child, but we all have potential to improve our strength."),
-				new WidgetTextRequirement(119, 3, true, "<str>I managed to plant a seed with my fists!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I managed to plant a seed with my fists!")
 			),
 			"Finished Barbarian Seed Planting"
 		);
@@ -380,7 +381,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_POT_SMASHING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("It will become more natural with practice."),
-				new WidgetTextRequirement(119, 3, true, "<str>I managed to smash a plant pot without littering!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I managed to smash a plant pot without littering!")
 			),
 			"Finished Barbarian Pot Smashing"
 		);
@@ -389,7 +390,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_FIREMAKING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Fine news indeed!"),
-				new WidgetTextRequirement(119, 3, true, "I managed to light a fire with a bow!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to light a fire with a bow!")
 			),
 			"Finished Barbarian Firemaking"
 		);
@@ -398,7 +399,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_PYREMAKING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("On this great day you have my eternal thanks. May you find riches while rescuing my spiritual ancestors in the caverns for many moons to come."),
-				new WidgetTextRequirement(119, 3, true, "I managed to create a pyre ship!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to create a pyre ship!")
 			),
 			"Finished Barbarian Pyremaking"
 		);
@@ -407,7 +408,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_SPEAR.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("The manufacture of spears is now yours as a speciality. Use your skill well."),
-				new WidgetTextRequirement(119, 3, true, "I managed to smith a spear!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to smith a spear!")
 			),
 			"Finished Barbarian Spear Smithing"
 		);
@@ -416,7 +417,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_HASTA.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("To live life to it's fullest of course - that you may be a peaceful spirit when your time ends."),
-				new WidgetTextRequirement(119, 3, true, "I managed to create a hasta!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to create a hasta!")
 			),
 			"Finished Barbarian Hasta Smithing"
 		);
@@ -425,7 +426,7 @@ public class BarbarianTraining extends BasicQuestHelper
 			getConfigManager(), ConfigKeys.BARBARIAN_TRAINING_FINISHED_HERBLORE.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("I will take that off your hands now. I will say no more than that I am eternally grateful."),
-				new WidgetTextRequirement(119, 3, true, "I managed to create a new potion!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to create a new potion!")
 			),
 			"Finished Barbarian Herblore"
 		);
@@ -438,7 +439,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement("You plant "),
 					new ChatMessageRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>plant a seed with my fists<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>plant a seed with my fists<col=000080>!")
 			)
 		);
 
@@ -450,7 +451,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement(" sapling"),
 					new ChatMessageRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>smash a pot without littering<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>smash a pot without littering<col=000080>!")
 			)
 		);
 
@@ -461,7 +462,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement("The fire catches and the logs begin to burn."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>light a fire with a bow<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>light a fire with a bow<col=000080>!")
 			)
 		);
 
@@ -472,7 +473,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement("The ancient barbarian is laid to rest."),
 					new ChatMessageRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>create a pyre ship<col=000080>! I should let")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>create a pyre ship<col=000080>! I should let")
 			)
 		);
 
@@ -483,7 +484,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement("You catch a leaping trout.", "You catch a leaping salmon.", "You catch a leaping sturgeon."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to catch a <col=800000>fish with the new rod<col=000080>! I should let")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to catch a <col=800000>fish with the new rod<col=000080>! I should let")
 			)
 		);
 
@@ -494,7 +495,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement("You catch a tuna.", "You catch a swordfish.", "You catch a shark.", "You catch a shark!"),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>fish with my hands<col=000080>! I should let <col=800000>Otto <col=000080>know")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>fish with my hands<col=000080>! I should let <col=800000>Otto <col=000080>know")
 			)
 		);
 
@@ -505,7 +506,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement("You combine your potion with the fish eggs."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to make a <col=800000>new type of potion<col=000080>! I should let")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to make a <col=800000>new type of potion<col=000080>! I should let")
 			)
 		);
 
@@ -517,7 +518,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement(" spear."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>smith a spear<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>smith a spear<col=000080>!")
 			)
 		);
 
@@ -529,7 +530,7 @@ public class BarbarianTraining extends BasicQuestHelper
 					new ChatMessageRequirement(" hasta."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>smith a hasta<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>smith a hasta<col=000080>!")
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
@@ -56,6 +56,7 @@ import net.runelite.api.coords.WorldPoint;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.QuestStep;
+import net.runelite.api.widgets.ComponentID;
 
 public class ClockTower extends BasicQuestHelper
 {
@@ -187,7 +188,7 @@ public class ClockTower extends BasicQuestHelper
 		startedQuestDuringSession = new Conditions(true, new VarplayerRequirement(QuestVarPlayer.QUEST_CLOCK_TOWER.getId(), 0));
 
 		synced = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 2, "<col=7f0000>Clock Tower</col>"),
+			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "<col=7f0000>Clock Tower</col>"),
 			startedQuestDuringSession
 		);
 

--- a/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
@@ -198,19 +198,19 @@ public class ClockTower extends BasicQuestHelper
 		poisonedRats = new ChatMessageRequirement("The rats swarm towards the poisoned food...");
 
 		placedRedCog = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "<str>I have successfully placed the Red Cog on its spindle"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have successfully placed the Red Cog on its spindle"),
 			new ChatMessageRequirement(inGroundFloor, "The cog fits perfectly.")
 		);
 		placedBlueCog = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "<str>I have successfully placed the Blue Cog on its spindle"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have successfully placed the Blue Cog on its spindle"),
 			new ChatMessageRequirement(inFirstFloor, "The cog fits perfectly.")
 		);
 		placedBlackCog = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "<str>I have successfully placed the Black Cog on its spindle"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have successfully placed the Black Cog on its spindle"),
 			new ChatMessageRequirement(inBasement, "The cog fits perfectly.")
 		);
 		placedWhiteCog = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "<str>I have successfully placed the White Cog on its spindle"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have successfully placed the White Cog on its spindle"),
 			new ChatMessageRequirement(inSecondFloor, "The cog fits perfectly.")
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
+++ b/src/main/java/com/questhelper/helpers/quests/clocktower/ClockTower.java
@@ -188,7 +188,7 @@ public class ClockTower extends BasicQuestHelper
 		startedQuestDuringSession = new Conditions(true, new VarplayerRequirement(QuestVarPlayer.QUEST_CLOCK_TOWER.getId(), 0));
 
 		synced = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "<col=7f0000>Clock Tower</col>"),
+			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "Clock Tower"),
 			startedQuestDuringSession
 		);
 

--- a/src/main/java/com/questhelper/helpers/quests/fairytalei/FairytaleI.java
+++ b/src/main/java/com/questhelper/helpers/quests/fairytalei/FairytaleI.java
@@ -57,6 +57,7 @@ import java.util.Map;
 
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class FairytaleI extends BasicQuestHelper
 {
@@ -203,7 +204,7 @@ public class FairytaleI extends BasicQuestHelper
 
 
 		talkedToFarmers = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "back and talk to <col=800000>Martin"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "back and talk to <col=800000>Martin"),
 			new DialogRequirement("Right, well thanks for your input."),
 			new DialogRequirement("I don't think the crops ARE failing"));
 

--- a/src/main/java/com/questhelper/helpers/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/legendsquest/LegendsQuest.java
@@ -691,7 +691,7 @@ public class LegendsQuest extends BasicQuestHelper
 
 		talkedToUngadulu = new RuneliteRequirement(configManager, "legendsquestinvestigatedfirewall",
 			new Conditions(true, LogicType.OR,
-				new WidgetTextRequirement(119, 3, true, "is acting weird and talking a lot of nonsense"),
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "is acting weird and talking a lot of nonsense"),
 				new MesBoxRequirement("The shaman throws himself to the floor and starts convulsing."),
 				new DialogRequirement("is acting weird and talking a lot of nonsense")));
 

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -455,13 +455,13 @@ public class MonkeyMadnessI extends BasicQuestHelper
 
 		givenDentures = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the magical monkey dentures."),
-			new WidgetTextRequirement(119, 3, true, "<str> - Something to do with monkey speech."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str> - Something to do with monkey speech."));
 		givenBar = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the gold bar."),
-			new WidgetTextRequirement(119, 3, true, "<str> - A gold bar."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str> - A gold bar."));
 		givenMould = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey amulet mould."),
-			new WidgetTextRequirement(119, 3, true, "<str> - A monkey amulet mould."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str> - A monkey amulet mould."));
 
 		hasTalisman = new Conditions(LogicType.OR, karamjanGreegree, talisman);
 
@@ -470,11 +470,11 @@ public class MonkeyMadnessI extends BasicQuestHelper
 
 		givenTalisman = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey talisman."),
-			new WidgetTextRequirement(119, 3, true, "<str> - An authentic magical monkey talisman.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str> - An authentic magical monkey talisman.")
 		);
 		givenBones = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Zooknock the monkey remains."),
-			new WidgetTextRequirement(119, 3, true, "<str> - Some kind of monkey remains.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str> - Some kind of monkey remains.")
 		);
 
 		talkedToGarkorWithGreeGree = new VarbitRequirement(126, 3, Operation.GREATER_EQUAL);
@@ -492,7 +492,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		givenMonkey = new RuneliteRequirement(getConfigManager(), "mm1givenmonkey", new Conditions(true,
 			LogicType.OR,
 			givenMonkeyDialog,
-			new WidgetTextRequirement(119, 3, true, "appear to have earnt Awowogei's favour.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "appear to have earnt Awowogei's favour.")
 		));
 
 		gotSigil = new VarbitRequirement(126, 6, Operation.GREATER_EQUAL);

--- a/src/main/java/com/questhelper/helpers/quests/naturespirit/NatureSpirit.java
+++ b/src/main/java/com/questhelper/helpers/quests/naturespirit/NatureSpirit.java
@@ -57,6 +57,7 @@ import java.util.Map;
 
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class NatureSpirit extends BasicQuestHelper
 {
@@ -213,11 +214,11 @@ public class NatureSpirit extends BasicQuestHelper
 		mirrorNearby = new ItemOnTileRequirement(mirror);
 		usedMushroom = new Conditions(true, LogicType.OR, new ChatMessageRequirement("The stone seems to absorb the fungus."),
 			new WidgetTextRequirement(229, 1, "nature symbol<br>scratched into it. This stone seems complete in some way."),
-			new WidgetTextRequirement(119, 3, true, "Mort Myre Fungi was absorbed"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Mort Myre Fungi was absorbed"));
 		usedCard = new Conditions(true, LogicType.OR, new ChatMessageRequirement("The stone seems to absorb the used spell scroll."),
 			new ChatMessageRequirement("The stone seems to absorb the spell scroll."),
 			new WidgetTextRequirement(229, 1, "spirit symbol<br>scratched into it. This stone seems to be complete"),
-			new WidgetTextRequirement(119, 3, true, "spell scroll was absorbed"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "spell scroll was absorbed"));
 
 		ghastNearby = new NpcCondition(NpcID.GHAST_946);
 

--- a/src/main/java/com/questhelper/helpers/quests/princealirescue/PrinceAliRescue.java
+++ b/src/main/java/com/questhelper/helpers/quests/princealirescue/PrinceAliRescue.java
@@ -54,6 +54,7 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class PrinceAliRescue extends BasicQuestHelper
 {
@@ -172,8 +173,8 @@ public class PrinceAliRescue extends BasicQuestHelper
 		inCell = new ZoneRequirement(cell);
 		hasWigPasteAndKey = new Conditions(dyedWig.alsoCheckBank(questBank), paste.alsoCheckBank(questBank), key.alsoCheckBank(questBank));
 		givenKeyMould = new Conditions(true, LogicType.OR,	// TODO quest journal widget text outdated
-			new WidgetTextRequirement(119, 3, true, "I have duplicated a key, I need to get it from"),
-			new WidgetTextRequirement(119, 3, true, "I got a duplicated cell door key"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I have duplicated a key, I need to get it from"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I got a duplicated cell door key"),
 			new WidgetTextRequirement(11, 2, true, "You give Osman the imprint along with a bronze bar."),
 			new DialogRequirement("I'll use this to have a copy of the key made. I'll send it to Leela once it's ready."),
 			new DialogRequirement("I think I have everything needed."),

--- a/src/main/java/com/questhelper/helpers/quests/shilovillage/ShiloVillage.java
+++ b/src/main/java/com/questhelper/helpers/quests/shilovillage/ShiloVillage.java
@@ -68,6 +68,7 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class ShiloVillage extends BasicQuestHelper
 {
@@ -232,7 +233,7 @@ public class ShiloVillage extends BasicQuestHelper
 		shownStone = new Conditions(true, LogicType.OR,
 			new DialogRequirement("If you have found anything else that you need " +
 				"help with, please just let me know."),
-			new WidgetTextRequirement(119, 3, true, "<str>Trufitus identified the plaque")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>Trufitus identified the plaque")
 		);
 
 		hasReadTattered = new Conditions(true, LogicType.OR,

--- a/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -350,7 +350,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 			new VarplayerRequirement(QuestVarPlayer.QUEST_TAI_BWO_WANNAI_TRIO.getId(), 2));
 
 		syncedState = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 2, "<col=7f0000>Tai Bwo Wannai Trio</col>"),
+			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "<col=7f0000>Tai Bwo Wannai Trio</col>"),
 			startedQuestDuringSession
 		);
 

--- a/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -350,7 +350,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 			new VarplayerRequirement(QuestVarPlayer.QUEST_TAI_BWO_WANNAI_TRIO.getId(), 2));
 
 		syncedState = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "<col=7f0000>Tai Bwo Wannai Trio</col>"),
+			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "Tai Bwo Wannai Trio"),
 			startedQuestDuringSession
 		);
 

--- a/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -355,7 +355,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		);
 
 		givenVessel = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "<str>He has successfully caught a Karambwan."),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>He has successfully caught a Karambwan."),
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand over the Karambwan vessel to Tiadeche."),
 			new DialogRequirement("What is it?")
 		);
@@ -363,7 +363,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		givenKarambwanji = new Conditions(true, LogicType.OR,
 			givenVessel,
 			new WidgetTextRequirement(193, 2, "You hand Lubufu 20 raw Karambwanji."),
-			new WidgetTextRequirement(119, 3, true, "<str>I have given Lubufu 20 Karambwanji.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have given Lubufu 20 Karambwanji.")
 		);
 
 		vesselOnGround = new ItemOnTileRequirement(karambwanVessel);
@@ -372,12 +372,12 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 			givenVessel,
 			new DialogRequirement("I will return only when I have caught a Karambwan."),
 			new WidgetTextRequirement(219, 1, 4, "How are you fishing for the Karambwan?"),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>He will only return to the village once he has caught a")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>He will only return to the village once he has caught a")
 		);
 
 		beenAskedToResearchVessel = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Take a Karambwan vessel to my brother Tinsay."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I must take a <col=800000>Karambwan vessel<col=000080> to <col=800000>Tinsay<col=000080> and retrieve")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I must take a <col=800000>Karambwan vessel<col=000080> to <col=800000>Tinsay<col=000080> and retrieve")
 		);
 
 		bonesNearby = new ItemOnTileRequirement(ItemID.JOGRE_BONES);
@@ -390,25 +390,25 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 			new NpcCondition(NpcID.TAMAYU_4705),
 			new DialogRequirement("I simply cannot match the Shaikahan's agility!",
 				"I cannot do enough damage with this spear..."),
-			new WidgetTextRequirement(119, 3, true, "He appears to be having difficulty in the hunt.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "He appears to be having difficulty in the hunt.")
 		);
 
 		givenPotion = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand over the agility potion to Tamayu."),
 			new DialogRequirement("Thank you Bwana. Now I must prepare for my next"),
-			new WidgetTextRequirement(119, 3, true, "<str>I have increased his agility to match the Shaikahan's.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have increased his agility to match the Shaikahan's.")
 		);
 		givenSpear = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Tamayu, try using this weapon."),
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand the spear to Tamayu."),
-			new WidgetTextRequirement(119, 3, true, "<str>I have give him a stronger and Karambwan poisoned spear.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have give him a stronger and Karambwan poisoned spear.")
 		);
 
 		defeatedBeast = new Conditions(true, LogicType.OR,
 			new DialogRequirement("I did it! I, Tamayu, first son of Timfraku, did slay " +
 				"the Shaikahan!"),
 			new DialogRequirement("The deaths of my kin have been avenged. You are my witness."),
-			new WidgetTextRequirement(119, 3, true, "<str>Tamayu has slain the Shaikahan!")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>Tamayu has slain the Shaikahan!")
 		);
 
 		hadAtLeastRawKarambwan = new Conditions(LogicType.OR, rawKarambwan, poisonKarambwan, karambwanPaste,
@@ -417,13 +417,13 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 
 		givenBones = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Tinsay the burnt Jogre bones marinated"),
-			new WidgetTextRequirement(119, 3, true, "<str>I have given him a burnt Jogre bones marinated in"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have given him a burnt Jogre bones marinated in"),
 			new DialogRequirement("Finally! A near lifetime of craving satisfied!")
 		);
 
 		givenSandwich = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Tinsay the seaweed in monkey skin sandwich."),
-			new WidgetTextRequirement(119, 3, true, "<str>I have given him a seaweed in monkey skin sandwich."),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have given him a seaweed in monkey skin sandwich."),
 			new DialogRequirement("Yes ... perfect! You really do not understand how necessary that was."),
 			givenBones
 		);
@@ -431,7 +431,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		givenRum = new Conditions(true, LogicType.OR,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand Tinsay the sliced bananas in Karamjan " +
 				"rum."),
-			new WidgetTextRequirement(119, 3, true, "<str>I have given him sliced banana in Karamja rum."),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I have given him sliced banana in Karamja rum."),
 			new DialogRequirement("Yes ... that's it! Hits just the spot!"),
 			givenSandwich,
 			givenBones
@@ -443,7 +443,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		hadMarinated = new Conditions(LogicType.OR, marinatedJogreBones.alsoCheckBank(questBank), givenBones);
 
 		talkedTinsay1 = new Conditions(true, LogicType.OR,
-			new WidgetTextRequirement(119, 3, true, "<col=000080>He requires <col=800000>banana in Karamja " +
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>He requires <col=800000>banana in Karamja " +
 				"rum<col=000080> to repair the tribal"),
 			new DialogRequirement("And you're going to use this to repair the"),
 			new DialogRequirement("Hmm ... I think I need banana in Karamjan rum.")
@@ -452,7 +452,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		hadManual = new Conditions(true, LogicType.OR,
 			craftingManual,
 			new WidgetTextRequirement(ComponentID.DIALOG_SPRITE_TEXT, "You hand over the crafting manual to Tiadeche."),
-			new WidgetTextRequirement(119, 3, true, "<str>retrieved crafting instructions for Tiadeche.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>retrieved crafting instructions for Tiadeche.")
 		);
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
+++ b/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
@@ -306,44 +306,44 @@ public class TheDigSite extends BasicQuestHelper
 		// Exam questions 1
 		talkedToFemaleStudent = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Hey! My lucky mascot!"),
-			new WidgetTextRequirement(119, 3, true, "I should talk to her to see if she can help"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I should talk to her to see if she can help"));
 		femaleStudentQ1Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("The proper health and safety points are"),
-			new WidgetTextRequirement(119, 3, true, "She gave me an answer"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "She gave me an answer"));
 
-		WidgetTextRequirement orangeGivenAnswer1Diary = new WidgetTextRequirement(119, 3, true, "He gave me an answer to one of the questions");
+		WidgetTextRequirement orangeGivenAnswer1Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "He gave me an answer to one of the questions");
 		orangeGivenAnswer1Diary.addRange(20, 35);
 		talkedToOrangeStudent = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Look what I found!"),
-			new WidgetTextRequirement(119, 3, true, "<str>to find it and return it to him."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>to find it and return it to him."));
 		orangeStudentQ1Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("The people eligible to use the digsite are:"),
 			orangeGivenAnswer1Diary);
 
-		WidgetTextRequirement greenGivenAnswer1Diary = new WidgetTextRequirement(119, 3, true, "He gave me an answer to one of the questions");
+		WidgetTextRequirement greenGivenAnswer1Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "He gave me an answer to one of the questions");
 		greenGivenAnswer1Diary.addRange(0, 19);
 
 		talkedToGreenStudent = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Oh wow! You've found it!"),
-			new WidgetTextRequirement(119, 3, true, "<str>to him; maybe someone has picked it up?"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>to him; maybe someone has picked it up?"));
 		greenStudentQ1Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("The study of Earth Sciences is:"),
 			greenGivenAnswer1Diary);
 
 		// Exam questions 2
-		WidgetTextRequirement femaleGivenAnswer2Diary = new WidgetTextRequirement(119, 3, true, "<str>I need to speak to the student in the purple skirt about");
+		WidgetTextRequirement femaleGivenAnswer2Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I need to speak to the student in the purple skirt about");
 		femaleGivenAnswer2Diary.addRange(43, 52);
 		femaleStudentQ2Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Finds handling: Finds must"),
 			femaleGivenAnswer2Diary);
 
-		WidgetTextRequirement orangeGivenAnswer2Diary = new WidgetTextRequirement(119, 3, true, "<str>I need to speak to the student in the orange top about the");
+		WidgetTextRequirement orangeGivenAnswer2Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I need to speak to the student in the orange top about the");
 		orangeGivenAnswer2Diary.addRange(43, 52);
 		orangeStudentQ2Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Correct sample transportation: "),
 			orangeGivenAnswer2Diary);
 
-		WidgetTextRequirement greenGivenAnswer2Diary = new WidgetTextRequirement(119, 3, true, "<str>I need to speak to the student in the green top about the");
+		WidgetTextRequirement greenGivenAnswer2Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I need to speak to the student in the green top about the");
 		greenGivenAnswer2Diary.addRange(43, 52);
 		greenStudentQ2Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Correct rock pick usage: Always handle"),
@@ -353,20 +353,20 @@ public class TheDigSite extends BasicQuestHelper
 		femaleExtorting = new Conditions(true, LogicType.OR,
 			new DialogRequirement("OK, I'll see what I can turn up for you."),
 			new DialogRequirement("Well, I have seen people get them from panning"),
-			new WidgetTextRequirement(119, 3, true, "I need to bring her an opal"));
-		WidgetTextRequirement femaleGivenAnswer3Diary = new WidgetTextRequirement(119, 3, true, "<str>I need to speak to the student in the purple skirt about");
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I need to bring her an opal"));
+		WidgetTextRequirement femaleGivenAnswer3Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I need to speak to the student in the purple skirt about");
 		femaleGivenAnswer3Diary.addRange(56, 63);
 		femaleStudentQ3Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Sample preparation: Samples cleaned"),
 			femaleGivenAnswer3Diary);
 
-		WidgetTextRequirement orangeGivenAnswer3Diary = new WidgetTextRequirement(119, 3, true, "<str>I need to speak to the student in the orange top about the");
+		WidgetTextRequirement orangeGivenAnswer3Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I need to speak to the student in the orange top about the");
 		orangeGivenAnswer3Diary.addRange(56, 63);
 		orangeStudentQ3Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("The proper technique for handling bones is: Handle"),
 			orangeGivenAnswer3Diary);
 
-		WidgetTextRequirement greenGivenAnswer3Diary = new WidgetTextRequirement(119, 3, true, "<str>I need to speak to the student in the green top about the");
+		WidgetTextRequirement greenGivenAnswer3Diary = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I need to speak to the student in the green top about the");
 		greenGivenAnswer3Diary.addRange(56, 63);
 		greenStudentQ3Learnt = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Specimen brush use: Brush carefully"),

--- a/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
+++ b/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
@@ -61,6 +61,7 @@ import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class TheDigSite extends BasicQuestHelper
 {
@@ -286,10 +287,10 @@ public class TheDigSite extends BasicQuestHelper
 
 
 		syncedUp = new Conditions(true, LogicType.OR, knowStateAsJustStartedQuest,
-			new WidgetTextRequirement(119, 2, "The Dig Site"));
+			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "The Dig Site"));
 
 		syncedUp2 = new Conditions(true, LogicType.OR, knowStateAsJustCompletedFirstExam,
-			new WidgetTextRequirement(119, 2, "The Dig Site"),
+			new WidgetTextRequirement(ComponentID.DIARY_TITLE, "The Dig Site"),
 			new DialogRequirement("You got all the questions correct. Well done!"),
 			new DialogRequirement("Hey! Excellent!"));
 

--- a/src/main/java/com/questhelper/helpers/quests/thefremenniktrials/TheFremennikTrials.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremenniktrials/TheFremennikTrials.java
@@ -403,7 +403,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("That is great news outerlander! We always need more music lovers here!"),
 			new DialogRequirement("So how would I go about writing this epic?"),
-			new WidgetTextRequirement(119, 3, true, "Bard<col=000080> will vote for me if"))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Bard<col=000080> will vote for me if"))
 		);
 
 		syncedOlaf = new Conditions(true, synced, hasStartedOlaf);
@@ -435,11 +435,11 @@ public class TheFremennikTrials extends BasicQuestHelper
 			new Conditions(petRockInCauldron, cabbageInCauldron, potatoInCauldron, onionInCauldron, cauldronFilledDialog));
 
 		finishedOlafMessage = new ChatMessageRequirement("Congratulations! You have completed the Bard's Trial!");
-		finishedOlafWidget = new Conditions(true, new WidgetTextRequirement(119, 3, true, "I now have the Bard's vote"));
+		finishedOlafWidget = new Conditions(true, new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Bard's vote"));
 		finishedOlafTask = new RuneliteRequirement(configManager, "fremmytrialscompletedolaf",
 			new Conditions(true, LogicType.OR, finishedOlafMessage, finishedOlafWidget));
 
-		talkedToManniWidget = new Conditions(true, new WidgetTextRequirement(119, 3, true, "Reveller<col=000080> will vote for me"));
+		talkedToManniWidget = new Conditions(true, new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Reveller<col=000080> will vote for me"));
 		talkedToManniChat = new Conditions(true, LogicType.OR,
 			new DialogRequirement("pick up a keg from that table over there"),
 			new DialogRequirement("Grab a keg of beer from that table near the bar, and come back here with it.")
@@ -465,14 +465,14 @@ public class TheFremennikTrials extends BasicQuestHelper
 		finishedManniTask = new RuneliteRequirement(configManager, "fremmytrialsfinishedmanni",
 			new Conditions(true, LogicType.OR,
 			new ChatMessageRequirement("Congratulations! You have completed the Revellers' Trial!"),
-			new WidgetTextRequirement(119, 3, true, "I now have the Reveller's vote"))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Reveller's vote"))
 		);
 
 		// No gz message
 		finishedSigliTask = new RuneliteRequirement(configManager, "fremmytrialsfinishedsigli",
 			new Conditions(true, LogicType.OR,
 				new ChatMessageRequirement("Congratulations! You have completed the Hunter's Trial!"),
-				new WidgetTextRequirement(119, 3, true, "I now have the Hunter's vote")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Hunter's vote")
 			)
 		);
 
@@ -481,7 +481,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 				new DialogRequirement("We are a very insular clan"),
 				new DialogRequirement("Any suggestions on where to start looking for this flower?"),
 				new DialogRequirement("Did you manage to obtain my flower for me yet?"),
-				new WidgetTextRequirement(119, 3, true, "has a <col=800000>rare flower<col=000080> that he wants."))
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "has a <col=800000>rare flower<col=000080> that he wants."))
 		);
 
 		talkedToSailor = new RuneliteRequirement(configManager, "fremmytrialssigmundsailor",
@@ -503,7 +503,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 		talkedToYsra = new RuneliteRequirement(configManager, "fremmytrialssigmundysra",
 			new Conditions(true, LogicType.OR,
 			ysraAsked,
-			new WidgetTextRequirement(119, 3, true,
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true,
 				"<col=000080>The <col=800000>shopkeeper<col=000080> is looking for a <col=800000>tax " +
 					"reduction<col=000080>..."))
 		);
@@ -511,38 +511,38 @@ public class TheFremennikTrials extends BasicQuestHelper
 		talkedToBrundtForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundbrundt",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("Speak to Sigli then, and you may have my promise to reduce our sales taxes. And best of luck with the rest of your trials."),
-			new WidgetTextRequirement(119, 3, true, "The <col=800000>chieftain<col=000080> wants a <col=800000>map of new hunting grounds<col=000080>...")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "The <col=800000>chieftain<col=000080> wants a <col=800000>map of new hunting grounds<col=000080>...")
 			));
 
 		talkedToSigliForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundsigli",
 			new Conditions(true, LogicType.OR,
 			// TODO: Fix this check, missing a br
 			new DialogRequirement("who knows where my hunting ground is."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The hunter<col=000080> is looking for a <col=800000>custom bow string<col=000080>...")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The hunter<col=000080> is looking for a <col=800000>custom bow string<col=000080>...")
 			));
 
 		talkedToSkulgrimenForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundskulgrimen",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("Sounds good to me."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The <col=800000>armourer<col=000080> is looking for a <col=800000>rare inedible fish<col=000080>...")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The <col=800000>armourer<col=000080> is looking for a <col=800000>rare inedible fish<col=000080>...")
 			));
 
 		talkedToFishermanForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundfisherman",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("I'll see what I can do."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The <col=800000>fisherman<col=000080> is looking for a <col=800000>map of fishing spots<col=000080>..."))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The <col=800000>fisherman<col=000080> is looking for a <col=800000>map of fishing spots<col=000080>..."))
 		);
 
 		talkedToSwensenForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundswensen",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement(" take the time to make a forecast somehow."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The <col=800000>navigator<col=000080> is looking for a <col=800000>weather forecast<col=000080>..."))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The <col=800000>navigator<col=000080> is looking for a <col=800000>weather forecast<col=000080>..."))
 		);
 
 		talkedToPeerForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundpeer",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("That is all."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The <col=800000>seer<col=000080> is looking for a <col=800000>warrior to be his bodyguard<col=000080>..."))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The <col=800000>seer<col=000080> is looking for a <col=800000>warrior to be his bodyguard<col=000080>..."))
 		);
 		Conditions thorvaldAsked = new Conditions(true, LogicType.AND, new DialogRequirement("Okay, I'll see what I can do."),
 			new ZoneRequirement(new Zone(new WorldPoint(2661, 3690, 0), new WorldPoint(2669, 3696, 0))));
@@ -550,28 +550,28 @@ public class TheFremennikTrials extends BasicQuestHelper
 		talkedToThorvaldForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundthorvald",
 			new Conditions(true, LogicType.OR,
 			thorvaldAsked,
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The <col=800000>warrior<col=000080> is looking for a <col=800000>champions token<col=000080>..."))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The <col=800000>warrior<col=000080> is looking for a <col=800000>champions token<col=000080>..."))
 		);
 
 		talkedToManniForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundmanni",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("That's all."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>The <col=800000>reveller<col=000080> is looking for a <col=800000>legendary cocktail<col=000080>..."))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>The <col=800000>reveller<col=000080> is looking for a <col=800000>legendary cocktail<col=000080>..."))
 		);
 
 		talkedToThoraForSigmund = new RuneliteRequirement(configManager, "fremmytrialssigmundthora",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("cash. You should go ask him"),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>All <col=800000>Askeladden<col=000080> wants is " +
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>All <col=800000>Askeladden<col=000080> wants is " +
 				"<col=800000>some money<col=000080>!"),
-			new WidgetTextRequirement(119, 3, true, "<col=800000>Thora")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=800000>Thora")
 			));
 
 		// TODO: No gz message
 		finishedSigmundTask = new RuneliteRequirement(configManager, "fremmytrialssigmundfinished",
 			new Conditions(true, LogicType.OR,
 			new ChatMessageRequirement("Congratulations! You have completed the Merchant's Trial!"),
-			new WidgetTextRequirement(119, 3, true, "I now have the Merchant's vote")));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Merchant's vote")));
 
 		syncedSigmund = new Conditions(LogicType.OR, getFlower, talkedToSailor, talkedToOlafForSigmund, talkedToYsra, talkedToBrundtForSigmund, talkedToSigliForSigmund, talkedToSkulgrimenForSigmund,
 			talkedToFishermanForSigmund, talkedToSwensenForSigmund, talkedToPeerForSigmund, talkedToThorvaldForSigmund, talkedToManniForSigmund, talkedToThoraForSigmund);
@@ -582,7 +582,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 		talkedToThorvald = new RuneliteRequirement(configManager, "fremmytrialsthorvaldstarted",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("Hahahahaha! I'm beginning"),
-			new WidgetTextRequirement(119, 3, true, "Warrior<col=000080> will vote for me if"))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Warrior<col=000080> will vote for me if"))
 		);
 
 		koschei1Near = new NpcCondition(NpcID.KOSCHEI_THE_DEATHLESS);
@@ -596,13 +596,13 @@ public class TheFremennikTrials extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 			new ChatMessageRequirement("Congratulations! You have completed the warrior's trial!"),
 				new ChatMessageRequirement("Congratulations! You have completed the warriors trial!"),
-			new WidgetTextRequirement(119, 3, true, "I now have the Warrior's vote"))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Warrior's vote"))
 		);
 
 		talkedToSwensen = new RuneliteRequirement(configManager, "fremmytrialsswensenstarted",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("A maze? Is that all?"),
-			new WidgetTextRequirement(119, 3, true, "Navigator<col=000080> will vote for me if"))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Navigator<col=000080> will vote for me if"))
 		);
 
 		inSwensenRoom1 = new ZoneRequirement(swensenRoom1);
@@ -619,7 +619,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 		finishedSwensenTask = new RuneliteRequirement(configManager, "fremmytrialswensenfinished",
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("Outerlander! You have finished my maze!"),
-			new WidgetTextRequirement(119, 3, true, "I now have the Navigator's vote"))
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Navigator's vote"))
 		);
 
 		/* Peer Task */
@@ -628,7 +628,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 			new Conditions(true, LogicType.OR,
 			new DialogRequirement("I have one small question"),
 			new DialogRequirement("So I can bring nothing with me when I enter your house?"),
-			new WidgetTextRequirement(119, 3, true, "Seer<col=000080> will vote for me if")));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Seer<col=000080> will vote for me if")));
 
 		isMind = new Conditions(true, new WidgetTextRequirement(229, 1, "My first is in mage"));
 		isTree = new Conditions(true, new WidgetTextRequirement(229, 1, "My first is in tar"));
@@ -656,7 +656,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 
 		finishedPeerTask = new Conditions(true, LogicType.OR,
 			new DialogRequirement("To have solved my puzzle"),
-			new WidgetTextRequirement(119, 3, true, "I now have the Seer's vote"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I now have the Seer's vote"));
 
 		syncedPeer = new Conditions(talkedToPeer);
 

--- a/src/main/java/com/questhelper/helpers/quests/thegiantdwarf/TheGiantDwarf.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegiantdwarf/TheGiantDwarf.java
@@ -207,7 +207,7 @@ public class TheGiantDwarf extends BasicQuestHelper
 
 		talkedToVermundi = new Conditions(true, LogicType.OR,
 			new DialogRequirement("Great, thanks a lot, I'll check out the library!"),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I should speak to the " +
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I should speak to the " +
 				"<col=800000>librarian<col=000080> in Keldagrim-West. He"),
 			new WidgetTextRequirement(219, 1, 2, "Yes, about those special clothes again..."));
 
@@ -216,12 +216,12 @@ public class TheGiantDwarf extends BasicQuestHelper
 				"Let me think... I believe it is on the top shelf of one of<br>the bookcases in the library, because it is such an old<br>book.",
 				"Well, thanks, I'll have a look."
 			),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>library of Keldagrim-West. I should ")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>library of Keldagrim-West. I should ")
 		);
 
 		hasBookOnCostumes = new Conditions(true, LogicType.OR,
 			bookOnCostumes,
-			new WidgetTextRequirement(119, 3, true, "<col=000080>with the <col=800000>book on dwarven costumes<col=000080> that I got from the")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>with the <col=800000>book on dwarven costumes<col=000080> that I got from the")
 		);
 
 		talkedToVermundiWithBook = new VarbitRequirement(584, 1);
@@ -230,40 +230,40 @@ public class TheGiantDwarf extends BasicQuestHelper
 			new DialogRequirement(questHelperPlugin.getPlayerStateManager().getPlayerName(),
 				"Don't worry, I'll get them for you. Let's see... some coal and some logs. Shouldn't be too hard.", false),
 			new DialogRequirement("Well, like I said, I can't do anything really without my spinning machine."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I must get <col=800000>coal<col=000080> and <col=800000>logs<col=000080>.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I must get <col=800000>coal<col=000080> and <col=800000>logs<col=000080>.")
 		);
 
 		usedCoalOnMachine = new Conditions(true, LogicType.OR,
 			new DialogRequirement("it needs to be powered up."),
 			new ChatMessageRequirement("You load the spinning machine with coal and logs."),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I have to start up the dwarven <col=800000>spinning machine<col=000080> in the"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I have to start up the dwarven <col=800000>spinning machine<col=000080> in the"));
 
 		startedMachine = new Conditions(true, LogicType.OR,
 			new ChatMessageRequirement("...and successfully start the engine!"),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I should ask <col=800000>Vermundi<col=000080>, the owner of the <col=800000>clothes stall<col=000080> in the"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I should ask <col=800000>Vermundi<col=000080>, the owner of the <col=800000>clothes stall<col=000080> in the"));
 
 		givenExquisiteClothes = new Conditions(true, new VarbitRequirement(576, true, 0));
 		hasExquisiteClothes = new Conditions(true, LogicType.OR,
 			givenExquisiteClothes,
 			exquisiteClothes,
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I have the <col=800000>exquisite clothes<col=000080> that the <col=800000>sculptor<col=000080> needs. Now I"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I have the <col=800000>exquisite clothes<col=000080> that the <col=800000>sculptor<col=000080> needs. Now I"));
 
 		talkedToSaro = new Conditions(true, LogicType.OR,
 			// TODO: You need to click 'click to continue' here for the step to actually progress
 			new DialogRequirement("Thanks!"),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I should seek out the <col=800000>eccentric old dwarf<col=000080> in <col=800000>Keldagrim-"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I should seek out the <col=800000>eccentric old dwarf<col=000080> in <col=800000>Keldagrim-"),
 			new DialogRequirement("I thought I already told you where to get them?")
 		);
 
 		talkedToDromund = new Conditions(true, LogicType.OR,
 			// TODO: You need to click 'click to continue' here for the step to actually progress
 			new DialogRequirement("Get out you pesky human! The boots are mine and"),
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I must find some way to get the <col=800000>pair of boots<col=000080> from the"),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I must find some way to get the <col=800000>pair of boots<col=000080> from the"),
 			new DialogRequirement("Are you sure you don't want to give me those boots?"));
 
 		hasLeftBoot = new Conditions(true, LogicType.OR,
 			leftBoot,
-			new WidgetTextRequirement(119, 3, true,
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true,
 				"<str>I have sneakily stolen one boots from the old dwarf.")
 		);
 
@@ -271,7 +271,7 @@ public class TheGiantDwarf extends BasicQuestHelper
 		hasExquisiteBoots = new Conditions(true, LogicType.OR,
 			givenExquisiteBoots,
 			exquisiteBoots,
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I have the <col=800000>exquisite pair of boots<col=000080> that the <col=800000>sculptor<col=000080> needs.")
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I have the <col=800000>exquisite pair of boots<col=000080> that the <col=800000>sculptor<col=000080> needs.")
 		);
 
 		talkedToSantiri = new Conditions(true, dwarvenBattleaxeBroken);
@@ -294,7 +294,7 @@ public class TheGiantDwarf extends BasicQuestHelper
 		hasDwarvenBattleaxe = new Conditions(true, LogicType.OR,
 			givenDwarvenBattleaxe,
 			dwarvenBattleaxe,
-			new WidgetTextRequirement(119, 3, true, "<col=000080>I must give the <col=800000>restored battleaxe<col=000080> to <col=800000>Riki<col=000080>, the <col=800000>sculptor's"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<col=000080>I must give the <col=800000>restored battleaxe<col=000080> to <col=800000>Riki<col=000080>, the <col=800000>sculptor's"));
 
 		inConsortium = new ZoneRequirement(consortium);
 

--- a/src/main/java/com/questhelper/helpers/quests/watchtower/Watchtower.java
+++ b/src/main/java/com/questhelper/helpers/quests/watchtower/Watchtower.java
@@ -59,6 +59,7 @@ import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 
 public class Watchtower extends BasicQuestHelper
 {
@@ -355,47 +356,47 @@ public class Watchtower extends BasicQuestHelper
 
 		knownOgreStep = new Conditions(true, LogicType.OR,
 			new DialogRequirement("In the meantime, I'll throw those fingernails out for you."),
-			new WidgetTextRequirement(119, 3, true, "deal with the tribal ogres."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "deal with the tribal ogres."));
 
 		talkedToGrew = new Conditions(true, LogicType.OR, new DialogRequirement("The morsel is back.", "Heheheheh!"),
-			new WidgetTextRequirement(119, 3, true, "Grew wants me to give him", "I have <col=800000>one of Gorad's teeth"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Grew wants me to give him", "I have <col=800000>one of Gorad's teeth"));
 
 		talkedToOg = new Conditions(true, LogicType.OR, new DialogRequirement("Here is a key to the chest it's in.", "Where my gold from dat dirty Toban?"),
-			new WidgetTextRequirement(119, 3, true, "Og wants me to", "I have Og's <col=800000>stolen gold"), hasTobansKey);
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Og wants me to", "I have Og's <col=800000>stolen gold"), hasTobansKey);
 
 		talkedToToban = new Conditions(true, LogicType.OR, new DialogRequirement("Prove to me your might", "Hahaha! Small t'ing returns."),
-			new WidgetTextRequirement(119, 3, true, "Toban wants me to give him", "I have the <col=800000>dragon bones"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Toban wants me to give him", "I have the <col=800000>dragon bones"));
 
 		hasRelic1 = new Conditions(true, LogicType.OR, relic1,
-			new WidgetTextRequirement(119, 3, true, "I returned Og's stolen gold."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I returned Og's stolen gold."));
 
 		hasRelic2 = new Conditions(true, LogicType.OR, relic2,
-			new WidgetTextRequirement(119, 3, true, "I knocked out one of Gorad's teeth and gave it to Grew."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I knocked out one of Gorad's teeth and gave it to Grew."));
 
 		hasRelic3 = new Conditions(true, LogicType.OR, relic3,
-			new WidgetTextRequirement(119, 3, true, "I gave the dragon bones to Toban."));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I gave the dragon bones to Toban."));
 
 		gettingOgreRockCake = new VarbitRequirement(3120, 1);
 		gaveCake = new Conditions(true, LogicType.OR,
 			new DialogRequirement("This time we will let it go."),
 			new DialogRequirement("Well, well, look at this."),
-			new WidgetTextRequirement(119, 3, true, "<str>I gave the north-east guard a rock cake."),
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I gave the north-east guard a rock cake."),
 			inAreaBeforeBridgeJump
 		);
 		// 3319, 1, tried to enter city
 		knowsRiddle = new VarbitRequirement(3121, 1);
 
 		talkedToScaredSkavid = new Conditions(true, LogicType.OR, new DialogRequirement("Master, how are you doing", "Those will gets you started."),
-			new WidgetTextRequirement(119, 3, true, "ar, nod, gor, ig, cur"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "ar, nod, gor, ig, cur"));
 
 		talkedToSkavid1 = new Conditions(true, LogicType.OR, new ChatMessageRequirement(inSkavidRoom1, "It seems the skavid understood you.", "You have already talked to this skavid."),
-			new WidgetTextRequirement(119, 3, true, "'Bidith tanath'"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "'Bidith tanath'"));
 		talkedToSkavid2 = new Conditions(true, LogicType.OR, new ChatMessageRequirement(inSkavidRoom2, "It seems the skavid understood you.", "You have already talked to this skavid."),
-			new WidgetTextRequirement(119, 3, true, "'Gor cur'"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "'Gor cur'"));
 		talkedToSkavid3 = new Conditions(true, LogicType.OR, new ChatMessageRequirement(inSkavidRoom3, "It seems the skavid understood you.", "You have already talked to this skavid."),
-			new WidgetTextRequirement(119, 3, true, "'Cur bidith'"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "'Cur bidith'"));
 		talkedToSkavid4 = new Conditions(true, LogicType.OR, new ChatMessageRequirement(inSkavidRoom4, "It seems the skavid understood you.", "You have already talked to this skavid."),
-			new WidgetTextRequirement(119, 3, true, "'Gor nod'"));
+			new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "'Gor nod'"));
 
 		seenShamans = new VarbitRequirement(3125, 1);
 

--- a/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
+++ b/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
@@ -31,6 +31,7 @@ import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.player.SpellbookRequirement;
 import com.questhelper.requirements.util.Spellbook;
+import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.steps.ConditionalStep;
@@ -43,6 +44,7 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +71,8 @@ public class BikeShedder extends BasicQuestHelper
 	private ItemRequirement conditionalRequirementCoins;
 	private DetailedQuestStep conditionalRequirementLookAtCoins;
 	private ItemRequirement conditionalRequirementGoldBar;
+	private WidgetTextRequirement lookAtCooksAssistantRequirement;
+	private DetailedQuestStep lookAtCooksAssistant;
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
@@ -83,6 +87,7 @@ public class BikeShedder extends BasicQuestHelper
 		steps.addStep(new ZoneRequirement(new WorldPoint(3222, 3217, 0)), useCoinOnBush);
 		steps.addStep(new ZoneRequirement(new WorldPoint(3223, 3216, 0)), useManyCoinsOnBush);
 		steps.addStep(conditionalRequirementZoneRequirement, conditionalRequirementLookAtCoins);
+		steps.addStep(new ZoneRequirement(new WorldPoint(3224, 3221, 0)), lookAtCooksAssistant);
 		return new ImmutableMap.Builder<Integer, QuestStep>()
 			.put(-1, steps)
 			.build();
@@ -131,6 +136,10 @@ public class BikeShedder extends BasicQuestHelper
 		conditionalRequirementGoldBar.setConditionToHide(or(conditionalRequirementZoneNorthRequirement, conditionalRequirementZoneSouthRequirement));
 
 		conditionalRequirementLookAtCoins = new DetailedQuestStep(this, "Admire the coins in your inventory.", conditionalRequirementCoins);
+
+		lookAtCooksAssistantRequirement = new WidgetTextRequirement(ComponentID.DIARY_TITLE, "Cook's Assistant");
+		lookAtCooksAssistantRequirement.setDisplayText("Cook's Assistant quest journal open");
+		lookAtCooksAssistant = new DetailedQuestStep(this, "Open the Cook's Assistant quest journal. You must have started the quest for this test to work.", lookAtCooksAssistantRequirement);
 	}
 
 	@Override
@@ -144,6 +153,7 @@ public class BikeShedder extends BasicQuestHelper
 		panels.add(new PanelDetails("Use log on mysterious bush", List.of(useLogOnBush), List.of(anyLog)));
 		panels.add(new PanelDetails("Use coins on mysterious bush", List.of(useCoinOnBush, useManyCoinsOnBush), List.of(oneCoin, manyCoins)));
 		panels.add(new PanelDetails("Conditional requirement", List.of(conditionalRequirementLookAtCoins), List.of(conditionalRequirementCoins, conditionalRequirementGoldBar)));
+		panels.add(new PanelDetails("Quest state", List.of(lookAtCooksAssistant), List.of(lookAtCooksAssistantRequirement)));
 
 		return panels;
 	}

--- a/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
+++ b/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
@@ -73,6 +73,7 @@ public class BikeShedder extends BasicQuestHelper
 	private ItemRequirement conditionalRequirementGoldBar;
 	private WidgetTextRequirement lookAtCooksAssistantRequirement;
 	private DetailedQuestStep lookAtCooksAssistant;
+	private WidgetTextRequirement lookAtCooksAssistantTextRequirement;
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
@@ -139,7 +140,9 @@ public class BikeShedder extends BasicQuestHelper
 
 		lookAtCooksAssistantRequirement = new WidgetTextRequirement(ComponentID.DIARY_TITLE, "Cook's Assistant");
 		lookAtCooksAssistantRequirement.setDisplayText("Cook's Assistant quest journal open");
-		lookAtCooksAssistant = new DetailedQuestStep(this, "Open the Cook's Assistant quest journal. You must have started the quest for this test to work.", lookAtCooksAssistantRequirement);
+		lookAtCooksAssistantTextRequirement = new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "he now lets me use his high quality range");
+		lookAtCooksAssistantTextRequirement.setDisplayText("Cook's Assistant quest journal open & received reward (checking text)");
+		lookAtCooksAssistant = new DetailedQuestStep(this, "Open the Cook's Assistant quest journal. You must have started the quest for this test to work.", lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement);
 	}
 
 	@Override
@@ -153,7 +156,7 @@ public class BikeShedder extends BasicQuestHelper
 		panels.add(new PanelDetails("Use log on mysterious bush", List.of(useLogOnBush), List.of(anyLog)));
 		panels.add(new PanelDetails("Use coins on mysterious bush", List.of(useCoinOnBush, useManyCoinsOnBush), List.of(oneCoin, manyCoins)));
 		panels.add(new PanelDetails("Conditional requirement", List.of(conditionalRequirementLookAtCoins), List.of(conditionalRequirementCoins, conditionalRequirementGoldBar)));
-		panels.add(new PanelDetails("Quest state", List.of(lookAtCooksAssistant), List.of(lookAtCooksAssistantRequirement)));
+		panels.add(new PanelDetails("Quest state", List.of(lookAtCooksAssistant), List.of(lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement)));
 
 		return panels;
 	}

--- a/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
@@ -35,6 +35,7 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.Widget;
+import javax.annotation.Nonnull;
 
 public class WidgetTextRequirement extends SimpleRequirement
 {
@@ -53,6 +54,9 @@ public class WidgetTextRequirement extends SimpleRequirement
 	// Used to restrict the considered set of children
 	private int min = -1;
 	private int max = -1;
+
+	@Setter
+	private String displayText = "";
 
 	public WidgetTextRequirement(@Component int componentId, String... text)
 	{
@@ -182,5 +186,12 @@ public class WidgetTextRequirement extends SimpleRequirement
 	public void checkWidgetText(Client client)
 	{
 		hasPassed = hasPassed || checkWidget(client);
+	}
+
+	@Nonnull
+	@Override
+	public String getDisplayText()
+	{
+		return displayText;
 	}
 }

--- a/src/main/java/com/questhelper/statemanagement/BarbarianTrainingStateTracker.java
+++ b/src/main/java/com/questhelper/statemanagement/BarbarianTrainingStateTracker.java
@@ -36,6 +36,7 @@ import com.questhelper.requirements.runelite.RuneliteRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.widget.WidgetTextRequirement;
 import net.runelite.api.Client;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import javax.inject.Inject;
@@ -63,7 +64,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Certainly. Take the rod from under my bed and fish in the lake. When you have caught a few fish, I am sure you will be ready to talk more with me."),
 				new DialogRequirement("Alas, I do not sense that you have been successful in your fishing yet. The look in your eyes is not that of the osprey."),
-				new WidgetTextRequirement(119, 3, true, "fish with a new")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "fish with a new")
 			)
 		);
 
@@ -72,7 +73,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("... and I thought fishing was a safe way to pass the time."),
 				new DialogRequirement("I see you need encouragement in learning the ways of fishing without a harpoon."),
-				new WidgetTextRequirement(119, 3, true, "fish with my")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "fish with my")
 			)
 		);
 
@@ -81,7 +82,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Remember to be calm, and good luck."),
 				new DialogRequirement("I see you have yet to be successful in planting a seed with your fists."),
-				new WidgetTextRequirement(119, 3, true, "plant a seed with")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "plant a seed with")
 			)
 		);
 
@@ -90,7 +91,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("May the spirits guide you into success."),
 				new DialogRequirement("You have not yet attempted to plant a tree. Why not?"),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smash pots after")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smash pots after")
 			)
 		);
 
@@ -99,7 +100,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("The spirits will aid you. The power they supply will guide your hands. Go and benefit from their guidance upon oak logs."),
 				new DialogRequirement("By now you know my response."),
-				new WidgetTextRequirement(119, 3, true, "light a fire with")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "light a fire with")
 			)
 		);
 
@@ -108,7 +109,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Dive into the whirlpool in the lake to the east. The spirits will use their abilities to ensure you arrive in the correct location. Be warned, their influence fades, so you must find y"),
 				new DialogRequirement("I will repeat myself fully, since this is quite complex. Listen well."),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to <col=800000>create pyre ships")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to <col=800000>create pyre ships")
 			)
 		);
 
@@ -117,7 +118,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Have I become so predictable? But yes, I do indeed require a potion. It is of the highest importance that you bring me a lesser attack potion combined with fish roe."),
 				new DialogRequirement("Do you have my potion?"),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to make a <col=800000>new type")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to make a <col=800000>new type")
 			)
 		);
 
@@ -126,7 +127,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Note well that you will require wood for the spear shafts. The quality of wood must be similar to that of the metal involved."),
 				new DialogRequirement("You do not exude the presence of one who has poured his soul into manufacturing spears."),
-				new WidgetTextRequirement(119, 3, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smith spears")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "Otto<col=000080> has tasked me with learning how to <col=800000>smith spears")
 			)
 		);
 
@@ -135,7 +136,7 @@ public class BarbarianTrainingStateTracker
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Indeed. You may use our special anvil for this spear type too. The ways of black and dragon hastae are beyond our knowledge, however."),
 				new DialogRequirement("Take some wood and metal and make a spear upon the<br>nearby anvil, then you may return to me. As an<br>example, you may use bronze bars with normal logs or<br>iron bars with oak logs."),
-				new WidgetTextRequirement(119, 3, true, " has tasked me with learning how to <col=800000>smith a hasta")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, " has tasked me with learning how to <col=800000>smith a hasta")
 			)
 		);
 
@@ -144,7 +145,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_FISHING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Patience young one. These are fish which are fat with eggs rather than fat of flesh. It is these eggs that are the thing to make use of."),
-				new WidgetTextRequirement(119, 3, true, "I managed to catch a fish with the new rod!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to catch a fish with the new rod!")
 			),
 			"Finished Barbarian Fishing"
 		);
@@ -153,7 +154,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_HARPOON.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("I mean that when you eventually die and find peace, at least the spirits you encounter will be your friends. Alas for you adventurous sort, the natural ways of passing are close to imp"),
-				new WidgetTextRequirement(119, 3, true, "I managed to fish with my hands!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to fish with my hands!")
 			),
 			"Finished Barbarian Harpooning"
 		);
@@ -162,7 +163,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_SEED_PLANTING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("No child, but we all have potential to improve our strength."),
-				new WidgetTextRequirement(119, 3, true, "<str>I managed to plant a seed with my fists!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I managed to plant a seed with my fists!")
 			),
 			"Finished Barbarian Seed Planting"
 		);
@@ -171,7 +172,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_POT_SMASHING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("It will become more natural with practice."),
-				new WidgetTextRequirement(119, 3, true, "<str>I managed to smash a plant pot without littering!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "<str>I managed to smash a plant pot without littering!")
 			),
 			"Finished Barbarian Pot Smashing"
 		);
@@ -180,7 +181,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_FIREMAKING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("Fine news indeed!"),
-				new WidgetTextRequirement(119, 3, true, "I managed to light a fire with a bow!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to light a fire with a bow!")
 			),
 			"Finished Barbarian Firemaking"
 		);
@@ -189,7 +190,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_PYREMAKING.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("On this great day you have my eternal thanks. May you find riches while rescuing my spiritual ancestors in the caverns for many moons to come."),
-				new WidgetTextRequirement(119, 3, true, "I managed to create a pyre ship!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to create a pyre ship!")
 			),
 			"Finished Barbarian Pyremaking"
 		);
@@ -198,7 +199,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_SPEAR.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("The manufacture of spears is now yours as a speciality. Use your skill well."),
-				new WidgetTextRequirement(119, 3, true, "I managed to smith a spear!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to smith a spear!")
 			),
 			"Finished Barbarian Spear Smithing"
 		);
@@ -207,7 +208,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_HASTA.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("To live life to it's fullest of course - that you may be a peaceful spirit when your time ends."),
-				new WidgetTextRequirement(119, 3, true, "I managed to create a hasta!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to create a hasta!")
 			),
 			"Finished Barbarian Hasta Smithing"
 		);
@@ -216,7 +217,7 @@ public class BarbarianTrainingStateTracker
 			configManager, ConfigKeys.BARBARIAN_TRAINING_FINISHED_HERBLORE.getKey(),
 			new Conditions(true, LogicType.OR,
 				new DialogRequirement("I will take that off your hands now. I will say no more than that I am eternally grateful."),
-				new WidgetTextRequirement(119, 3, true, "I managed to create a new potion!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I managed to create a new potion!")
 			),
 			"Finished Barbarian Herblore"
 		);
@@ -229,7 +230,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement("You plant "),
 					new ChatMessageRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>plant a seed with my fists<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>plant a seed with my fists<col=000080>!")
 			)
 		);
 
@@ -241,7 +242,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement(" sapling"),
 					new ChatMessageRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>smash a pot without littering<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>smash a pot without littering<col=000080>!")
 			)
 		);
 
@@ -252,7 +253,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement("The fire catches and the logs begin to burn."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>light a fire with a bow<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>light a fire with a bow<col=000080>!")
 			)
 		);
 
@@ -263,7 +264,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement("The ancient barbarian is laid to rest."),
 					new ChatMessageRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>create a pyre ship<col=000080>! I should let")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>create a pyre ship<col=000080>! I should let")
 			)
 		);
 
@@ -274,7 +275,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement("You catch a leaping trout.", "You catch a leaping salmon.", "You catch a leaping sturgeon."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to catch a <col=800000>fish with the new rod<col=000080>! I should let")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to catch a <col=800000>fish with the new rod<col=000080>! I should let")
 			)
 		);
 
@@ -285,7 +286,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement("You catch a tuna.", "You catch a swordfish.", "You catch a shark.", "You catch a shark!"),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>fish with my hands<col=000080>! I should let <col=800000>Otto <col=000080>know")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>fish with my hands<col=000080>! I should let <col=800000>Otto <col=000080>know")
 			)
 		);
 
@@ -296,7 +297,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement("You combine your potion with the fish eggs."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to make a <col=800000>new type of potion<col=000080>! I should let")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to make a <col=800000>new type of potion<col=000080>! I should let")
 			)
 		);
 
@@ -308,7 +309,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement(" spear."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>smith a spear<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>smith a spear<col=000080>!")
 			)
 		);
 
@@ -320,7 +321,7 @@ public class BarbarianTrainingStateTracker
 					new ChatMessageRequirement(" hasta."),
 					new MesBoxRequirement("You feel you have learned more of barbarian ways. Otto might wish to talk to you more.")
 				),
-				new WidgetTextRequirement(119, 3, true, "I've managed to <col=800000>smith a hasta<col=000080>!")
+				new WidgetTextRequirement(ComponentID.DIARY_TEXT, true, "I've managed to <col=800000>smith a hasta<col=000080>!")
 			)
 		);
 


### PR DESCRIPTION
In the latest OSRS update, the child IDs for the quest journal https://github.com/runelite/runelite/commit/ed8619a2e1cc2cf7cfdd4331821be70565b996f3#diff-9a4617133d1883cb6a1ea7643bc34df5fe0544576ec7f4149f39352ae6dc4df0R278-R281
This broke all the quest sync checking for:
 - Barbarian Training (and its state tracker)
 - Clock Tower
 - Fairy Tale part 1
 - Legend's Quest
 - Monkey Madness 1
 - Nature Spirit
 - Prince Ali Rescue
 - Shilo Village
 - Tai Bwo Wannai Trio
 - The Dig Site
 - The Fremennik Trials
 - The Giant Dwarf
 - Watchtower

To fix this change, I decided to use RuneLite's ComponentID's `DIARY_TITLE` and `DIARY_TEXT` instead of rawdogging the IDs like we did previously. This should help in the future if Jagex changes these, but it does make the diff a bit more difficult to read.
If we don't like that it reads `DIARY_TEXT` and `DIARY_TITLE` we could make an internal alias for them.

screenshots of when i thought only the title ID had changed

![closed](https://github.com/user-attachments/assets/52f2c59c-93a2-4f04-9ecc-3d025317aa4a)
![open](https://github.com/user-attachments/assets/8ab8536c-9811-4dc2-91e8-9fbf8f65bb27)

Unrelated changes I've included:
 - Added an optional display text to the WidgetTextRequirement - this normally isn't needed but it was nice for the bike shedder quest
 - Removed the `<col...` tags from the Quest Journal title checks (there were only 2)

Reported by Yawooza in Discord https://discord.com/channels/772056816242130964/776427467560321034/1288630920781365280
