### PR TITLE
refactor: Clean up OwnerStep usage

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/biohazard/GiveIngredientsToHelpersStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/biohazard/GiveIngredientsToHelpersStep.java
@@ -27,7 +27,6 @@ package com.questhelper.helpers.quests.biohazard;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.steps.DetailedOwnerStep;
-import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.PuzzleWrapperStep;
 import com.questhelper.steps.QuestStep;

--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/MemoryPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/MemoryPuzzle.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.client.eventbus.Subscribe;
 
 public class MemoryPuzzle extends DetailedOwnerStep
 {

--- a/src/main/java/com/questhelper/helpers/quests/dragonslayerii/CryptPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/dragonslayerii/CryptPuzzle.java
@@ -29,7 +29,6 @@ import com.questhelper.requirements.zone.Zone;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.questhelpers.QuestUtil;
 import com.questhelper.requirements.Requirement;
-import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.steps.DetailedOwnerStep;
 import com.questhelper.steps.DetailedQuestStep;

--- a/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/TaverleyBalloonFlight.java
+++ b/src/main/java/com/questhelper/helpers/quests/enlightenedjourney/TaverleyBalloonFlight.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.client.eventbus.Subscribe;
 
 public class TaverleyBalloonFlight extends DetailedOwnerStep
 {

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/MimicChallenge.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/MimicChallenge.java
@@ -37,7 +37,6 @@ import java.util.List;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.client.eventbus.Subscribe;
 
 public class MimicChallenge extends DetailedOwnerStep
 {

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/NumberChallenge.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/NumberChallenge.java
@@ -12,7 +12,6 @@ import java.util.List;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.client.eventbus.Subscribe;
 
 public class NumberChallenge extends DetailedOwnerStep
 {

--- a/src/main/java/com/questhelper/helpers/quests/recruitmentdrive/LadyTableStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/recruitmentdrive/LadyTableStep.java
@@ -39,7 +39,6 @@ import net.runelite.api.Client;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.client.eventbus.Subscribe;
 
 public class LadyTableStep extends DetailedOwnerStep
 {

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
@@ -26,22 +26,16 @@ package com.questhelper.helpers.quests.theeyesofglouphrie;
 
 import com.google.inject.Inject;
 import com.questhelper.requirements.item.ItemRequirement;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
-import com.questhelper.requirements.Requirement;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.steps.widget.WidgetDetails;
-import com.questhelper.steps.WidgetStep;
-import com.questhelper.steps.OwnerStep;
-import java.awt.Graphics2D;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import lombok.NonNull;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
@@ -54,9 +48,8 @@ import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public class PuzzleStep extends QuestStep implements OwnerStep
+public class PuzzleStep extends DetailedOwnerStep
 {
 	@Inject
 	protected EventBus eventBus;
@@ -123,19 +116,13 @@ public class PuzzleStep extends QuestStep implements OwnerStep
 		updateSteps();
 	}
 
-	@Override
-	public void shutDown()
-	{
-		shutDownStep();
-		currentStep = null;
-	}
-
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		updateSteps();
 	}
 
+	@Override
 	public void updateSteps()
 	{
 		if (client.getVarbitValue(2502) == 2)
@@ -635,21 +622,16 @@ public class PuzzleStep extends QuestStep implements OwnerStep
 
 	protected void startUpStep(QuestStep step)
 	{
-		if (currentStep == null)
-		{
-			currentStep = step;
-			eventBus.register(currentStep);
-			currentStep.startUp();
-			return;
-		}
+		if (step.equals(currentStep)) return;
 
-		if (!step.equals(currentStep))
+		if (currentStep != null)
 		{
 			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
 		}
+
+		eventBus.register(step);
+		step.startUp();
+		currentStep = step;
 	}
 
 	protected void shutDownStep()
@@ -659,42 +641,6 @@ public class PuzzleStep extends QuestStep implements OwnerStep
 			eventBus.unregister(currentStep);
 			currentStep.shutDown();
 			currentStep = null;
-		}
-	}
-
-	@Override
-	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, @NonNull List<String> additionalText, @NonNull List<Requirement> requirements)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeOverlayHint(panelComponent, plugin, additionalText, requirements);
-		}
-	}
-
-	@Override
-	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldArrowOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldArrowOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldLineOverlayHint(graphics, plugin);
 		}
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
@@ -90,17 +90,6 @@ public class PuzzleStep extends DetailedOwnerStep
 	public PuzzleStep(QuestHelper questHelper)
 	{
 		super(questHelper, "Insert and swap discs to make the sum indicated on the machine");
-		solvePuzzle = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17282, new WorldPoint(2390, 9826, 0), "Put in the correct pieces.");
-		getPieces = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17283, new WorldPoint(2391, 9826, 0), "Swap in" +
-			" your pieces for the indicated pieces. You can also drop the discs then talk to Brimstail for more " +
-			"tokens.");
-		clickAnswer1 = new WidgetStep(getQuestHelper(), "Click the submit button.", 445, 36);
-		clickAnswer2 = new WidgetStep(getQuestHelper(), "Click the submit button.", 189, 39);
-		insertDisc = new WidgetStep(getQuestHelper(), "Insert the correct discs.", 449, 0);
-		clickDiscHole = new WidgetStep(getQuestHelper(), "Insert the disc.", 445, 31);
-		clickDiscHole2 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 24);
-		clickDiscHole3 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 25);
-		clickDiscHole4 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 26);
 		setupShapes();
 	}
 
