### PR TITLE
Fix: remove duplicated quantities for ecto-tokens

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/ghostsahoy/GhostsAhoy.java
+++ b/src/main/java/com/questhelper/helpers/quests/ghostsahoy/GhostsAhoy.java
@@ -186,8 +186,8 @@ public class GhostsAhoy extends BasicQuestHelper
 	{
 		ectoToken2 = new ItemRequirement("Ecto-token, or travel by Charter Ship", ItemID.ECTOTOKEN, 2);
 		charos = new ItemRequirement("Ring of Charos (a)", ItemID.RING_OF_CHAROSA).isNotConsumed();
-		ectoTokensCharos = new ItemRequirement("20 Ecto-token, OR 10 Ecto-Tokens and coins to travel by Charter Ship", ItemID.ECTOTOKEN, 20);
-		ectoTokensNoCharos = new ItemRequirement("31 Ecto-token, OR 25 Ecto-Tokens and coins to travel by Charter Ship", ItemID.ECTOTOKEN, 31);ectoToken4 = new ItemRequirement("Ecto-token, or travel by Charter Ship", ItemID.ECTOTOKEN, 4);
+		ectoTokensCharos = new ItemRequirement("Ecto-token, OR 10 Ecto-Tokens and coins to travel by Charter Ship", ItemID.ECTOTOKEN, 20);
+		ectoTokensNoCharos = new ItemRequirement("Ecto-token, OR 25 Ecto-Tokens and coins to travel by Charter Ship", ItemID.ECTOTOKEN, 31);ectoToken4 = new ItemRequirement("Ecto-token, or travel by Charter Ship", ItemID.ECTOTOKEN, 4);
 		ectoToken12 = new ItemRequirement("Ecto-token, or travel by Charter Ship and 10 ecto-tokens", ItemID.ECTOTOKEN, 12);
 		ectoToken27 = new ItemRequirement("Ecto-token, or travel by Charter Ship and 25 ecto-tokens", ItemID.ECTOTOKEN, 27);
 		ectoToken10 = new ItemRequirement("Ecto-token", ItemID.ECTOTOKEN, 10);


### PR DESCRIPTION
Potential fix to a very minor issue (#1835), showing duplicated quantities for Ecto-tokens required:
![image](https://github.com/user-attachments/assets/851bfd2d-570f-4a34-8f3a-698e45fe0c0c)
