### PR TITLE
Varlamore Part 2 Quest Cleanup

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deathontheisle/DeathOnTheIsle.java
+++ b/src/main/java/com/questhelper/helpers/quests/deathontheisle/DeathOnTheIsle.java
@@ -510,7 +510,6 @@ public class DeathOnTheIsle extends BasicQuestHelper
 		talkToGuardsAgainToTellThemYouAreReadyStep.addStep(not(inVilla), returnToButlerAndHeadInside);
 
 		/// 28 + 30
-		// TODO: what happens if you accuse the wrong person?
 		interrogateConstantiniusAgain = new NpcStep(this, NpcID.CONSTANTINIUS, new WorldPoint(1446, 2931, 2), "Interrogate Constantinius.");
 		interrogateConstantiniusAgain.addDialogStep("No.");
 		interrogateXocotlaAgain = new NpcStep(this, NpcID.XOCOTLA, new WorldPoint(1444, 2928, 2), "Interrogate Xocotla.");
@@ -529,7 +528,6 @@ public class DeathOnTheIsle extends BasicQuestHelper
 		accuseAdala = new NpcStep(this, NpcID.ADALA, new WorldPoint(1446, 2933, 2), "Accuse Adala of the crime, ready for a fight you cannot lose.");
 		accuseAdala.addDialogStep("Accuse Adala.");
 
-		// TODO: helper steps to climb upstairs?
 		speakToSuspects = new ConditionalStep(this, accuseAdala);
 		speakToSuspects.addStep(not(inVilla), returnToButlerAndHeadInside);
 		speakToSuspects.addStep(not(interrogatedConstantiniusAgain), interrogateConstantiniusAgain);
@@ -539,18 +537,15 @@ public class DeathOnTheIsle extends BasicQuestHelper
 
 		/// 32
 		getAdalasConfession = new NpcStep(this, NpcID.ADALA_13821, new WorldPoint(1446, 2933, 2), "Talk to Adala to get her confession.");
-		// TODO: helper steps to climb upstairs?
 		getAdalasConfessionStep = new ConditionalStep(this, getAdalasConfession);
 		getAdalasConfessionStep.addStep(not(inVilla), returnToButlerAndHeadInside);
 
 		/// 33
 		talkToGuardsAboutAdala = new NpcStep(this, NpcID.STRADIUS, new WorldPoint(1442, 2933, 2), "Talk to the guards about Adala.");
-		// TODO: helper step to climb upstairs?
 		talkToGuardsAboutAdalaStep = new ConditionalStep(this, talkToGuardsAboutAdala);
 		talkToGuardsAboutAdalaStep.addStep(not(inVilla), returnToButlerAndHeadInside);
 
 		/// 34
-		// NOTE: The stairs don't highlight well. A tile step would be better, but tile steps don't work here.
 		var headDownFromTopFloor = new ObjectStep(this, ObjectID.STAIRCASE_54714, new WorldPoint(1445, 2939, 2), "Climb down the staircase.");
 		var headDownFromMiddleFloor = new ObjectStep(this, ObjectID.STAIRCASE_54714, new WorldPoint(1442, 2936, 1), "Climb down the staircase.");
 		var climbFirstLooseRocksToTheatre = new ObjectStep(this, ObjectID.LOOSE_ROCKS_54720, new WorldPoint(1469, 2918, 0), "Climb the Loose rocks south-east of the villa on your way to the theatre.");

--- a/src/main/java/com/questhelper/helpers/quests/ethicallyacquiredantiquities/EthicallyAcquiredAntiquities.java
+++ b/src/main/java/com/questhelper/helpers/quests/ethicallyacquiredantiquities/EthicallyAcquiredAntiquities.java
@@ -40,11 +40,7 @@ import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -68,7 +64,9 @@ public class EthicallyAcquiredAntiquities extends BasicQuestHelper
 
 	QuestStep talkToCuratorHerminius, investigateToolsBehindDisplayCase, investigateCaseAgain, talkToCitizen, talkToAcademic,
 			talkToTourist, talkToRegulus, talkToCrewmember, talkToArtima, returnToCrewmember, talkToTraderStan, talkToBetty, readBettysNotes,
-			pickpocketCuratorHaig, searchStoreroomCrate, talkToCuratorBeforeShaming, shameCuratorHaigHalen, talkToCuratorBeforeCutscene, watchCutscene;
+			pickpocketCuratorHaig, searchStoreroomCrate, talkToCuratorBeforeShaming, talkToCuratorBeforeCutscene, watchCutscene;
+
+	PuzzleWrapperStep shameCuratorHaigHalen;
 
 	DetailedQuestStep inspectEmptyDisplayCase, talkToCuratorHaigHalen, returnToCuratorHerminius;
 
@@ -205,9 +203,9 @@ public class EthicallyAcquiredAntiquities extends BasicQuestHelper
 				"search the crate.");
 		talkToCuratorBeforeShaming = new NpcStep(this, NpcID.CURATOR_HAIG_HALEN, new WorldPoint(3257, 3449, 0), "Go speak to Curator Haig Halen again.");
 		talkToCuratorBeforeShaming.addDialogStep("I found Xerna's Diadem...");