@@ -133,6 +122,22 @@ public class PuzzleStep extends DetailedOwnerStep
 		{
 			solvePuzzle1();
 		}
+	}
+
+	@Override
+	public void setupSteps()
+	{
+		solvePuzzle = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17282, new WorldPoint(2390, 9826, 0), "Put in the correct pieces.");
+		getPieces = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17283, new WorldPoint(2391, 9826, 0), "Swap in" +
+				" your pieces for the indicated pieces. You can also drop the discs then talk to Brimstail for more " +
+				"tokens.");
+		clickAnswer1 = new WidgetStep(getQuestHelper(), "Click the submit button.", 445, 36);
+		clickAnswer2 = new WidgetStep(getQuestHelper(), "Click the submit button.", 189, 39);
+		insertDisc = new WidgetStep(getQuestHelper(), "Insert the correct discs.", 449, 0);
+		clickDiscHole = new WidgetStep(getQuestHelper(), "Insert the disc.", 445, 31);
+		clickDiscHole2 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 24);
+		clickDiscHole3 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 25);
+		clickDiscHole4 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 26);
 	}
 
 	public void solvePuzzle1()
@@ -491,7 +496,6 @@ public class PuzzleStep extends DetailedOwnerStep
 		}
 		return ids;
 	}
-
 
 	public int checkForItems(List<Item> items, int potentialMatch)
 	{

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/AltarPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/AltarPuzzle.java
@@ -25,24 +25,18 @@
 package com.questhelper.helpers.quests.theforsakentower;
 
 import com.google.inject.Inject;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.zone.ZoneRequirement;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.OwnerStep;
-import com.questhelper.steps.PuzzleWrapperStep;
-import com.questhelper.steps.QuestStep;
-import java.awt.Graphics2D;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import lombok.NonNull;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NullObjectID;
@@ -51,9 +45,8 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public class AltarPuzzle extends QuestStep implements OwnerStep
+public class AltarPuzzle extends DetailedOwnerStep
 {
 	@Inject
 	protected EventBus eventBus;
@@ -86,25 +79,13 @@ public class AltarPuzzle extends QuestStep implements OwnerStep
 		setupSteps();
 	}
 
-	@Override
-	public void startUp()
-	{
-		updateSteps();
-	}
-
-	@Override
-	public void shutDown()
-	{
-		shutDownStep();
-		currentStep = null;
-	}
-
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		updateSteps();
 	}
 
+	@Override
 	protected void updateSteps()
 	{
 		if (inBasement.check(client))
@@ -282,91 +263,12 @@ public class AltarPuzzle extends QuestStep implements OwnerStep
 		}
 	}
 
-	protected void startUpStep(QuestStep step)
-	{
-		if (currentStep == null)
-		{
-			currentStep = step;
-			eventBus.register(currentStep);
-			currentStep.startUp();
-			return;
-		}
-
-		if (!step.equals(currentStep))
-		{
-			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
-		}
-	}
-
-	protected void shutDownStep()
-	{
-		if (currentStep != this)
-		{
-			eventBus.unregister(currentStep);
-			currentStep.shutDown();
-			currentStep = null;
-		}
-	}
-
-	@Override
-	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, @NonNull List<String> additionalText, @NonNull List<Requirement> requirements)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeOverlayHint(panelComponent, plugin, additionalText, requirements);
-		}
-	}
-
-	@Override
-	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldArrowOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldArrowOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldLineOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public QuestStep getActiveStep()
-	{
-		if (currentStep != this)
-		{
-			return currentStep.getActiveStep();
-		}
-		else
-		{
-			return this;
-		}
-	}
-
 	private void setupItemRequirements()
 	{
 		ring1 = new ItemRequirement("Energy disk (level 1)", ItemID.ENERGY_DISK_LEVEL_1);
 		ring2 = new ItemRequirement("Energy disk (level 2)", ItemID.ENERGY_DISK_LEVEL_2);
 		ring3 = new ItemRequirement("Energy disk (level 3)", ItemID.ENERGY_DISK_LEVEL_3);
 		ring4 = new ItemRequirement("Energy disk (level 4)", ItemID.ENERGY_DISK_LEVEL_4);
-
 	}
 
 	private void setupConditions()
