### PR TITLE
Fixed typo in Rag and Bone Man II

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
@@ -693,7 +693,7 @@ public class RagAndBoneManII extends BasicQuestHelper
 
 		// Feldip Hills
 		mapForFeldip.put(RagBoneState.WOLF_BONE, killWolf);
-		mapForFeldip.put(RagBoneState.OGRE_BONE, killOgre);
+		mapForFeldip.put(RagBoneState.OGRE_RIBS, killOgre);
 		mapForFeldip.put(RagBoneState.ZOGRE_BONE, killZogre);
 
 		stepsForRagAndBoneManII.putAll(mapForFeldip);

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagBoneGroups.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagBoneGroups.java
@@ -53,7 +53,7 @@ public class RagBoneGroups
 			RagBoneState.ICE_GIANT_RIBS, RagBoneState.MOGRE_BONE, RagBoneState.JOGRE_BONE,
 			RagBoneState.BABY_DRAGON_BONE, RagBoneState.TROLL_BONE, RagBoneState.RABBIT_BONE,
 			RagBoneState.BASILISK_BONE, RagBoneState.DAGANNOTH_RIBS, RagBoneState.FIRE_GIANT_BONE,
-			RagBoneState.TERRORBIRD_WING, RagBoneState.WOLF_BONE, RagBoneState.OGRE_BONE,
+			RagBoneState.TERRORBIRD_WING, RagBoneState.WOLF_BONE, RagBoneState.OGRE_RIBS,
 			RagBoneState.ZOGRE_BONE);
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagBoneState.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagBoneState.java
@@ -51,7 +51,7 @@ public enum RagBoneState
 	BAT_WING("Bat", 8, 8),
 	RAT_BONE("Rat", 9, 9),
 	BABY_DRAGON_BONE("Baby Blue Dragon", 10, 10),
-	OGRE_BONE("Ogre", 11, 11),
+	OGRE_RIBS("Ogre Ribs", 11, 11),
 	JOGRE_BONE("Jogre", 12, 12),
 	ZOGRE_BONE("Zogre", 13, 13),
 	MOGRE_BONE("Mogre", 14, 14),


### PR DESCRIPTION
Quest Helper named a non existent item "Ogre Bone"  it was Ogre ribs.

https://oldschool.runescape.wiki/w/Ogre_ribs