-		shameCuratorHaigHalen = new NpcStep(this, NpcID.CURATOR_HAIG_HALEN, new WorldPoint(3257, 3449, 0), "Shame Curator Haig Halen, get the meter to 100%.");
-		shameCuratorHaigHalen.addDialogStep("I found Xerna's Diadem...");
-		shameCuratorHaigHalen.addDialogSteps("Aren't you embarrassed to have stolen items in your collection?",
+		shameCuratorHaigHalen = new NpcStep(this, NpcID.CURATOR_HAIG_HALEN, new WorldPoint(3257, 3449, 0), "Shame Curator Haig Halen, get the meter to 100%.")
+				.addDialogStep("I found Xerna's Diadem...")
+				.addDialogSteps("Aren't you embarrassed to have stolen items in your collection?",
 				"Are you even a real historian, or just a petty criminal?", "Did you know Varlamore sends thieves to the Colosseum?",
 				"How will Varlamorians learn their history now?", "You're supposed to protect history, not steal it!",
 				"You're setting a terrible example", "You've betrayed the trust of Varlamore.", "You're not above the law! You stole this stuff!",
@@ -223,7 +221,8 @@ public class EthicallyAcquiredAntiquities extends BasicQuestHelper
 						"back already!",
 				"Think of the Varlamorian children who won't get to see this artefact.", "You should give Varlamore a chance before stealing their stuff.",
 				"This is stealing! Thieving! Taking what's not yours!", "I thought archaeology was cool. I didn't realise it was just thieving!",
-				"How would you feel if someone came in here and stole all your stuff?", "You're hoarding artefacts, but you should be sharing them!");
+				"How would you feel if someone came in here and stole all your stuff?", "You're hoarding artefacts, but you should be sharing them!")
+				.puzzleWrapStep("Work out how to shame Curator Haig Halen, get the meter to 100%.");
 		talkToCuratorBeforeCutscene = new NpcStep(this, NpcID.CURATOR_HAIG_HALEN, new WorldPoint(3257, 3449, 0), "Speak to Curator before a cutscene.");
 		watchCutscene = new NpcStep(this, NpcID.CURATOR_HAIG_HALEN, new WorldPoint(3257, 3449, 0), "Watch cutscene.");
 		returnToCuratorHerminius = new NpcStep(this, NpcID.CURATOR_HERMINIUS, new WorldPoint(1712, 3163, 0), "Speak to the Curator in the centre of the Grand " +

--- a/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/LockedChestPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/LockedChestPuzzle.java
@@ -71,12 +71,13 @@ public class LockedChestPuzzle extends DetailedOwnerStep
     final String[] letter3 = new String[]{"W", "E", "R", "I", "L", "A", "N", "U", "T", "O"};
     final String[] letter4 = new String[]{"E", "I", "D", "A", "O", "W", "K", "N", "R", "U"};
 
-    DetailedQuestStep readBook;
+    PuzzleWrapperStep readBook;
 
-    ObjectStep openChest;
+    PuzzleWrapperStep openChest;
 
     ChestCodeStep solveChest;
 
+    PuzzleWrapperStep solveChestPuzzleWrapped;
     public LockedChestPuzzle(QuestHelper questHelper)
     {
         super(questHelper, "");
@@ -129,18 +130,23 @@ public class LockedChestPuzzle extends DetailedOwnerStep
     @Override
     protected void setupSteps()
     {
-        setupItemRequirements();
-        setupConditions();
+		setupItemRequirements();
+		setupConditions();
 
-        readBook = new DetailedQuestStep(getQuestHelper(), "Read the book.", book.highlighted());
-        openChest = new ObjectStep(getQuestHelper(), ObjectID.CHEST_54376, new WorldPoint(1638, 3217, 1), "Search the south-west chest.");
+        readBook = new DetailedQuestStep(getQuestHelper(), "Read the book.", book.highlighted())
+                .puzzleWrapStep()
+                .withNoHelpHiddenInSidebar(true);
+        openChest = new ObjectStep(getQuestHelper(), ObjectID.CHEST_54376, new WorldPoint(1638, 3217, 1), "Search the south-west chest.")
+                .puzzleWrapStep()
+                .withNoHelpHiddenInSidebar(true);
         solveChest = new ChestCodeStep(getQuestHelper(), 10);
+        solveChestPuzzleWrapped = solveChest.puzzleWrapStep().withNoHelpHiddenInSidebar(true);
     }
 
     @Override
     public Collection<QuestStep> getSteps()
     {
-        return Arrays.asList(readBook, openChest, solveChest);
+        return Arrays.asList(readBook, openChest, solveChestPuzzleWrapped);
     }
 
     int[] rotationPosOfAnswer = new int[4];

--- a/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/TheHeartOfDarkness.java
+++ b/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/TheHeartOfDarkness.java
@@ -119,8 +119,10 @@ public class TheHeartOfDarkness extends BasicQuestHelper
     DetailedQuestStep talkToJanusAfterTrial;
 
     DetailedQuestStep talkToPrinceToStartThirdTrial;
-    NpcStep talkToTenoch, talkToSilia, talkToAdrius, talkToEleuia, accuseTenoch, accuseSilia, accuseEleuia;
+    PuzzleWrapperStep talkToTenoch, talkToSilia, talkToAdrius, talkToEleuia, accuseTenoch, accuseSilia, accuseEleuia;
     DetailedQuestStep accuseGuiltyIndividual;
+
+    PuzzleWrapperStep accuseGuiltyIndividualPuzzleWrapped;
 
     DetailedQuestStep goUpToFinalTrial, fightPrince, fightPrinceSidebar, talkToJanusAfterPrinceFight, talkToJanusAfterAllTrials, searchChestForEmissaryRobes, talkToItzlaToFollow,
             enterTemple, talkToItzlaAfterSermon, talkToFides, enterRuins;
@@ -708,22 +710,47 @@ public class TheHeartOfDarkness extends BasicQuestHelper
 
         // Third trial section
         talkToPrinceToStartThirdTrial = new NpcStep(this, NpcID.PRINCE_ITZLA_ARKAN_13770, new WorldPoint(1638, 3218, 2), "Talk to the prince in the room.");
-        talkToTenoch = new NpcStep(this, NpcID.TENOCH, new WorldPoint(1643, 3225, 2), "Talk to Tenoch.");
-        talkToTenoch.addDialogSteps("Interrogate Tenoch.", "Tell me about the Final Dawn.");
-        talkToSilia = new NpcStep(this, NpcID.SILIA, new WorldPoint(1645, 3223, 2), "Talk to Silia.");
-        talkToSilia.addDialogSteps("Interrogate Silia.", "Tell me about the Final Dawn.");
-        talkToAdrius = new NpcStep(this, NpcID.ADRIUS, new WorldPoint(1645, 3220, 2), "Talk to Adrius.");
-        talkToAdrius.addDialogSteps("Interrogate Adrius.", "Tell me about the Final Dawn.");
-        talkToEleuia = new NpcStep(this, NpcID.ELEUIA, new WorldPoint(1643, 3218, 2), "Talk to Eleuia.");
-        talkToEleuia.addDialogSteps("Interrogate Eleuia.", "Tell me about the Final Dawn.");
-        accuseTenoch = new NpcStep(this, NpcID.TENOCH, new WorldPoint(1643, 3225, 2), "Accuse Tenoch.");
-        accuseTenoch.addDialogSteps("Yes.", "Choose Tenoch.");
-        accuseSilia = new NpcStep(this, NpcID.SILIA, new WorldPoint(1645, 3223, 2), "Accuse Silia.");
-        accuseSilia.addDialogSteps("Yes.", "Choose Silia.");
-        accuseEleuia = new NpcStep(this, NpcID.ELEUIA, new WorldPoint(1643, 3218, 2), "Accuse Eleuia.");
-        accuseEleuia.addDialogSteps("Yes.", "Choose Eleuia.");
+
+        talkToTenoch = new NpcStep(this, NpcID.TENOCH, new WorldPoint(1643, 3225, 2), "Talk to Tenoch.")
+                .addDialogSteps("Interrogate Tenoch.", "Tell me about the Final Dawn.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
+        talkToSilia = new NpcStep(this, NpcID.SILIA, new WorldPoint(1645, 3223, 2), "Talk to Silia.")
+                .addDialogSteps("Interrogate Silia.", "Tell me about the Final Dawn.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
+        talkToAdrius = new NpcStep(this, NpcID.ADRIUS, new WorldPoint(1645, 3220, 2), "Talk to Adrius.")
+                .addDialogSteps("Interrogate Adrius.", "Tell me about the Final Dawn.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
+        talkToEleuia = new NpcStep(this, NpcID.ELEUIA, new WorldPoint(1643, 3218, 2), "Talk to Eleuia.")
+                .addDialogSteps("Interrogate Eleuia.", "Tell me about the Final Dawn.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
+        accuseTenoch = new NpcStep(this, NpcID.TENOCH, new WorldPoint(1643, 3225, 2), "Accuse Tenoch.")
+                .addDialogSteps("Yes.", "Choose Tenoch.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
+        accuseSilia = new NpcStep(this, NpcID.SILIA, new WorldPoint(1645, 3223, 2), "Accuse Silia.")
+                .addDialogSteps("Yes.", "Choose Silia.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
+        accuseEleuia = new NpcStep(this, NpcID.ELEUIA, new WorldPoint(1643, 3218, 2), "Accuse Eleuia.")
+                .addDialogSteps("Yes.", "Choose Eleuia.")
+                .puzzleWrapStep("Work out who the guilty emissary is.")
+                .withNoHelpHiddenInSidebar(true);
+
         accuseGuiltyIndividual = new DetailedQuestStep(this, "Accuse the guilty individual.");
         accuseGuiltyIndividual.addSubSteps(accuseTenoch, accuseSilia, accuseEleuia);
+        accuseGuiltyIndividualPuzzleWrapped = accuseGuiltyIndividual
+                .puzzleWrapStep("Work out who the guilty emissary is.");
+        accuseGuiltyIndividualPuzzleWrapped.addSubSteps(talkToTenoch, talkToSilia, talkToAdrius, talkToEleuia, accuseTenoch, accuseSilia, accuseEleuia);
 
         goUpToFinalTrial = new NpcStep(this, NpcID.FOREBEARER_JANUS_13766, new WorldPoint(1640, 3226, 2), "Talk to Janus to go to the final trial, ready for " +
                 "a fight.");
@@ -1081,7 +1108,7 @@ public class TheHeartOfDarkness extends BasicQuestHelper
 
         allSteps.add(new PanelDetails("Second Trial", List.of(startCombatTrial, completeCombatTrial, talkToJanusAfterTrial), List.of(combatGear)));
         allSteps.add(new PanelDetails("Third Trial", List.of(talkToPrinceToStartThirdTrial, talkToTenoch, talkToSilia, talkToAdrius, talkToEleuia,
-                accuseGuiltyIndividual, goUpToFinalTrial)));
+                accuseGuiltyIndividualPuzzleWrapped, goUpToFinalTrial)));
         allSteps.add(new PanelDetails("Final Trial", List.of(fightPrinceSidebar, talkToJanusAfterPrinceFight)));
         allSteps.add(new PanelDetails("Cult", List.of(talkToJanusAfterAllTrials, searchChestForEmissaryRobes, talkToItzlaToFollow, enterTemple, talkToItzlaAfterSermon, talkToFides)));
         allSteps.add(new PanelDetails("The Old Ones", List.of(enterRuins, takePickaxe, mineRocks, pullFirstLever, climbDownLedge, slideAlongIceLedge, pullSecondLever, jumpOverFrozenPlatforms, pullThirdLever,

--- a/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/TheHeartOfDarkness.java
+++ b/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/TheHeartOfDarkness.java
@@ -98,8 +98,6 @@ public class TheHeartOfDarkness extends BasicQuestHelper
             inFirstIceRoom, inSecondIceAreaFirstRoom, inSecondIceAreaSecondRoom, inThirdIceArea, pulledFirstLever, pulledSecondLever, pulledThirdLever,
             unlockedShortcut, inBossRoom;
 
-    ObjectStep activateSecondStatue, activateFirstStatue, activateThirdStatue, activateFourthStatue;
-
     Zone teomat, firstTrialRoom, secondTrialRoom, firstIceRoom, secondIceAreaFirstRoom, secondIceAreaSecondRoom, thirdIceArea, bossRoom;
 
     DetailedQuestStep talkToItzlaAtTeomat,travelToGorge, talkToBartender, restOnBed, talkToPrinceAfterRest, talkToShopkeeper, talkToPrinceInPubAgain,
@@ -143,8 +141,9 @@ public class TheHeartOfDarkness extends BasicQuestHelper
     DetailedQuestStep pullChain;
     ObjectStep climbDownIceShortcut;
 
-    DetailedQuestStep searchAirUrn, searchEarthUrn, searchWaterUrn, searchFireUrn, fixAirStatue, fixWaterStatue, fixEarthStatue, fixFireStatue,
+    PuzzleWrapperStep searchAirUrn, searchEarthUrn, searchWaterUrn, searchFireUrn, fixAirStatue, fixWaterStatue, fixEarthStatue, fixFireStatue,
             inspectAirMarkings, inspectWaterMarkings, inspectEarthMarkings, inspectFireMarkings;
+    PuzzleWrapperStep activateSecondStatue, activateFirstStatue, activateThirdStatue, activateFourthStatue;
 
     DetailedQuestStep enterFinalBossRoom;
 
@@ -337,7 +336,7 @@ public class TheHeartOfDarkness extends BasicQuestHelper
         goToIcePuzzle.addStep(and(inThirdIceArea, unlockedShortcut), puzzleStep);
         goToIcePuzzle.addStep(inThirdIceArea, pullChain);
         goToIcePuzzle.addStep(inSecondIceAreaSecondRoom, jumpOverFrozenPlatforms);
-        goToIcePuzzle.addStep(inSecondIceAreaFirstRoom, climbUpLedgeToFirstLever);
+        goToIcePuzzle.addStep(inSecondIceAreaFirstRoom, slideAlongIceLedge);
         goToIcePuzzle.addStep(and(inFirstIceRoom, unlockedShortcut), climbDownIceShortcut);
         goToIcePuzzle.addStep(inFirstIceRoom, climbDownLedge);
         steps.put(64, goToIcePuzzle);
@@ -863,51 +862,94 @@ public class TheHeartOfDarkness extends BasicQuestHelper
                 "entrance.");
 
         searchAirUrn = new ObjectStep(this, NullObjectID.NULL_55358, new WorldPoint(1647, 9622, 0), "Search the urn with an air symbol on it near to the " +
-                "earth markings in the south-east of the area.");
+                "earth markings in the south-east of the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         searchEarthUrn = new ObjectStep(this, NullObjectID.NULL_55359, new WorldPoint(1652, 9622, 0), "Search the urn with an earth symbol on it near to the " +
-                "earth markings in the south-east of the area.");
+                "earth markings in the south-east of the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         searchWaterUrn = new ObjectStep(this, NullObjectID.NULL_55357, new WorldPoint(1610, 9622, 0), "Search the urn with an water symbol on it near to the " +
-                "water markings in the south-west of the area.");
+                "water markings in the south-west of the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         searchFireUrn = new ObjectStep(this, NullObjectID.NULL_55356, new WorldPoint(1615, 9622, 0), "Search the urn with an fire symbol on it near to the " +
-                "water markings in the south-west of the area.");
+                "water markings in the south-west of the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         fixAirStatue = new ObjectStep(this, NullObjectID.NULL_54471, new WorldPoint(1608, 9638, 0), "Fix the broken air statue in the west of the area.",
-                airIcon.highlighted());
-        fixAirStatue.addDialogStep("Yes.");
-        fixAirStatue.addIcon(ItemID.ICON_29887);
+                airIcon.highlighted())
+                .addDialogStep("Yes.")
+                .addIcon(ItemID.ICON_29887)
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         fixWaterStatue = new ObjectStep(this, NullObjectID.NULL_54465, new WorldPoint(1608, 9624, 0), "Fix the broken water statue in the west of the area.",
-                waterIcon.highlighted());
-        fixWaterStatue.addDialogStep("Yes.");
-        fixWaterStatue.addIcon(ItemID.ICON_29888);
+                waterIcon.highlighted())
+                .addDialogStep("Yes.")
+                .addIcon(ItemID.ICON_29888)
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
+
         fixEarthStatue = new ObjectStep(this, NullObjectID.NULL_54477, new WorldPoint(1605, 9635, 0), "Fix the broken earth statue in the west of the area.",
-                earthIcon.highlighted());
-        fixEarthStatue.addDialogStep("Yes.");
-        fixEarthStatue.addIcon(ItemID.ICON_29886);
+                earthIcon.highlighted())
+                .addDialogStep("Yes.")
+                .addIcon(ItemID.ICON_29886)
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         fixFireStatue = new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1605, 9627, 0), "Fix the broken fire statue in the west of the area.",
-                fireIcon.highlighted());
-        fixFireStatue.addDialogStep("Yes.");
-        fixFireStatue.addIcon(ItemID.ICON);
+                fireIcon.highlighted())
+                .addDialogStep("Yes.")
+                .addIcon(ItemID.ICON)
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
 
         inspectAirMarkings = new ObjectStep(this, NullObjectID.NULL_55363, new WorldPoint(1650, 9642, 0), "Inspect the air markings in the north-east of " +
-                "the area.");
+                "the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         inspectWaterMarkings = new ObjectStep(this, NullObjectID.NULL_55362, new WorldPoint(1613, 9621, 0), "Inspect the water markings in the south-west of " +
-                "the area.");
+                "the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         inspectEarthMarkings = new ObjectStep(this, NullObjectID.NULL_55364, new WorldPoint(1650, 9621, 0), "Inspect the earth markings in the south-east of " +
-                "the area.");
+                "the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
         inspectFireMarkings = new ObjectStep(this, NullObjectID.NULL_55361, new WorldPoint(1613, 9642, 0), "Inspect the fire markings in the north-west of " +
-                "the area.");
+                "the area.")
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
 