@@ -383,7 +285,8 @@ public class AltarPuzzle extends QuestStep implements OwnerStep
 		basement = new Zone(new WorldPoint(1374, 10217, 0), new WorldPoint(1389, 10231, 0));
 	}
 
-	private void setupSteps()
+	@Override
+	protected void setupSteps()
 	{
 		goUpLadder = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33484, new WorldPoint(1382, 10229, 0), "Leave the tower's basement.");
 		goUpStairs = new ObjectStep(getQuestHelper(), ObjectID.STAIRCASE_33550, new WorldPoint(1378, 3825, 0), "Climb up the staircase to the tower's 1st floor.");

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/AltarPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/AltarPuzzle.java
@@ -54,8 +54,6 @@ public class AltarPuzzle extends DetailedOwnerStep
 	@Inject
 	protected Client client;
 
-	private QuestStep currentStep;
-
 	ItemRequirement ring1, ring2, ring3, ring4;
 
 	Zone secondFloor, floor1, basement;
@@ -64,19 +62,15 @@ public class AltarPuzzle extends DetailedOwnerStep
 
 	QuestStep goUpLadder, goUpStairs, goUpToSecondFloor, restartStep, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15;
 
-	ArrayList<QuestStep> rebalanceW = new ArrayList<>();
-	ArrayList<QuestStep> rebalanceE = new ArrayList<>();
-	ArrayList<QuestStep> rebalanceC = new ArrayList<>();
+	ArrayList<QuestStep> rebalanceW;
+	ArrayList<QuestStep> rebalanceE;
+	ArrayList<QuestStep> rebalanceC;
 
 	List<QuestStep> moves = new ArrayList<>();
 
 	public AltarPuzzle(QuestHelper questHelper)
 	{
 		super(questHelper, "");
-		setupItemRequirements();
-		setupZones();
-		setupConditions();
-		setupSteps();
 	}
 
 	@Subscribe
@@ -288,6 +282,14 @@ public class AltarPuzzle extends DetailedOwnerStep
 	@Override
 	protected void setupSteps()
 	{
+		setupItemRequirements();
+		setupZones();
+		setupConditions();
+
+		rebalanceW = new ArrayList<>();
+		rebalanceC = new ArrayList<>();
+		rebalanceE = new ArrayList<>();
+
 		goUpLadder = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33484, new WorldPoint(1382, 10229, 0), "Leave the tower's basement.");
 		goUpStairs = new ObjectStep(getQuestHelper(), ObjectID.STAIRCASE_33550, new WorldPoint(1378, 3825, 0), "Climb up the staircase to the tower's 1st floor.");
 		goUpToSecondFloor = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33486, new WorldPoint(1382, 3827, 1), "Climb up the ladder to the top floor.");

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
@@ -25,7 +25,6 @@
 package com.questhelper.helpers.quests.theforsakentower;
 
 import com.google.inject.Inject;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.QuestHelper;
@@ -35,11 +34,8 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.requirements.util.LogicType;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.OwnerStep;
-import com.questhelper.steps.QuestStep;
-import java.awt.Graphics2D;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,7 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.NonNull;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NullObjectID;
@@ -58,9 +53,8 @@ import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public class JugPuzzle extends QuestStep implements OwnerStep
+public class JugPuzzle extends DetailedOwnerStep
 {
 	private static final Pattern JUG_VALUES_MATCHER = Pattern.compile("^You add ([0-9]) gallons* of coolant to your ([0-9])-gallon jug.(?: It now contains ([0-9]) gallons* of coolant[.])*(?: Your ([0-9])-gallon jug is left(?: (empty)| with ([0-9]) gallons* of coolant))*");
 	private static final Pattern JUG_FILLED = Pattern.compile("^You fill up your ([0-9])-gallon jug");
@@ -98,25 +92,13 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 		setupSteps();
 	}
 
-	@Override
-	public void startUp()
-	{
-		updateSteps();
-	}
-
-	@Override
-	public void shutDown()
-	{
-		shutDownStep();
-		currentStep = null;
-	}
-
 	@Subscribe
 	public void onGameTick(GameTick ignoredEvent)
 	{
 		updateSteps();
 	}
 
