### PR TITLE
feat: Add config to hide quest rewards

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -373,6 +373,17 @@ public interface QuestHelperConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "hideQuestRewards",
+		name = "Hide quest rewards",
+		description = "Enable this config if you want to hide quest rewards.<br>If you already had a quest helper open, you need to<br>restart it to hide the quest rewards.",
+		section = sidebarDetailsSection
+	)
+	default boolean hideQuestRewards()
+	{
+		return false;
+	}
+
 	@ConfigSection(
 		position = 2,
 		name = "Quest Hints",

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -441,7 +441,11 @@ public class QuestOverviewPanel extends JPanel
 		updateQuestNotes(quest.getNotes());
 
 		/* Rewards */
-		questRewardsPanel.setRewards(quest.getQuestRewards());
+		if (questHelperPlugin.getConfig().hideQuestRewards()) {
+			questRewardsPanel.hideRewards();
+		} else {
+			questRewardsPanel.setRewards(quest.getQuestRewards());
+		}
 	}
 
 	private static void collectRequirements(QuestHelper quest, List<Requirement> allRequirements, Set<String> processedQuestIds)

--- a/src/main/java/com/questhelper/panel/QuestRewardsPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRewardsPanel.java
@@ -100,4 +100,12 @@ public class QuestRewardsPanel extends JPanel
 
 		revalidate();
 	}
+
+	public void hideRewards()
+	{
+		rewardsText.setText("Hidden by the \"Hide quest rewards\" config");
+		rewardsText.setForeground(Color.GRAY);
+
+		revalidate();
+	}
 }


### PR DESCRIPTION
The default behaviour has not changed, so rewards show for people unless they tick the "Hide quest rewards" config

![image](https://github.com/user-attachments/assets/c8bac5ba-e5f5-42e2-8662-7764b28c5409)

Once it's ticked and they start a new quest helper, the rewards section is still there, but instead with text explaining that the rewards are hidden due to the config they've enabled.

![image](https://github.com/user-attachments/assets/f483846f-97ff-4aad-9b08-42e3df41ab34)