-        activateFirstStatue = new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the first statue in the order.");
-        activateFirstStatue.addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
-        activateSecondStatue = new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the second statue in the order.");
-        activateSecondStatue.addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
-        activateThirdStatue = new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the third statue in the order.");
-        activateThirdStatue.addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
-        activateFourthStatue = new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the fourth statue in the order.");
-        activateFourthStatue.addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
-        statueActivateSteps[0] = activateFirstStatue;
-        statueActivateSteps[1] = activateSecondStatue;
-        statueActivateSteps[2] = activateThirdStatue;
-        statueActivateSteps[3] = activateFourthStatue;
+        ObjectStep firstStatueStep = (ObjectStep) new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the first statue in the order.")
+                .addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
+        activateFirstStatue = firstStatueStep
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
+
+        ObjectStep secondStatueStep = (ObjectStep) new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the second statue in the order.")
+                .addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
+        activateSecondStatue = secondStatueStep
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
+
+        ObjectStep thirdStatueStep = (ObjectStep) new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the third statue in the order.")
+                .addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
+        activateThirdStatue = thirdStatueStep
+                .puzzleWrapStep("Work out how to open the door to the far west.")
+                .withNoHelpHiddenInSidebar(true);
+        ObjectStep fourthStatueStep = (ObjectStep) new ObjectStep(this, NullObjectID.NULL_54459, new WorldPoint(1650, 9642, 0), "Activate the fourth statue in the order.")
+                .addAlternateObjects(NullObjectID.NULL_54465, NullObjectID.NULL_54471, NullObjectID.NULL_54477);
+        activateFourthStatue = fourthStatueStep
+                .puzzleWrapStep("Work out how to open the door to the far west.");
+
+        activateFourthStatue.addSubSteps(searchAirUrn, searchEarthUrn, searchWaterUrn, searchFireUrn, fixAirStatue, fixWaterStatue, fixEarthStatue, fixFireStatue,
+                inspectAirMarkings, inspectWaterMarkings, inspectEarthMarkings, inspectFireMarkings, activateSecondStatue, activateFirstStatue,
+                activateThirdStatue);
+
+        statueActivateSteps[0] = firstStatueStep;
+        statueActivateSteps[1] = secondStatueStep;
+        statueActivateSteps[2] = thirdStatueStep;
+        statueActivateSteps[3] = fourthStatueStep;
 
         enterFinalBossRoom = new ObjectStep(this, NullObjectID.NULL_55355, new WorldPoint(1601, 9631, 0), "Enter the door to the west, ready for the boss.");
 

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -61,13 +61,15 @@ public class QuestStepPanel extends JPanel
 	private final HashMap<QuestStep, JTextPane> steps = new HashMap<>();
 	private final @Nullable QuestRequirementsPanel requiredItemsPanel;
 	private final @Nullable QuestRequirementsPanel recommendedItemsPanel;
