### PR TITLE
Fix: Cold War hunter requirement

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/helpers/quests/coldwar/ColdWar.java
@@ -496,7 +496,7 @@ public class ColdWar extends BasicQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.HUNTER, 10, true));
+		req.add(new SkillRequirement(Skill.HUNTER, 10));
 		req.add(new SkillRequirement(Skill.AGILITY, 30));
 		req.add(new SkillRequirement(Skill.CRAFTING, 30));
 		req.add(new SkillRequirement(Skill.CONSTRUCTION, 34));


### PR DESCRIPTION
Removed "canBeBoosted" boolean from Hunter requirement as it is incorrect and cannot be boosted.

Fixes #1822