### PR TITLE
fix: Remove charcoal req on step in TDS

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
+++ b/src/main/java/com/questhelper/helpers/quests/thedigsite/TheDigSite.java
@@ -166,7 +166,7 @@ public class TheDigSite extends BasicQuestHelper
 		makeExplosives.addStep(new Conditions(chemicalCompound), goDownToExplode);
 		makeExplosives.addStep(new Conditions(arcenia, mixedChemicals2), addRoot);
 		makeExplosives.addStep(new Conditions(arcenia, mixedChemicals, groundCharcoal), addCharcoal);
-		makeExplosives.addStep(new Conditions(arcenia, mixedChemicals, charcoal), grindCharcoal);
+		makeExplosives.addStep(new Conditions(arcenia, mixedChemicals), grindCharcoal);
 		makeExplosives.addStep(new Conditions(arcenia, nitrate, nitro), mixNitroWithNitrate);
 		makeExplosives.addStep(new Conditions(arcenia, powder, nitro), usePowderOnExpert);
 		makeExplosives.addStep(new Conditions(arcenia, powder, liquid), useLiquidOnExpert);


### PR DESCRIPTION
This was meaning players were incorrectly guided to open a chest rather than grind charcoal. This means the player is guided to grind charcoal still, even if they don't have some yet.