-	private QuestStep currentlyHighlighted = null;
 	private boolean stepAutoLocked;
+	private final QuestHelper questHelper;
+	private QuestStep lastHighlightedStep = null;
 
 	public QuestStepPanel(PanelDetails panelDetails, QuestStep currentStep, QuestManager questManager, QuestHelperPlugin questHelperPlugin)
 	{
 		this.panelDetails = panelDetails;
 		this.questHelperPlugin = questHelperPlugin;
+		this.questHelper = questManager.getSelectedQuest();
 
 		setLayout(new BorderLayout(0, 1));
 		setBorder(new EmptyBorder(5, 0, 0, 0));
@@ -184,7 +186,7 @@ public class QuestStepPanel extends JPanel
 			{
 				if (!first)
 				{
-					text.append("\n");
+					text.append("\n\n");
 				}
 				text.append(line);
 				first = false;
@@ -245,9 +247,9 @@ public class QuestStepPanel extends JPanel
 	{
 		expand();
 
-		if (currentlyHighlighted != null && steps.get(currentlyHighlighted) != null)
+		if (steps.get(lastHighlightedStep) != null)
 		{
-			steps.get(currentlyHighlighted).setForeground(Color.LIGHT_GRAY);
+			steps.get(lastHighlightedStep).setForeground(Color.LIGHT_GRAY);
 		}
 		else
 		{
@@ -261,27 +263,25 @@ public class QuestStepPanel extends JPanel
 		{
 			steps.get(currentStep).setForeground(ColorScheme.BRAND_ORANGE);
 		}
-		currentlyHighlighted = currentStep;
+
+		lastHighlightedStep = currentStep;
 	}
 
 	public void removeHighlight()
 	{
-		if (currentlyHighlighted != null)
+		headerLabel.setForeground(Color.WHITE);
+		if (isCollapsed())
 		{
-			headerLabel.setForeground(Color.WHITE);
-			if (isCollapsed())
-			{
-				applyDimmer(false, headerPanel);
-			}
-			headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
-			viewControls.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
-			leftTitleContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
-			if (steps.get(currentlyHighlighted) != null)
-			{
-				steps.get(currentlyHighlighted).setForeground(Color.LIGHT_GRAY);
-			}
-			currentlyHighlighted = null;
+			applyDimmer(false, headerPanel);
 		}
+		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		viewControls.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		leftTitleContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		if (steps.get(currentlyActiveQuestSidebarStep()) != null)
+		{
+			steps.get(currentlyActiveQuestSidebarStep()).setForeground(Color.LIGHT_GRAY);
+		}
+
 		collapse();
 	}
 
@@ -393,9 +393,14 @@ public class QuestStepPanel extends JPanel
 			steps.get(step).setVisible(newVisibility);
 		}
 
-		if (stepVisibilityChanged && currentlyHighlighted != null)
+		if (stepVisibilityChanged)
 		{
-			updateHighlightCheck(client, currentlyHighlighted.getQuestHelper().getCurrentStep(), currentlyHighlighted.getQuestHelper());
+			updateHighlightCheck(client, currentlyActiveQuestSidebarStep(), questHelper);
 		}
+	}
+
+	private QuestStep currentlyActiveQuestSidebarStep()
+	{
+		return questHelperPlugin.getSelectedQuest().getCurrentStep().getSidePanelStep();
 	}
 }

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -220,6 +220,7 @@ public class QuestStepPanel extends JPanel
 
 			for (QuestStep step : getSteps())
 			{
+				if (step.getConditionToHide() != null && step.getConditionToHide().check(client)) continue;
 				if (step == newStep || step.getSubsteps().contains(newStep))
 				{
 					highlighted = true;
@@ -381,10 +382,20 @@ public class QuestStepPanel extends JPanel
 
 	public void updateStepVisibility(Client client)
 	{
+		boolean stepVisibilityChanged = false;
 		for (QuestStep step : steps.keySet())
 		{
-			step.setShowInSidebar(step.getConditionToHide() == null || !step.getConditionToHide().check(client));
-			steps.get(step).setVisible(step.isShowInSidebar());
+			boolean oldVisibility = step.isShowInSidebar();
+			boolean newVisibility = step.getConditionToHide() == null || !step.getConditionToHide().check(client);
+			stepVisibilityChanged = stepVisibilityChanged || (oldVisibility != newVisibility);
+
+			step.setShowInSidebar(newVisibility);
+			steps.get(step).setVisible(newVisibility);
+		}
+
+		if (stepVisibilityChanged && currentlyHighlighted != null)
+		{
+			updateHighlightCheck(client, currentlyHighlighted.getQuestHelper().getCurrentStep(), currentlyHighlighted.getQuestHelper());
 		}
 	}
 }

--- a/src/main/java/com/questhelper/steps/NpcStep.java
+++ b/src/main/java/com/questhelper/steps/NpcStep.java
@@ -195,14 +195,18 @@ public class NpcStep extends DetailedQuestStep
 		}
 	}
 