+	@Override
 	protected void updateSteps()
 	{
 		Widget widget = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
@@ -262,71 +244,6 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 		}
 	}
 
-	protected void startUpStep(QuestStep step)
-	{
-		if (currentStep == null)
-		{
-			currentStep = step;
-			eventBus.register(currentStep);
-			currentStep.startUp();
-			return;
-		}
-
-		if (!step.equals(currentStep))
-		{
-			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
-		}
-	}
-
-	protected void shutDownStep()
-	{
-		if (currentStep != null)
-		{
-			eventBus.unregister(currentStep);
-			currentStep.shutDown();
-			currentStep = null;
-		}
-	}
-
-	@Override
-	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, @NonNull List<String> additionalText, @NonNull List<Requirement> requirements)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeOverlayHint(panelComponent, plugin, additionalText, requirements);
-		}
-	}
-
-	@Override
-	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldArrowOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldArrowOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldLineOverlayHint(graphics, plugin);
-		}
-	}
-
 	@Override
 	public QuestStep getActiveStep()
 	{
@@ -365,7 +282,8 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 		inBasement = new ZoneRequirement(basement);
 	}
 
-	private void setupSteps()
+	@Override
+	protected void setupSteps()
 	{
 		syncStep = new DetailedQuestStep(getQuestHelper(), "Please check both the jugs to continue.");
 		searchCupboardTinderbox = new ObjectStep(getQuestHelper(), ObjectID.CUPBOARD_33515, new WorldPoint(1381, 3829, 0), "Search the cupboard on the north wall for a tinderbox.");

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/JugPuzzle.java
@@ -78,18 +78,11 @@ public class JugPuzzle extends DetailedOwnerStep
 
 	Zone firstFloor, secondFloor, basement;
 
-	private final HashMap<String, Integer> jugs = new HashMap<>();
+	private HashMap<String, Integer> jugs;
 
 	public JugPuzzle(QuestHelper questHelper)
 	{
 		super(questHelper, "");
-		jugs.put("5", -1);
-		jugs.put("8", -1);
-
-		setupItemRequirements();
-		setupZones();
-		setupConditions();
-		setupSteps();
 	}
 
 	@Subscribe
@@ -285,6 +278,14 @@ public class JugPuzzle extends DetailedOwnerStep
 	@Override
 	protected void setupSteps()
 	{
+		jugs = new HashMap<>();
+		jugs.put("5", -1);
+		jugs.put("8", -1);
+
+		setupItemRequirements();
+		setupZones();
+		setupConditions();
+
 		syncStep = new DetailedQuestStep(getQuestHelper(), "Please check both the jugs to continue.");
 		searchCupboardTinderbox = new ObjectStep(getQuestHelper(), ObjectID.CUPBOARD_33515, new WorldPoint(1381, 3829, 0), "Search the cupboard on the north wall for a tinderbox.");
 		searchCupboardJug = new ObjectStep(getQuestHelper(), ObjectID.CUPBOARD_33514, new WorldPoint(1378, 3826, 0), "Search the cupboard in the south east corner of the north room for a 5 and an 8 gallon jug.");
@@ -313,7 +314,6 @@ public class JugPuzzle extends DetailedOwnerStep
 		goDownToFirstFloor = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33485, new WorldPoint(1382, 3827, 2), "Go down from the top floor.");
 		goDownToGroundFloor = new ObjectStep(getQuestHelper(), ObjectID.STAIRCASE_33552, new WorldPoint(1378, 3825, 1), "Go down to the ground floor.");
 		goUpToGroundFloor = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33484, new WorldPoint(1382, 10229, 0), "Leave the tower's basement.");
-
 	}
 
 	public List<PanelDetails> panelDetails()

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/PotionPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/PotionPuzzle.java
@@ -92,10 +92,6 @@ public class PotionPuzzle extends DetailedOwnerStep
 	public PotionPuzzle(QuestHelper questHelper)
 	{
 		super(questHelper, "");
-		setupItemRequirements();
-		setupZones();
-		setupConditions();
-		setupSteps();
 	}
 
 	@Subscribe
@@ -214,6 +210,10 @@ public class PotionPuzzle extends DetailedOwnerStep
 	@Override
 	protected void setupSteps()
 	{
+		setupItemRequirements();
+		setupZones();
+		setupConditions();
+
 		goUpLadder = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33484, new WorldPoint(1382, 10229, 0), "Leave the tower's basement.");
 		goUpStairs = new ObjectStep(getQuestHelper(), ObjectID.STAIRCASE_33550, new WorldPoint(1378, 3825, 0), "Go to the tower's 1st floor.");
 		goDownToFirstFloor = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33485, new WorldPoint(1382, 3827, 2), "Go down from the top floor.");

