### PR TITLE
fix: Corrects Kandarin hard xp reward (#1839)

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
@@ -348,7 +348,7 @@ public class KandarinHard extends ComplexStateQuestHelper
 	{
 		return Arrays.asList(
 			new ItemReward("Kandarin headgear (3)", ItemID.KANDARIN_HEADGEAR_3, 1),
-			new ItemReward("15,500 Exp. Lamp (Any skill over 50)", ItemID.ANTIQUE_LAMP, 1));
+			new ItemReward("15,000 Exp. Lamp (Any skill over 50)", ItemID.ANTIQUE_LAMP, 1));
 	}
 
 	@Override


### PR DESCRIPTION
Kandarin diary reward is incorrectly listed as 15,500 xp, it is actually 15,000 xp as [listed here](https://oldschool.runescape.wiki/w/Kandarin_Diary#Hard)