-	public void addAlternateNpcs(Integer... alternateNpcIDs)
+	public NpcStep addAlternateNpcs(Integer... alternateNpcIDs)
 	{
 		this.alternateNpcIDs.addAll(Arrays.asList(alternateNpcIDs));
+
+		return this;
 	}
 
-	public void addAlternateNpcs(List<Integer> alternateNpcIDs)
+	public NpcStep addAlternateNpcs(List<Integer> alternateNpcIDs)
 	{
 		this.alternateNpcIDs.addAll(alternateNpcIDs);
+
+		return this;
 	}
 
 	public void setMustBeFocusedOnNpcs(Integer... ids)

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -232,14 +232,16 @@ public class ObjectStep extends DetailedQuestStep
 		}
 	}
 
-	public void addAlternateObjects(Integer... alternateObjectIDs)
+	public QuestStep addAlternateObjects(Integer... alternateObjectIDs)
 	{
 		this.alternateObjectIDs.addAll(Arrays.asList(alternateObjectIDs));
+		return this;
 	}
 
-	public void addAlternateObjects(Collection<Integer> alternateObjectIDs)
+	public QuestStep addAlternateObjects(Collection<Integer> alternateObjectIDs)
 	{
 		this.alternateObjectIDs.addAll(alternateObjectIDs);
+		return this;
 	}
 
 	@Subscribe

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -232,13 +232,13 @@ public class ObjectStep extends DetailedQuestStep
 		}
 	}
 