--- a/src/main/java/com/questhelper/helpers/quests/theforsakentower/PotionPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theforsakentower/PotionPuzzle.java
@@ -25,7 +25,6 @@
 package com.questhelper.helpers.quests.theforsakentower;
 
 import com.google.inject.Inject;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.QuestHelper;
@@ -33,12 +32,8 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.ZoneRequirement;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.OwnerStep;
-import com.questhelper.steps.PuzzleWrapperStep;
-import com.questhelper.steps.QuestStep;
-import java.awt.Graphics2D;
+import com.questhelper.steps.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,9 +50,8 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public class PotionPuzzle extends QuestStep implements OwnerStep
+public class PotionPuzzle extends DetailedOwnerStep
 {
 	@Inject
 	protected EventBus eventBus;
@@ -104,25 +98,13 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 		setupSteps();
 	}
 
-	@Override
-	public void startUp()
-	{
-		updateSteps();
-	}
-
-	@Override
-	public void shutDown()
-	{
-		shutDownStep();
-		currentStep = null;
-	}
-
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		updateSteps();
 	}
 
+	@Override
 	protected void updateSteps()
 	{
 		if (inBasement.check(client))
@@ -180,71 +162,6 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 		}
 	}
 
-	protected void startUpStep(QuestStep step)
-	{
-		if (currentStep == null)
-		{
-			currentStep = step;
-			eventBus.register(currentStep);
-			currentStep.startUp();
-			return;
-		}
-
-		if (!step.equals(currentStep))
-		{
-			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
-		}
-	}
-
-	protected void shutDownStep()
-	{
-		if (currentStep != null)
-		{
-			eventBus.unregister(currentStep);
-			currentStep.shutDown();
-			currentStep = null;
-		}
-	}
-
-	@Override
-	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, List<String> additionalText, List<Requirement> requirements)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeOverlayHint(panelComponent, plugin, additionalText, requirements);
-		}
-	}
-
-	@Override
-	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldArrowOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldArrowOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldLineOverlayHint(graphics, plugin);
-		}
-	}
-
 	@Override
 	public QuestStep getActiveStep()
 	{
@@ -294,7 +211,8 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 		secondFloor = new Zone(new WorldPoint(1377, 3821, 2), new WorldPoint(1386, 3828, 2));
 	}
 
-	private void setupSteps()
+	@Override
+	protected void setupSteps()
 	{
 		goUpLadder = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33484, new WorldPoint(1382, 10229, 0), "Leave the tower's basement.");
 		goUpStairs = new ObjectStep(getQuestHelper(), ObjectID.STAIRCASE_33550, new WorldPoint(1378, 3825, 0), "Go to the tower's 1st floor.");

--- a/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/LockedChestPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/LockedChestPuzzle.java
@@ -25,7 +25,6 @@
 package com.questhelper.helpers.quests.theheartofdarkness;
 
 import com.google.inject.Inject;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
