### PR TITLE
Fix up the level requirements for Fremennick Isles

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikisles/TheFremennikIsles.java
@@ -308,9 +308,9 @@ public class TheFremennikIsles extends BasicQuestHelper
 
 		tuna.setTooltip("You can buy some from Flosi in east Jatizso, or fish some from the pier.");
 
-		Requirement useMithrilOre = new SkillRequirement(Skill.MINING, 55);
-		Requirement useCoal = and(new SkillRequirement(Skill.MINING,  10), not(useMithrilOre));
-		Requirement useTin = not(new SkillRequirement(Skill.MINING,  10));
+		Requirement useMithrilOre = new SkillRequirement(Skill.MINING, 55);  // Level 55+
+		Requirement useTin = not(new SkillRequirement(Skill.MINING,  2));  // Level 1
+		Requirement useCoal = and(not(useTin), not(useMithrilOre));  // Levels 2-54
 		mithrilOre = new ItemRequirement("Mithril ore", ItemID.MITHRIL_ORE, 6).showConditioned(useMithrilOre);
 		mithrilOre.setTooltip("You can mine some in the underground mine north west of Jatizso.");
 		coal = new ItemRequirement("Coal", ItemID.COAL, 7).showConditioned(useCoal);


### PR DESCRIPTION
"Either 8 tin ores, 7 pieces of coal, or 6 mithril ores (depends on your Mining level; level 1 will require tin ore, 2-54 will require coal, and 55-99 require mithril ore). Note: The ores can be noted." from https://oldschool.runescape.wiki/w/The_Fremennik_Isles

Fixes https://github.com/Zoinkwiz/quest-helper/issues/1799