-	public QuestStep addAlternateObjects(Integer... alternateObjectIDs)
+	public ObjectStep addAlternateObjects(Integer... alternateObjectIDs)
 	{
 		this.alternateObjectIDs.addAll(Arrays.asList(alternateObjectIDs));
 		return this;
 	}
 
-	public QuestStep addAlternateObjects(Collection<Integer> alternateObjectIDs)
+	public ObjectStep addAlternateObjects(Collection<Integer> alternateObjectIDs)
 	{
 		this.alternateObjectIDs.addAll(alternateObjectIDs);
 		return this;

--- a/src/main/java/com/questhelper/steps/PuzzleWrapperStep.java
+++ b/src/main/java/com/questhelper/steps/PuzzleWrapperStep.java
@@ -241,9 +241,10 @@ public class PuzzleWrapperStep extends ConditionalStep
 	}
 
 	@Override
-	public void addIcon(int iconItemID)
+	public QuestStep addIcon(int iconItemID)
 	{
 		steps.get(null).addIcon(iconItemID);
+		return this;
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/steps/PuzzleWrapperStep.java
+++ b/src/main/java/com/questhelper/steps/PuzzleWrapperStep.java
@@ -33,7 +33,9 @@ import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.conditional.Conditions;
 import static com.questhelper.requirements.util.LogicHelper.not;
 import com.questhelper.requirements.util.LogicType;
-import java.util.ArrayList;
+
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.NonNull;
@@ -51,7 +53,7 @@ public class PuzzleWrapperStep extends ConditionalStep
 		this.noSolvingStep = hiddenStep;
 		this.questHelperConfig = questHelper.getConfig();
 		addStep(not(new ConfigRequirement(questHelper.getConfig()::solvePuzzles)), noSolvingStep);
-		addSubSteps(noSolvingStep, step);
+		super.addSubSteps(noSolvingStep, step);
 		conditionToHideInSidebar(new Conditions(shouldHideHiddenPuzzleHintInSidebar, new Conditions(LogicType.NOR, new ConfigRequirement(questHelper.getConfig()::solvePuzzles))));
 	}
 
@@ -116,15 +118,17 @@ public class PuzzleWrapperStep extends ConditionalStep
 	}
 
 	@Override
-	public void addDialogStep(String choice)
+	public QuestStep addDialogStep(String choice)
 	{
 		steps.get(null).addDialogStep(choice);
+		return this;
 	}
 
 	@Override
-	public void addDialogStep(Pattern pattern)
+	public QuestStep addDialogStep(Pattern pattern)
 	{
 		steps.get(null).addDialogStep(pattern);
+		return this;
 	}
 
 	@Override
@@ -134,87 +138,100 @@ public class PuzzleWrapperStep extends ConditionalStep
 	}
 
 	@Override
-	public void addDialogStepWithExclusion(String choice, String exclusionString)
+	public QuestStep addDialogStepWithExclusion(String choice, String exclusionString)
 	{
 		steps.get(null).addDialogStepWithExclusion(choice, exclusionString);
+		return this;
 	}
 
 	@Override
-	public void addDialogStepWithExclusions(String choice, String... exclusionString)
+	public QuestStep addDialogStepWithExclusions(String choice, String... exclusionString)
 	{
 		steps.get(null).addDialogStepWithExclusions(choice, exclusionString);
+		return this;
 	}
 
 	@Override