@@ -40,9 +39,7 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -50,7 +47,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class LockedChestPuzzle extends QuestStep implements OwnerStep {
+public class LockedChestPuzzle extends DetailedOwnerStep
+{
     @Inject
     protected EventBus eventBus;
 
@@ -79,137 +77,88 @@ public class LockedChestPuzzle extends QuestStep implements OwnerStep {
 
     ChestCodeStep solveChest;
 
-    public LockedChestPuzzle(QuestHelper questHelper) {
+    public LockedChestPuzzle(QuestHelper questHelper)
+    {
         super(questHelper, "");
         setupItemRequirements();
-        setupZones();
         setupConditions();
         setupSteps();
     }
 
     @Override
-    public void startUp() {
+    public void startUp()
+    {
         updateSteps();
     }
 
     @Override
-    public void shutDown() {
+    public void shutDown()
+    {
         shutDownStep();
         currentStep = null;
     }
 
     @Subscribe
-    public void onGameTick(GameTick event) {
+    public void onGameTick(GameTick event)
+    {
         updateSteps();
     }
 
-    protected void updateSteps() {
-        if (answer == null) {
+    @Override
+    protected void updateSteps()
+    {
+        if (answer == null)
+        {
             startUpStep(readBook);
-        } else if (inChestInterface.check(client)) {
+        } else if (inChestInterface.check(client))
+        {
             startUpStep(solveChest);
-        } else {
+        } else
+        {
             startUpStep(openChest);
         }
     }
 
-    protected void startUpStep(QuestStep step) {
-        if (currentStep == null) {
-            currentStep = step;
-            eventBus.register(currentStep);
-            currentStep.startUp();
-            return;
-        }
-
-        if (!step.equals(currentStep)) {
-            shutDownStep();
-            eventBus.register(step);
-            step.startUp();
-            currentStep = step;
-        }
-    }
-
-    protected void shutDownStep() {
-        if (currentStep != null) {
-            eventBus.unregister(currentStep);
-            currentStep.shutDown();
-            currentStep = null;
-        }
-    }
-
-    @Override
-    public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, List<String> additionalText, List<Requirement> requirements) {
-        if (currentStep != null) {
-            currentStep.makeOverlayHint(panelComponent, plugin, additionalText, requirements);
-        }
-    }
-
-    @Override
-    public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin) {
-        if (currentStep != null) {
-            currentStep.makeWorldOverlayHint(graphics, plugin);
-        }
-    }
-
-    @Override
-    public void makeWorldArrowOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin) {
-        if (currentStep != null) {
-            currentStep.makeWorldArrowOverlayHint(graphics, plugin);
-        }
-    }
-
-    @Override
-    public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin) {
-        if (currentStep != null) {
-            currentStep.makeWorldLineOverlayHint(graphics, plugin);
-        }
-    }
-
-    @Override
-    public QuestStep getActiveStep() {
-        if (currentStep != this) {
-            return currentStep.getActiveStep();
-        } else {
-            return this;
-        }
-    }
-
-    private void setupItemRequirements() {
+    private void setupItemRequirements()
+    {
         book = new ItemRequirement("Book", ItemID.BOOK_29878);
     }
 
-    private void setupConditions() {
+    private void setupConditions()
+    {
         inChestInterface = new WidgetTextRequirement(809, 5, 9, "Confirm");
     }
 
-    private void setupZones() {
-
-    }
-
-    private void setupSteps() {
+    @Override
+    protected void setupSteps()
+    {
         readBook = new DetailedQuestStep(getQuestHelper(), "Read the book.", book.highlighted());
         openChest = new ObjectStep(getQuestHelper(), ObjectID.CHEST_54376, new WorldPoint(1638, 3217, 1), "Search the south-west chest.");
         solveChest = new ChestCodeStep(getQuestHelper(), 10);
     }
 
     @Override
-    public Collection<QuestStep> getSteps() {
+    public Collection<QuestStep> getSteps()
+    {
         return Arrays.asList(readBook, openChest, solveChest);
     }
 
     int[] rotationPosOfAnswer = new int[4];
 
     @Subscribe
-    public void onWidgetLoaded(WidgetLoaded widgetLoaded) {
+    public void onWidgetLoaded(WidgetLoaded widgetLoaded)
+    {
         if (answer != null) return;
 
         int GROUP_ID = 392;
         List<String> tmpChars = new ArrayList<>();
         int firstLineChildId = 43;
         int maxChildId = 74;
-        if (widgetLoaded.getGroupId() == GROUP_ID) {
+        if (widgetLoaded.getGroupId() == GROUP_ID)
+        {
             Widget line;
-            for (int i = 0; i <= maxChildId - firstLineChildId; i++) {
+            for (int i = 0; i <= maxChildId - firstLineChildId; i++)
+            {
                 line = client.getWidget(GROUP_ID, firstLineChildId + i);
                 if (line == null) break;
                 Matcher matcher = WHITE_TEXT.matcher(line.getText());
@@ -220,9 +169,11 @@ public class LockedChestPuzzle extends QuestStep implements OwnerStep {
             }
         }
 
-        if (tmpChars.size() == 4) {
+        if (tmpChars.size() == 4)
+        {
             answer = "";
-            for (String tmpChar : tmpChars) {
+            for (String tmpChar : tmpChars)
+            {
                 answer += tmpChar;
             }
 
@@ -238,7 +189,7 @@ public class LockedChestPuzzle extends QuestStep implements OwnerStep {
 
     private int getPosForLetter(String letter, String[] rotationLetters)
     {
-        for (int i=0; i < rotationLetters.length; i++)
+        for (int i = 0; i < rotationLetters.length; i++)
         {
             if (rotationLetters[i].equals(letter))
             {

--- a/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/LockedChestPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/LockedChestPuzzle.java
@@ -80,9 +80,6 @@ public class LockedChestPuzzle extends DetailedOwnerStep
     public LockedChestPuzzle(QuestHelper questHelper)
     {
         super(questHelper, "");
-        setupItemRequirements();
-        setupConditions();
-        setupSteps();
     }
 
     @Override
@@ -132,6 +129,9 @@ public class LockedChestPuzzle extends DetailedOwnerStep
     @Override
     protected void setupSteps()
     {
+        setupItemRequirements();
+        setupConditions();
+
         readBook = new DetailedQuestStep(getQuestHelper(), "Read the book.", book.highlighted());
         openChest = new ObjectStep(getQuestHelper(), ObjectID.CHEST_54376, new WorldPoint(1638, 3217, 1), "Search the south-west chest.");
         solveChest = new ChestCodeStep(getQuestHelper(), 10);

--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WeightStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WeightStep.java
@@ -25,17 +25,12 @@
 package com.questhelper.helpers.quests.whileguthixsleeps;
 
 import com.google.inject.Inject;
-import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
-import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.OwnerStep;
-import com.questhelper.steps.QuestStep;
-import java.awt.Graphics2D;
+import com.questhelper.steps.*;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -50,9 +45,8 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public class WeightStep extends QuestStep implements OwnerStep
+public class WeightStep extends DetailedOwnerStep
 {
 	@Inject
 	protected EventBus eventBus;
@@ -75,25 +69,13 @@ public class WeightStep extends QuestStep implements OwnerStep
 		setupSteps();
 	}
 
-	@Override
-	public void startUp()
-	{
-		updateSteps();
-	}
-
-	@Override
-	public void shutDown()
-	{
-		shutDownStep();
-		currentStep = null;
-	}
-
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		updateSteps();
 	}
 
+	@Override
 	protected void updateSteps()
 	{
 		int goal = client.getVarbitValue(10936);
@@ -205,71 +187,6 @@ public class WeightStep extends QuestStep implements OwnerStep
 		// 10937 = total weight on statue
 	}
 
-	protected void startUpStep(QuestStep step)
-	{
-		if (currentStep == null)
-		{
-			currentStep = step;
-			eventBus.register(currentStep);
-			currentStep.startUp();
-			return;
-		}
-
-		if (!step.equals(currentStep))
-		{
-			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
-		}
-	}
-
-	protected void shutDownStep()
-	{
-		if (currentStep != null)
-		{
-			eventBus.unregister(currentStep);
-			currentStep.shutDown();
-			currentStep = null;
-		}
-	}
-
-	@Override
-	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, List<String> additionalText, List<Requirement> requirements)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeOverlayHint(panelComponent, plugin, additionalText, requirements);
-		}
-	}
-
-	@Override
-	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldArrowOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldArrowOverlayHint(graphics, plugin);
-		}
-	}
-
-	@Override
-	public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-		if (currentStep != null)
-		{
-			currentStep.makeWorldLineOverlayHint(graphics, plugin);
-		}
-	}
-
 	@Override
 	public QuestStep getActiveStep()
 	{
@@ -293,7 +210,8 @@ public class WeightStep extends QuestStep implements OwnerStep
 		weights.addAlternates(ItemID.WEIGHT_2KG, ItemID.WEIGHT_5KG);
 	}
 
-	private void setupSteps()
+	@Override
+	protected void setupSteps()
 	{
 		weightRoom = new Zone(new WorldPoint(4177, 4944, 1), new WorldPoint(4181, 4946, 1));
 		inWeightRoom = new ZoneRequirement(weightRoom);

--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WeightStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WeightStep.java
@@ -76,8 +76,6 @@ public class WeightStep extends DetailedOwnerStep
 	@Override
 	protected void updateSteps()
 	{
-		setupItemRequirements();
-
 		int goal = client.getVarbitValue(10936);
 		int weightOnStatue = client.getVarbitValue(10937);
 		int totalWeightGoal = goal + weightOnStatue;

--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WeightStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WeightStep.java
@@ -65,8 +65,6 @@ public class WeightStep extends DetailedOwnerStep
 	public WeightStep(QuestHelper questHelper)
 	{
 		super(questHelper, "");
-		setupItemRequirements();
-		setupSteps();
 	}
 
 	@Subscribe
@@ -78,6 +76,8 @@ public class WeightStep extends DetailedOwnerStep
 	@Override
 	protected void updateSteps()
 	{
+		setupItemRequirements();
+
 		int goal = client.getVarbitValue(10936);
 		int weightOnStatue = client.getVarbitValue(10937);
 		int totalWeightGoal = goal + weightOnStatue;
@@ -213,6 +213,8 @@ public class WeightStep extends DetailedOwnerStep
 	@Override
 	protected void setupSteps()
 	{
+		setupItemRequirements();
+		
 		weightRoom = new Zone(new WorldPoint(4177, 4944, 1), new WorldPoint(4181, 4946, 1));
 		inWeightRoom = new ZoneRequirement(weightRoom);
 

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -292,7 +292,7 @@ public class QuestManager
 				questHelperPlugin.displayPanel();
 			}
 			selectedQuest = questHelper;
-			eventBus.register(selectedQuest);
+			registerQuestToEventBus(selectedQuest);
 			if (isDeveloperMode())
 			{
 				selectedQuest.debugStartup(config);
@@ -331,7 +331,7 @@ public class QuestManager
 			selectedQuest.shutDown();
 			questBankManager.shutDownQuest();
 			SwingUtilities.invokeLater(panel::removeQuest);
-			eventBus.unregister(selectedQuest);
+			unregisterQuestFromEventBus(selectedQuest);
 
 			// If closing the item checking helper and should still check in background, start it back up in background
 			if (selectedQuest.getQuest() == QuestHelperQuest.CHECK_ITEMS && config.highlightItemsBackground())
@@ -369,7 +369,7 @@ public class QuestManager
 			}
 			questBankManager.shutDownQuest();
 			SwingUtilities.invokeLater(panel::removeQuest);
-			eventBus.unregister(selectedQuest);
+			unregisterQuestFromEventBus(selectedQuest);
 			selectedQuest = null;
 		}
 	}
@@ -422,18 +422,28 @@ public class QuestManager
 		clientThread.invokeLater(() -> {
 			if (!questHelper.isCompleted())
 			{
-				eventBus.register(questHelper);
+				registerQuestToEventBus(questHelper);
 				questHelper.startUp(config);
 				backgroundHelpers.put(questHelperName, questHelper);
 				if (questHelper.getCurrentStep() == null)
 				{
 					questHelper.shutDown();
-					eventBus.unregister(questHelper);
+					unregisterQuestFromEventBus(questHelper);
 					backgroundHelpers.remove(questHelperName);
 				}
 
 			}
 		});
+	}
+
+	private void registerQuestToEventBus(QuestHelper questHelper)
+	{
+		eventBus.register(questHelper);
+	}
+
+	private void unregisterQuestFromEventBus(QuestHelper questHelper)
+	{
+		eventBus.unregister(questHelper);
 	}
 
 	/**
@@ -460,7 +470,7 @@ public class QuestManager
 		}
 
 		questHelper.shutDown();
-		eventBus.unregister(questHelper);
+		unregisterQuestFromEventBus(questHelper);
 		backgroundHelpers.remove(questHelper.getQuest().getName());
 
 	}

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -182,7 +182,6 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	@Override
 	public void startUp()
 	{
-
 		steps.keySet().stream()
 			.filter(InitializableRequirement.class::isInstance)
 			.forEach(req -> ((InitializableRequirement) req).initialize(client));
@@ -333,21 +332,16 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 
 	protected void startUpStep(QuestStep step)
 	{
-		if (currentStep == null)
-		{
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
-			return;
-		}
+		if (step.equals(currentStep)) return;
 
-		if (!step.equals(currentStep))
+		if (currentStep != null)
 		{
 			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
 		}
+
+		eventBus.register(step);
+		step.startUp();
+		currentStep = step;
 	}
 
 	protected void shutDownStep()

--- a/src/main/java/com/questhelper/steps/DetailedOwnerStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedOwnerStep.java
@@ -83,21 +83,16 @@ public class DetailedOwnerStep extends QuestStep implements OwnerStep
 
 	protected void startUpStep(QuestStep step)
 	{
-		if (currentStep == null)
-		{
-			currentStep = step;
-			eventBus.register(currentStep);
-			currentStep.startUp();
-			return;
-		}
+		if (step.equals(currentStep)) return;
 
-		if (!step.equals(currentStep))
+		if (currentStep != null)
 		{
 			shutDownStep();
-			eventBus.register(step);
-			step.startUp();
-			currentStep = step;
 		}
+
+		eventBus.register(step);
+		step.startUp();
+		currentStep = step;
 	}
 
 	protected void shutDownStep()
@@ -177,7 +172,6 @@ public class DetailedOwnerStep extends QuestStep implements OwnerStep
 			return this;
 		}
 	}
-
 
 	protected void setupSteps()
 	{


### PR DESCRIPTION
A few helpers made direct use of the OwnerStep, when they were better suited to make use of the DetailedOwnerStep which implements much of the boilerplate already.

This shifts those steps to DetailedOwnerStep.