### PR TITLE
fix: Remove condition for disabling shortest path

### DIFF
--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -377,7 +377,7 @@ public class QuestManager
 	public void activateShortestPath()
 	{
 		if (selectedQuest == null) return;
-		selectedQuest.getCurrentStep().setShortestPath();
+		selectedQuest.getCurrentStep().getActiveStep().setShortestPath();
 	}
 
 	public void disableShortestPath()

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -383,7 +383,7 @@ public class QuestManager
 	public void disableShortestPath()
 	{
 		if (selectedQuest == null) return;
-		selectedQuest.getCurrentStep().disableShortestPath();
+		selectedQuest.getCurrentStep().getActiveStep().disableShortestPath();
 	}
 
 	/**

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -925,11 +925,7 @@ public class DetailedQuestStep extends QuestStep
 	{
 		if (worldPoint != null)
 		{
-			WorldPoint playerWp = client.getLocalPlayer().getWorldLocation();
-			if (!getQuestHelper().getConfig().useShortestPath() && playerWp != null)
-			{
-				eventBus.post(new PluginMessage("shortestpath", "clear"));
-			}
+			eventBus.post(new PluginMessage("shortestpath", "clear"));
 		}
 	}
 }

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -194,7 +194,7 @@ public class DetailedQuestStep extends QuestStep
 	public void shutDown()
 	{
 		worldMapPointManager.removeIf(QuestHelperWorldMapPoint.class::isInstance);
-		disableShortestPath();
+		removeShortestPath();
 		tileHighlights.clear();
 		started = false;
 	}
@@ -917,6 +917,15 @@ public class DetailedQuestStep extends QuestStep
 				data.put("target", worldPoint);
 				eventBus.post(new PluginMessage("shortestpath", "path", data));
 			}
+		}
+	}
+
+	@Override
+	public void removeShortestPath()
+	{
+		if (getQuestHelper().getConfig().useShortestPath())
+		{
+			eventBus.post(new PluginMessage("shortestpath", "clear"));
 		}
 	}
 

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -558,6 +558,10 @@ public abstract class QuestStep implements Module
 	{
 	}
 
+	public void removeShortestPath()
+	{
+	}
+
 	public void disableShortestPath()
 	{
 	}


### PR DESCRIPTION
This removes checks for removing the shortest path, as well as ensures the correct active step is used for disabling.