-	public void addDialogStep(int id, String choice)
+	public QuestStep addDialogStep(int id, String choice)
 	{
 		steps.get(null).addDialogStep(id, choice);
+		return this;
 	}
 
 	@Override
-	public void addDialogStep(int id, Pattern pattern)
+	public QuestStep addDialogStep(int id, Pattern pattern)
 	{
 		steps.get(null).addDialogStep(id, pattern);
+		return this;
 	}
 
 	@Override
-	public void addDialogSteps(String... newChoices)
+	public QuestStep addDialogSteps(String... newChoices)
 	{
 		steps.get(null).addDialogSteps(newChoices);
+		return this;
 	}
 
 	@Override
-	public void addDialogConsideringLastLineCondition(String dialogString, String choiceValue)
+	public QuestStep addDialogConsideringLastLineCondition(String dialogString, String choiceValue)
 	{
 		steps.get(null).addDialogConsideringLastLineCondition(dialogString, choiceValue);
+		return this;
 	}
 
 	@Override
-	public void addDialogChange(String choice, String newText)
+	public QuestStep addDialogChange(String choice, String newText)
 	{
 		steps.get(null).addDialogChange(choice, newText);
+		return this;
 	}
 
 	@Override
-	public void addWidgetChoice(String text, int groupID, int childID)
+	public QuestStep addWidgetChoice(String text, int groupID, int childID)
 	{
 		steps.get(null).addWidgetChoice(text, groupID, childID);
+		return this;
 	}
 
 	@Override
-	public void addWidgetChoice(String text, int groupID, int childID, int groupIDForChecking)
+	public QuestStep addWidgetChoice(String text, int groupID, int childID, int groupIDForChecking)
 	{
 		steps.get(null).addWidgetChoice(text, groupID, childID, groupIDForChecking);
-
+		return this;
 	}
 
 	@Override
-	public void addWidgetChoice(int id, int groupID, int childID)
+	public QuestStep addWidgetChoice(int id, int groupID, int childID)
 	{
 		steps.get(null).addWidgetChoice(id, groupID, childID);
+		return this;
 	}
 
 	@Override
-	public void addWidgetChange(String choice, int groupID, int childID, String newText)
+	public QuestStep addWidgetChange(String choice, int groupID, int childID, String newText)
 	{
 		steps.get(null).addWidgetChange(choice, groupID, childID, newText);
+		return this;
 	}
 
 	@Override
-	public void clearWidgetHighlights() {
+	public void clearWidgetHighlights()
+	{
 		steps.get(null).clearWidgetHighlights();
 	}
 
 	@Override
-	public void addWidgetHighlight(int groupID, int childID)
+	public QuestStep addWidgetHighlight(int groupID, int childID)
 	{
 		steps.get(null).addWidgetHighlight(groupID, childID);
+		return this;
 	}
 
 	@Override
-	public void addWidgetHighlight(int groupID, int childID, int childChildID)
+	public QuestStep addWidgetHighlight(int groupID, int childID, int childChildID)
 	{
 		steps.get(null).addWidgetHighlight(groupID, childID, childChildID);
+		return this;
 	}
 
 	@Override
@@ -227,5 +244,30 @@ public class PuzzleWrapperStep extends ConditionalStep
 	public void addIcon(int iconItemID)
 	{
 		steps.get(null).addIcon(iconItemID);
+	}
+
+	@Override
+	public List<QuestStep> getSubsteps()
+	{
+		if (questHelperConfig.solvePuzzles())
+		{
+			return steps.get(null).getSubsteps();
+		}
+		else
+		{
+			return noSolvingStep.getSubsteps();
+		}
+	}
+
+	@Override
+	public void addSubSteps(QuestStep... substep)
+	{
+		noSolvingStep.addSubSteps(Arrays.asList(substep));
+	}
+
+	@Override
+	public void addSubSteps(Collection<QuestStep> substeps)
+	{
+		noSolvingStep.addSubSteps(substeps);
 	}
 }

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -475,9 +475,10 @@ public abstract class QuestStep implements Module
 			.build());
 	}
 
-	public void addIcon(int iconItemID)
+	public QuestStep addIcon(int iconItemID)
 	{
 		this.iconItemID = iconItemID;
+		return this;
 	}
 
 	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -293,14 +293,16 @@ public abstract class QuestStep implements Module
 		widgetChoices.checkChoices(client);
 	}
 
-	public void addDialogStep(String choice)
+	public QuestStep addDialogStep(String choice)
 	{
 		choices.addChoice(new DialogChoiceStep(questHelper.getConfig(), choice));
+		return this;
 	}
 
-	public void addDialogStep(Pattern pattern)
+	public QuestStep addDialogStep(Pattern pattern)
 	{
 		choices.addChoice(new DialogChoiceStep(questHelper.getConfig(), pattern));
+		return this;
 	}
 
 	public void resetDialogSteps()
@@ -308,67 +310,78 @@ public abstract class QuestStep implements Module
 		choices.resetChoices();
 	}
 
-	public void addDialogStepWithExclusion(String choice, String exclusionString)
+	public QuestStep addDialogStepWithExclusion(String choice, String exclusionString)
 	{
 		choices.addDialogChoiceWithExclusion(new DialogChoiceStep(questHelper.getConfig(), choice), exclusionString);
+		return this;
 	}
 
-	public void addDialogStepWithExclusions(String choice, String... exclusionString)
+	public QuestStep addDialogStepWithExclusions(String choice, String... exclusionString)
 	{
 		choices.addDialogChoiceWithExclusions(new DialogChoiceStep(questHelper.getConfig(), choice), exclusionString);
+		return this;
 	}
 
-	public void addDialogStep(int id, String choice)
+	public QuestStep addDialogStep(int id, String choice)
 	{
 		choices.addChoice(new DialogChoiceStep(questHelper.getConfig(), id, choice));
+		return this;
 	}
 
-	public void addDialogStep(int id, Pattern pattern)
+	public QuestStep addDialogStep(int id, Pattern pattern)
 	{
 		choices.addChoice(new DialogChoiceStep(questHelper.getConfig(), id, pattern));
+		return this;
 	}
 
-	public void addDialogSteps(String... newChoices)
+	public QuestStep addDialogSteps(String... newChoices)
 	{
 		for (String choice : newChoices)
 		{
 			choices.addChoice(new DialogChoiceStep(questHelper.getConfig(), choice));
 		}
+		return this;
 	}
 
-	public void addDialogConsideringLastLineCondition(String dialogString, String choiceValue)
+	public QuestStep addDialogConsideringLastLineCondition(String dialogString, String choiceValue)
 	{
 		DialogChoiceStep choice = new DialogChoiceStep(questHelper.getConfig(), dialogString);
 		choice.setExpectedPreviousLine(choiceValue);
 		choices.addChoice(choice);
+		return this;
 	}
 
-	public void addDialogChange(String choice, String newText)
+	public QuestStep addDialogChange(String choice, String newText)
 	{
 		choices.addChoice(new DialogChoiceChange(questHelper.getConfig(), choice, newText));
+		return this;
 	}
 
-	public void addWidgetChoice(String text, int groupID, int childID)
+	public QuestStep addWidgetChoice(String text, int groupID, int childID)
 	{
 		widgetChoices.addChoice(new WidgetChoiceStep(questHelper.getConfig(), text, groupID, childID));
+		return this;
 	}
 
-	public void addWidgetChoice(String text, int groupID, int childID, int groupIDForChecking)
+	public QuestStep addWidgetChoice(String text, int groupID, int childID, int groupIDForChecking)
 	{
 		WidgetChoiceStep newChoice = new WidgetChoiceStep(questHelper.getConfig(), text, groupID, childID);
 		newChoice.setGroupIdForChecking(groupIDForChecking);
 		widgetChoices.addChoice(newChoice);
+		return this;
 
 	}
 
-	public void addWidgetChoice(int id, int groupID, int childID)
+	public QuestStep addWidgetChoice(int id, int groupID, int childID)
 	{
 		widgetChoices.addChoice(new WidgetChoiceStep(questHelper.getConfig(), id, groupID, childID));
+		return this;
 	}
 
-	public void addWidgetChange(String choice, int groupID, int childID, String newText)
+	public QuestStep addWidgetChange(String choice, int groupID, int childID, String newText)
 	{
 		widgetChoices.addChoice(new WidgetTextChange(questHelper.getConfig(), choice, groupID, childID, newText));
+		return this;
 	}
 
 	@Subscribe
@@ -384,29 +397,34 @@ public abstract class QuestStep implements Module
 		widgetsToHighlight.clear();
 	}
 
-	public void addSpellHighlight(Spell spell)
+	public QuestStep addSpellHighlight(Spell spell)
 	{
 		widgetsToHighlight.add(new SpellWidgetHighlight(spell));
+		return this;
 	}
 
-	public void addWidgetHighlight(WidgetHighlight widgetHighlight)
+	public QuestStep addWidgetHighlight(WidgetHighlight widgetHighlight)
 	{
 		widgetsToHighlight.add(widgetHighlight);
+		return this;
 	}
 
-	public void addWidgetHighlight(int groupID, int childID)
+	public QuestStep addWidgetHighlight(int groupID, int childID)
 	{
 		widgetsToHighlight.add(new WidgetHighlight(groupID, childID));
+		return this;
 	}
 
-	public void addWidgetHighlight(int groupID, int childID, int childChildID)
+	public QuestStep addWidgetHighlight(int groupID, int childID, int childChildID)
 	{
 		widgetsToHighlight.add(new WidgetHighlight(groupID, childID, childChildID));
+		return this;
 	}
 
-	public void addWidgetHighlightWithItemIdRequirement(int groupID, int childID, int itemID, boolean checkChildren)
+	public QuestStep addWidgetHighlightWithItemIdRequirement(int groupID, int childID, int itemID, boolean checkChildren)
 	{
 		widgetsToHighlight.add(new WidgetHighlight(groupID, childID, itemID, checkChildren));
+		return this;
 	}
 
 	// TODO: Add generic requirement for highlighting
@@ -564,5 +582,15 @@ public abstract class QuestStep implements Module
 
 	public void disableShortestPath()
 	{
+	}
+
+	public PuzzleWrapperStep puzzleWrapStep()
+	{
+		return new PuzzleWrapperStep(getQuestHelper(), this);
+	}
+
+	public PuzzleWrapperStep puzzleWrapStep(String alternateText)
+	{
+		return new PuzzleWrapperStep(getQuestHelper(), this, alternateText);
 	}
 }


### PR DESCRIPTION
This is primarily focusing on implementing the PuzzleWrapperStep to the newest Varlamore quests.

As part of this, I made a few QuestStep functions return said QuestStep. This is intended to make it a bit easier to make things like PuzzleWrapperStep in the future when there's various things needing to be applied to the base QuestStep.

I also needed to fix a bug in the sidebar with how substeps were detected for section highlighting, as it was causing the sidebar to not highlight correctly for substeps of puzzle wrappers.

The parts I've added a puzzle hide to are:

**Heart of Darkness**

- The first floor puzzle is entirely hidden, except a prompt saying to work out the passphrase for the guy.
- The third floor puzzle is entirely hidden, except for a prompt saying to work out who is guilty.
- The ice dungeon statue puzzle is entirely hidden, except a prompt saying to work out how to open the door.

**Ethically Acquired Antiquities**

- The shaming of Helen shouldn't show the prompts on what to say, and will say to instead work out how to shame him.

**Death on the Isle**

None added at present, as it is kinda all a puzzle. I think we could consider adding some, basically making it so sections are more like 'Search the wine cellar for all clues', 'Accuse the person you think is the murderer', etc. But I'd like that to be a discussion as I'm not 100% sure on it.

**Meat and Greet**

None needed to be added as @pajlada is a competent individual who's very good at coding ❤️ 