### PR TITLE
ItemRequirement rework

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -28,6 +28,7 @@ package com.questhelper;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.questhelper.bank.banktab.BankTabItem;
 import com.questhelper.bank.banktab.BankTabItems;
 import com.questhelper.managers.*;
 import com.questhelper.panel.QuestHelperPanel;
@@ -43,28 +44,14 @@ import com.google.inject.Module;
 import com.questhelper.util.worldmap.WorldMapAreaManager;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.swing.SwingUtilities;
 import com.questhelper.tools.Icon;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.Menu;
-import net.runelite.api.MenuEntry;
-import net.runelite.api.VarPlayer;
-import net.runelite.api.WorldType;
+import net.runelite.api.*;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.GameStateChanged;
@@ -256,20 +243,20 @@ public class QuestHelperPlugin extends Plugin
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
 		Item[] items = event.getItemContainer().getItems();
-		if (event.getItemContainer() == client.getItemContainer(InventoryID.BANK))
+		if (event.getContainerId() == InventoryID.BANK.getId())
 		{
 			ItemAndLastUpdated bankData = QuestContainerManager.getBankData();
 			bankData.update(client.getTickCount(), items);
 			questBankManager.updateLocalBank(event.getItemContainer());
 		}
 
-		if (event.getItemContainer() == client.getItemContainer(InventoryID.INVENTORY))
+		if (event.getContainerId() == InventoryID.INVENTORY.getId())
 		{
 			ItemAndLastUpdated inventoryData = QuestContainerManager.getInventoryData();
 			inventoryData.update(client.getTickCount(), items);
 		}
 
-		if (event.getItemContainer() == client.getItemContainer(InventoryID.EQUIPMENT))
+		if (event.getContainerId() == InventoryID.EQUIPMENT.getId())
 		{
 			ItemAndLastUpdated equippedData = QuestContainerManager.getEquippedData();
 			equippedData.update(client.getTickCount(), items);

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -28,7 +28,6 @@ package com.questhelper;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
-import com.questhelper.bank.banktab.BankTabItem;
 import com.questhelper.bank.banktab.BankTabItems;
 import com.questhelper.managers.*;
 import com.questhelper.panel.QuestHelperPanel;
@@ -177,7 +176,7 @@ public class QuestHelperPlugin extends Plugin
 	protected void startUp() throws IOException
 	{
 		questBankManager.startUp(injector, eventBus);
-		QuestContainerManager.getBankData().setMethodToObtainItems(() -> questBankManager.getBankItems().toArray(new Item[0]));
+		QuestContainerManager.getBankData().setSpecialMethodToObtainItems(() -> questBankManager.getBankItems().toArray(new Item[0]));
 		eventBus.register(worldMapAreaManager);
 
 		injector.injectMembers(playerStateManager);

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -26,6 +26,7 @@ package com.questhelper.bank.banktab;
 
 import com.questhelper.bank.QuestBank;
 import com.questhelper.QuestHelperPlugin;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
@@ -88,7 +89,7 @@ public class QuestHelperBankTagService
 			recommendedItems = recommendedItems.stream()
 				.filter(Objects::nonNull)
 				.filter(i -> (!onlyGetMissingItems
-					|| !i.check(plugin.getClient(), false, questBank.getBankItems()))
+					|| !i.checkWithBank(plugin.getClient()))
 					&& i.shouldDisplayText(plugin.getClient()))
 				.collect(Collectors.toList());
 		}
@@ -116,7 +117,7 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.check(plugin.getClient(), false, questBank.getBankItems()))
+						|| !i.checkWithBank(plugin.getClient()))
 						&& i.shouldDisplayText(plugin.getClient()))
 					.collect(Collectors.toList());
 			}
@@ -128,7 +129,7 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.check(plugin.getClient(), false, questBank.getBankItems()))
+						|| !i.checkWithBank(plugin.getClient()))
 						&& i.shouldDisplayText(plugin.getClient()))
 					.collect(Collectors.toList());
 			}
@@ -167,7 +168,7 @@ public class QuestHelperBankTagService
 				else
 				{
 					ItemRequirement match = itemsWhichPassReq.stream()
-						.filter(r -> r.checkBank(plugin.getClient()))
+						.filter(r -> r.checkWithBank(plugin.getClient()))
 						.findFirst()
 						.orElse(itemsWhichPassReq.get(0).named(itemRequirements.getName()));
 

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManI.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManI.java
@@ -25,6 +25,7 @@
 package com.questhelper.helpers.quests.ragandboneman;
 
 import com.questhelper.collections.ItemCollections;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.tools.QuestTile;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.panel.PanelDetails;
@@ -180,7 +181,7 @@ public class RagAndBoneManI extends BasicQuestHelper
 		potOfVinegarNeeded.setQuantity(winesNeededQuantity.get());
 
 		int jugsNeeded = winesNeededQuantity.get();
-		jugsNeeded -= potOfVinegar.alsoCheckBank(questBank).getMatches(client);
+		jugsNeeded -= potOfVinegar.checkTotalMatchesInContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
 		potNeeded.setQuantity(jugsNeeded);
 		jugOfVinegarNeeded.setQuantity(jugsNeeded);
 

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
@@ -26,6 +26,7 @@ package com.questhelper.helpers.quests.ragandboneman;
 
 import com.questhelper.collections.ItemCollections;
 import com.questhelper.collections.KeyringCollection;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.questinfo.QuestHelperQuest;
 import com.questhelper.tools.QuestTile;
 import com.questhelper.questinfo.QuestVarPlayer;
@@ -301,7 +302,7 @@ public class RagAndBoneManII extends BasicQuestHelper
 		potOfVinegarNeeded.setQuantity(winesNeededQuantity.get());
 
 		int jugsNeeded = winesNeededQuantity.get();
-		jugsNeeded -= potOfVinegar.alsoCheckBank(questBank).getMatches(client);
+		jugsNeeded -= potOfVinegar.checkTotalMatchesInContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
 		potNeeded.setQuantity(jugsNeeded);
 		jugOfVinegarNeeded.setQuantity(jugsNeeded);
 

--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/Solution.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/Solution.java
@@ -78,7 +78,7 @@ public class Solution
 		puzzleNeeds.clear();
 		toExchange.clear();
 
-		if (!puzzle1Requirement.check(client, false, items))
+		if (!puzzle1Requirement.checkItems(client, items))
 		{
 			puzzleNeeds.add(puzzle1Requirement);
 			var singleDiscExchange = valuePossibleSingleDiscExchangesRequirements.get(puzzle1SolutionValue).stream().filter(requirement -> inventoryHas(items, requirement.getId())).collect(Collectors.toUnmodifiableList());
@@ -131,7 +131,7 @@ public class Solution
 				item2 = possiblePuzzle2Solution.getItemRequirements().get(1);
 			}
 
-			if (possiblePuzzle2Solution.check(client, false, itemsAfterPuzzle1))
+			if (possiblePuzzle2Solution.checkItems(client, itemsAfterPuzzle1))
 			{
 				// Found a valid puzzle2 solution
 				puzzle2UpperRequirement = item1;
@@ -141,7 +141,7 @@ public class Solution
 
 			// Some goal values only have one possible solution
 			// Let's check if we have one of these
-			if (item1.check(client, false, itemsAfterPuzzle1))
+			if (item1.checkItems(client, itemsAfterPuzzle1))
 			{
 				// Found a partial solution
 				partialPuzzle2Solution = possiblePuzzle2Solution;
@@ -150,7 +150,7 @@ public class Solution
 				break;
 			}
 
-			if (item2.check(client, false, itemsAfterPuzzle1))
+			if (item2.checkItems(client, itemsAfterPuzzle1))
 			{
 				// Found a partial solution
 				partialPuzzle2Solution = possiblePuzzle2Solution;

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -45,7 +45,7 @@ public class ItemAndLastUpdated
     private Item[] items;
 
     @Setter
-    private Callable<Item[]> methodToObtainItems;
+    private Callable<Item[]> specialMethodToObtainItems;
 
     public ItemAndLastUpdated(TrackedContainers containerType)
     {
@@ -60,18 +60,18 @@ public class ItemAndLastUpdated
 
     /**
      * Get the Items contained within the Tracked Container.
-     * If this instance of ItemAndLastUpdated has a method to obtain the current state of the Container other than
+     * If this instance of ItemAndLastUpdated has a method in specialMethodToObtainItems to obtain the current state of the Container other than
      * from the {@link Item}[] items variable, it will use that and return the value.
-     * 
+     *
      * @return an {@link Item}[] of items currently thought to be in the container.
      */
     public @Nullable Item[] getItems()
     {
-        if (methodToObtainItems != null)
+        if (specialMethodToObtainItems != null)
         {
             try
             {
-                return methodToObtainItems.call();
+                return specialMethodToObtainItems.call();
             } catch (Exception e)
             {
                 log.warn("Failed to load container from method");

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -37,6 +37,7 @@ public class ItemAndLastUpdated
     @Getter
     private TrackedContainers containerType;
 
+    // last game tick item container was changed
     @Getter
     private int lastUpdated = -1;
     private Item[] items;

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -27,11 +27,13 @@ package com.questhelper.managers;
 import com.questhelper.requirements.item.TrackedContainers;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Item;
 import javax.annotation.Nullable;
 
 import java.util.concurrent.Callable;
 
+@Slf4j
 public class ItemAndLastUpdated
 {
     @Getter
@@ -65,7 +67,7 @@ public class ItemAndLastUpdated
                 return methodToObtainItems.call();
             } catch (Exception e)
             {
-                System.out.println("Failed to load container from method");
+                log.warn("Failed to load container from method");
             }
         }
 

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -28,6 +28,7 @@ import com.questhelper.requirements.item.TrackedContainers;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Item;
+import javax.annotation.Nullable;
 
 import java.util.concurrent.Callable;
 
@@ -54,7 +55,7 @@ public class ItemAndLastUpdated
         this.items = items;
     }
 
-    public Item[] getItems()
+    public @Nullable Item[] getItems()
     {
         if (methodToObtainItems != null)
         {

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -58,6 +58,13 @@ public class ItemAndLastUpdated
         this.items = items;
     }
 
+    /**
+     * Get the Items contained within the Tracked Container.
+     * If this instance of ItemAndLastUpdated has a method to obtain the current state of the Container other than
+     * from the {@link Item}[] items variable, it will use that and return the value.
+     * 
+     * @return an {@link Item}[] of items currently thought to be in the container.
+     */
     public @Nullable Item[] getItems()
     {
         if (methodToObtainItems != null)

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Callable;
 public class ItemAndLastUpdated
 {
     @Getter
-    TrackedContainers containerType;
+    private TrackedContainers containerType;
 
     @Getter
     private int lastUpdated = -1;

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.managers;
+
+import com.questhelper.requirements.item.TrackedContainers;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.Item;
+
+import java.util.concurrent.Callable;
+
+public class ItemAndLastUpdated
+{
+    @Getter
+    TrackedContainers containerType;
+
+    @Getter
+    private int lastUpdated = -1;
+    private Item[] items;
+
+    @Setter
+    private Callable<Item[]> methodToObtainItems;
+
+    public ItemAndLastUpdated(TrackedContainers containerType)
+    {
+        this.containerType = containerType;
+    }
+
+    public void update(int updateTick, Item[] items)
+    {
+        this.lastUpdated = updateTick;
+        this.items = items;
+    }
+
+    public Item[] getItems()
+    {
+        if (methodToObtainItems != null)
+        {
+            try
+            {
+                return methodToObtainItems.call();
+            } catch (Exception e)
+            {
+                System.out.println("Failed to load container from method");
+            }
+        }
+
+        return items;
+    }
+}

--- a/src/main/java/com/questhelper/managers/QuestContainerManager.java
+++ b/src/main/java/com/questhelper/managers/QuestContainerManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.managers;
+
+import com.questhelper.requirements.item.TrackedContainers;
+import lombok.Getter;
+
+public class QuestContainerManager
+{
+    @Getter
+    private final static ItemAndLastUpdated equippedData = new ItemAndLastUpdated(TrackedContainers.EQUIPPED);
+
+    @Getter
+    private final static ItemAndLastUpdated inventoryData = new ItemAndLastUpdated(TrackedContainers.INVENTORY);
+
+    @Getter
+    private final static ItemAndLastUpdated bankData = new ItemAndLastUpdated(TrackedContainers.BANK);
+}

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -163,7 +163,7 @@ public class QuestManager
 				}
 				if (panel.questActive)
 				{
-					clientThread.invokeLater(() -> panel.updateItemRequirements(client, questBankManager.getBankItems()));
+					clientThread.invokeLater(() -> panel.updateItemRequirements(client));
 				}
 				panel.updateLocks();
 			}
@@ -310,7 +310,7 @@ public class QuestManager
 				panel.addQuest(questHelper, true);
 
 				// Force an extra update immediately after starting a quest
-				clientThread.invokeLater(() -> panel.updateItemRequirements(client, questBankManager.getBankItems()));
+				clientThread.invokeLater(() -> panel.updateItemRequirements(client));
 			});
 		}
 		else

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -678,9 +678,9 @@ public class QuestHelperPanel extends PluginPanel
 		searchBar.setText("");
 	}
 
-	public void updateItemRequirements(Client client, List<Item> bankItems)
+	public void updateItemRequirements(Client client)
 	{
-		questOverviewPanel.updateRequirements(client, bankItems);
+		questOverviewPanel.updateRequirements(client);
 	}
 
 	/**

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -638,15 +638,15 @@ public class QuestOverviewPanel extends JPanel
 		return new Dimension(PANEL_WIDTH, super.getPreferredSize().height);
 	}
 
-	public void updateRequirements(Client client, List<Item> bankItems)
+	public void updateRequirements(Client client)
 	{
-		questGeneralRequirementsPanel.update(client, questHelperPlugin, bankItems);
-		questGeneralRecommendedPanel.update(client, questHelperPlugin, bankItems);
-		questItemRequirementsPanel.update(client, questHelperPlugin, bankItems);
-		questItemRecommendedPanel.update(client, questHelperPlugin, bankItems);
+		questGeneralRequirementsPanel.update(client, questHelperPlugin);
+		questGeneralRecommendedPanel.update(client, questHelperPlugin);
+		questItemRequirementsPanel.update(client, questHelperPlugin);
+		questItemRecommendedPanel.update(client, questHelperPlugin);
 
 		questStepPanelList.forEach((questStepPanel) -> {
-			questStepPanel.updateRequirements(client, bankItems);
+			questStepPanel.updateRequirements(client);
 		});
 		revalidate();
 	}

--- a/src/main/java/com/questhelper/panel/QuestRequirementsPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRequirementsPanel.java
@@ -26,6 +26,7 @@
 package com.questhelper.panel;
 
 import com.questhelper.QuestHelperPlugin;
+import com.questhelper.bank.QuestBank;
 import com.questhelper.managers.QuestManager;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
@@ -37,7 +38,6 @@ import com.questhelper.util.Fonts;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.Client;
-import net.runelite.api.Item;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.LinkBrowser;
 import org.apache.commons.lang3.tuple.Pair;
@@ -235,7 +235,7 @@ public class QuestRequirementsPanel extends JPanel
 		revalidate();
 	}
 
-	public void update(Client client, QuestHelperPlugin questHelperPlugin, List<Item> bankItems)
+	public void update(Client client, QuestHelperPlugin questHelperPlugin)
 	{
 		int numActive = 0;
 
@@ -281,7 +281,7 @@ public class QuestRequirementsPanel extends JPanel
 				}
 				else
 				{
-					newColor = itemRequirement.getColorConsideringBank(client, false, bankItems, questHelperPlugin.getConfig());
+					newColor = itemRequirement.getColorConsideringBank(client, questHelperPlugin.getConfig());
 				}
 			}
 			else

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -365,16 +365,16 @@ public class QuestStepPanel extends JPanel
 		}
 	}
 
-	public void updateRequirements(Client client, List<Item> bankItems)
+	public void updateRequirements(Client client)
 	{
 		if (requiredItemsPanel != null)
 		{
-			requiredItemsPanel.update(client, questHelperPlugin, bankItems);
+			requiredItemsPanel.update(client, questHelperPlugin);
 		}
 
 		if (recommendedItemsPanel != null)
 		{
-			recommendedItemsPanel.update(client, questHelperPlugin, bankItems);
+			recommendedItemsPanel.update(client, questHelperPlugin);
 		}
 
 		updateStepVisibility(client);

--- a/src/main/java/com/questhelper/requirements/item/ContainerState.java
+++ b/src/main/java/com/questhelper/requirements/item/ContainerState.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.requirements.item;
+
+import lombok.Data;
+
+@Data
+public class ContainerState
+{
+    private boolean state;
+    private int matchesFound;
+
+    private int lastCheckedTick = -2;
+
+    public void set(boolean state, int matchesFound, int currentTick)
+    {
+        this.state = state;
+        this.matchesFound = matchesFound;
+        this.lastCheckedTick = currentTick;
+    }
+}

--- a/src/main/java/com/questhelper/requirements/item/ContainerStateForRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ContainerStateForRequirement.java
@@ -24,19 +24,19 @@
  */
 package com.questhelper.requirements.item;
 
-import lombok.Data;
 
-@Data
-public class ContainerState
+import lombok.Getter;
+
+public class ContainerStateForRequirement
 {
-    private boolean state;
+    @Getter
     private int matchesFound;
 
+    @Getter
     private int lastCheckedTick = -2;
 
-    public void set(boolean state, int matchesFound, int currentTick)
+    public void set(int matchesFound, int currentTick)
     {
-        this.state = state;
         this.matchesFound = matchesFound;
         this.lastCheckedTick = currentTick;
     }

--- a/src/main/java/com/questhelper/requirements/item/FollowerItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/FollowerItemRequirement.java
@@ -65,7 +65,7 @@ public class FollowerItemRequirement extends ItemRequirement
 	}
 
 	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
+	public boolean check(Client client)
 	{
 		boolean match = client.getNpcs().stream()
 			.filter(npc -> npc.getInteracting() != null) // we need this check because Client#getLocalPlayer is Nullable
@@ -77,6 +77,6 @@ public class FollowerItemRequirement extends ItemRequirement
 			return true;
 		}
 
-		return super.check(client, checkConsideringSlotRestrictions, items);
+		return super.check(client);
 	}
 }

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -42,6 +42,7 @@ import java.awt.Color;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -520,6 +521,10 @@ public class ItemRequirement extends AbstractRequirement
 		// Consideration: If any have changed, AND ItemRequirement requires unique item, then we do need to aggregate all the results
 		for (ItemAndLastUpdated container : containers)
 		{
+			if (container.getItems() == null)
+			{
+				continue;
+			}
 			ContainerState stateForItemInContainer = knownContainerStates.get(container.getContainerType());
 			// Generic container, always check
 			if (container.getContainerType() == TrackedContainers.UNDEFINED)
@@ -566,6 +571,10 @@ public class ItemRequirement extends AbstractRequirement
 		List<Item> allItems = new ArrayList<>();
 		for (ItemAndLastUpdated container : containers)
 		{
+			if (container.getItems() == null)
+			{
+				continue;
+			}
 			allItems.addAll(List.of(container.getItems()));
 		}
 
@@ -646,7 +655,7 @@ public class ItemRequirement extends AbstractRequirement
 		return containers.toArray(new ItemAndLastUpdated[0]);
 	}
 
-	private int getMaxMatchingItems(Client client, Item[] items)
+	private int getMaxMatchingItems(Client client, @NonNull Item[] items)
 	{
 		// TODO: Is this right to do? Misleading on number for some scenarios
 		// Perhaps additionalOptions should have some text change instead assosciated

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -425,7 +425,7 @@ public class ItemRequirement extends AbstractRequirement
 		{
 			color = Color.GRAY;
 		}
-		else if (this.check(client))
+		else if (this.checkContainersOnPlayer(client))
 		{
 			color = config.passColour();
 		}
@@ -533,6 +533,11 @@ public class ItemRequirement extends AbstractRequirement
 		return getMaxMatchingItems(client, allItems.toArray(new Item[0]));
 	}
 
+	private boolean checkContainersOnPlayer(Client client)
+	{
+		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData());
+	}
+
 	public boolean checkWithBank(Client client)
 	{
 		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
@@ -545,7 +550,7 @@ public class ItemRequirement extends AbstractRequirement
 		{
 			color = Color.GRAY;
 		}
-		else if (this.checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData()))
+		else if (this.checkContainersOnPlayer(client))
 		{
 			color = config.passColour();
 		}

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -44,9 +44,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import org.jetbrains.annotations.Nullable;
 import javax.annotation.Nonnull;
@@ -111,21 +109,6 @@ public class ItemRequirement extends AbstractRequirement
 	protected boolean isChargedItem = false;
 
 	protected Requirement additionalOptions;
-
-	@Getter
-	protected boolean bankState;
-
-	int bankMatches;
-
-	@Getter
-	protected boolean inventoryState;
-
-	int inventoryMatches;
-
-	@Getter
-	protected boolean equipmentState;
-
-	int equipmentMatches;
 
 	Map<TrackedContainers, ContainerStateForRequirement> knownContainerStates = new HashMap<>();
 	{
@@ -406,35 +389,6 @@ public class ItemRequirement extends AbstractRequirement
 		return text.toString();
 	}
 
-	public void updateState(Client client)
-	{
-		ItemContainer equipped = client.getItemContainer(InventoryID.EQUIPMENT);
-		if (equipped != null)
-		{
-			equipmentMatches = getMaxMatchingItems(client, equipped.getItems());
-			equipmentState = equipmentMatches >= quantity;
-		}
-
-		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
-		if (inventory != null)
-		{
-			inventoryMatches = getMaxMatchingItems(client, inventory.getItems());
-			inventoryState = inventoryMatches >= quantity;
-		}
-
-		if (questBank != null)
-		{
-			bankMatches = getMaxMatchingItems(client, questBank.getBankItems().toArray(new Item[0]));
-			bankState = bankMatches >= quantity;
-		}
-	}
-
-	public boolean checkForSpecificItems(Client client, List<Item> items)
-	{
-		int matchesInItems = getMaxMatchingItems(client, items.toArray(new Item[0]));
-		return matchesInItems >= quantity;
-	}
-
 	// IDEA: Have a central event which lets you know diff on inventory
 	public void setAdditionalOptions(Requirement additionalOptions)
 	{
@@ -613,7 +567,7 @@ public class ItemRequirement extends AbstractRequirement
 		if (this.isEquip())
 		{
 			String equipText = "(equipped)";
-			if (!equipmentState)
+			if (!checkContainers(client, QuestContainerManager.getEquippedData()))
 			{
 				equipColor = config.failColour();
 			}

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -30,6 +30,8 @@ import com.questhelper.collections.ItemCollections;
 import com.questhelper.bank.QuestBank;
 import com.questhelper.collections.ItemWithCharge;
 import com.questhelper.QuestHelperConfig;
+import com.questhelper.managers.ItemAndLastUpdated;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.ManualRequirement;
 import com.questhelper.requirements.Requirement;
@@ -37,11 +39,7 @@ import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.InventorySlots;
 import com.questhelper.requirements.util.LogicType;
 import java.awt.Color;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
@@ -91,12 +89,13 @@ public class ItemRequirement extends AbstractRequirement
 	@Getter
 	protected Requirement conditionToHide = new ManualRequirement();
 
-	@Getter
 	@Setter
+	@Getter
 	private QuestBank questBank;
 
+	@Setter
 	@Getter
-	protected boolean hadItemLastCheck;
+	private boolean shouldCheckBank;
 
 	@Getter
 	protected boolean isConsumedItem = true;
@@ -111,8 +110,30 @@ public class ItemRequirement extends AbstractRequirement
 	@Getter
 	protected boolean isChargedItem = false;
 
-	@Setter
 	protected Requirement additionalOptions;
+
+	@Getter
+	protected boolean bankState;
+
+	int bankMatches;
+
+	@Getter
+	protected boolean inventoryState;
+
+	int inventoryMatches;
+
+	@Getter
+	protected boolean equipmentState;
+
+	int equipmentMatches;
+
+	Map<TrackedContainers, ContainerState> knownContainerStates = new HashMap<>();
+	{
+		for (TrackedContainers value : TrackedContainers.values())
+		{
+			knownContainerStates.put(value, new ContainerState());
+		}
+	}
 
 	public ItemRequirement(String name, int id)
 	{
@@ -216,10 +237,16 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	public void useQuestBank(QuestBank questBank)
+	{
+		this.shouldCheckBank = questBank != null;
+		this.questBank = questBank;
+	}
+
 	public ItemRequirement alsoCheckBank(QuestBank questBank)
 	{
 		ItemRequirement newItem = copy();
-		newItem.questBank = questBank;
+		newItem.useQuestBank(questBank);
 		return newItem;
 	}
 
@@ -295,7 +322,6 @@ public class ItemRequirement extends AbstractRequirement
 		newItem.setDisplayMatchedItemName(displayMatchedItemName);
 		newItem.setConditionToHide(conditionToHide);
 		newItem.questBank = questBank;
-		newItem.hadItemLastCheck = hadItemLastCheck;
 		newItem.isConsumedItem = isConsumedItem;
 		newItem.shouldAggregate = shouldAggregate;
 		newItem.setTooltip(getTooltip());
@@ -345,7 +371,7 @@ public class ItemRequirement extends AbstractRequirement
 			text.append(this.getQuantity()).append(" x ");
 		}
 
-		int itemID = findItemID(client, false);
+		int itemID = findItemID();
 		if (displayMatchedItemName && ((alternateItems.contains(itemID)) || id == itemID))
 		{
 			text.append(client.getItemDefinition(itemID).getName());
@@ -357,9 +383,9 @@ public class ItemRequirement extends AbstractRequirement
 
 		Color color = getColor(client, config);
 		lines.add(LineComponent.builder()
-			.left(text.toString())
-			.leftColor(color)
-			.build());
+				.left(text.toString())
+				.leftColor(color)
+				.build());
 		lines.addAll(getAdditionalText(client, true, config));
 		return lines;
 	}
@@ -378,6 +404,42 @@ public class ItemRequirement extends AbstractRequirement
 		text.append(getName());
 
 		return text.toString();
+	}
+
+	public void updateState(Client client)
+	{
+		ItemContainer equipped = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (equipped != null)
+		{
+			equipmentMatches = getMaxMatchingItems(client, equipped.getItems());
+			equipmentState = equipmentMatches >= quantity;
+		}
+
+		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+		if (inventory != null)
+		{
+			inventoryMatches = getMaxMatchingItems(client, inventory.getItems());
+			inventoryState = inventoryMatches >= quantity;
+		}
+
+		if (questBank != null)
+		{
+			bankMatches = getMaxMatchingItems(client, questBank.getBankItems().toArray(new Item[0]));
+			bankState = bankMatches >= quantity;
+		}
+	}
+
+	public boolean checkForSpecificItems(Client client, List<Item> items)
+	{
+		int matchesInItems = getMaxMatchingItems(client, items.toArray(new Item[0]));
+		return matchesInItems >= quantity;
+	}
+
+	// IDEA: Have a central event which lets you know diff on inventory
+	public void setAdditionalOptions(Requirement additionalOptions)
+	{
+		// TODO: Need to register / unregister through centralised ActiveRequirementsManager
+		this.additionalOptions = additionalOptions;
 	}
 
 	@Nullable
@@ -417,9 +479,9 @@ public class ItemRequirement extends AbstractRequirement
 	}
 
 	/** Find the first item that this requirement allows that the player has, or -1 if they don't have any item(s) */
-	private int findItemID(Client client, boolean checkConsideringSlotRestrictions)
+	private int findItemID()
 	{
-		int remainder = getRequiredItemDifference(client, id, checkConsideringSlotRestrictions, null);
+		int remainder = getNumberOfItemFound(id, null);
 		if (remainder <= 0)
 		{
 			return id;
@@ -431,7 +493,7 @@ public class ItemRequirement extends AbstractRequirement
 			{
 				remainder = quantity;
 			}
-			remainder -= (quantity - getRequiredItemDifference(client, alternate, checkConsideringSlotRestrictions, null));
+			remainder -= (quantity - getNumberOfItemFound(alternate, null));
 			if (remainder <= 0)
 			{
 				return alternate;
@@ -440,32 +502,102 @@ public class ItemRequirement extends AbstractRequirement
 		return -1;
 	}
 
-	public Color getColorConsideringBank(Client client, boolean checkConsideringSlotRestrictions,
-										 List<Item> bankItems, QuestHelperConfig config)
+	public boolean checkItems(Client client, List<Item> items)
+	{
+		return getMaxMatchingItems(client, items.toArray(new Item[0])) >= quantity;
+	}
+
+	public int checkTotalMatchesInContainers(Client client, ItemAndLastUpdated... containers)
+	{
+		// If exclusive, we need to check all containers together
+		if (exclusiveToOneItemType)
+		{
+			return getTotalMatchesInContainersIfExclusive(client, containers);
+		}
+
+		int totalFound = 0;
+
+		// Consideration: If any have changed, AND ItemRequirement requires unique item, then we do need to aggregate all the results
+		for (ItemAndLastUpdated container : containers)
+		{
+			ContainerState stateForItemInContainer = knownContainerStates.get(container.getContainerType());
+			// Generic container, always check
+			if (container.getContainerType() == TrackedContainers.UNDEFINED)
+			{
+				totalFound += getMaxMatchingItems(client, container.getItems());
+			}
+			else if (stateForItemInContainer.getLastCheckedTick() < container.getLastUpdated())
+			{
+				int matchesInContainer = getMaxMatchingItems(client, container.getItems());
+				boolean containerPasses = matchesInContainer >= quantity;
+				stateForItemInContainer.set(containerPasses, matchesInContainer, client.getTickCount());
+				totalFound += matchesInContainer;
+			}
+			else
+			{
+				totalFound += stateForItemInContainer.getMatchesFound();
+			}
+		}
+
+		return totalFound;
+	}
+
+	// This will ignore any defined conditions for what to consider, and will check across all
+	// containers passed in for the item
+	public boolean checkContainers(Client client, ItemAndLastUpdated... containers)
+	{
+		// If exclusive, we need to check all containers together
+		if (exclusiveToOneItemType)
+		{
+			return checkContainersIfExclusive(client, containers);
+		}
+
+		return checkTotalMatchesInContainers(client, containers) >= quantity;
+	}
+
+	private boolean checkContainersIfExclusive(Client client, ItemAndLastUpdated... containers)
+	{
+		int total = getTotalMatchesInContainersIfExclusive(client, containers);
+		return total >= quantity;
+	}
+
+	private int getTotalMatchesInContainersIfExclusive(Client client, ItemAndLastUpdated... containers)
+	{
+		List<Item> allItems = new ArrayList<>();
+		for (ItemAndLastUpdated container : containers)
+		{
+			allItems.addAll(List.of(container.getItems()));
+		}
+
+		return getMaxMatchingItems(client, allItems.toArray(new Item[0]));
+	}
+
+	public boolean checkWithBank(Client client)
+	{
+		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
+	}
+
+	public Color getColorConsideringBank(Client client, QuestHelperConfig config)
 	{
 		Color color = config.failColour();
 		if (!this.isActualItem())
 		{
 			color = Color.GRAY;
 		}
-		else if (this.check(client, checkConsideringSlotRestrictions))
+		else if (this.checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData()))
 		{
 			color = config.passColour();
 		}
 
-		if (color == config.failColour() && bankItems != null)
+		if (color == config.failColour() && this.checkContainers(client, QuestContainerManager.getBankData()))
 		{
-			if (check(client, false, bankItems))
-			{
-				color = Color.WHITE;
-			}
+			color = Color.WHITE;
 		}
 
 		return color;
 	}
 
-	protected ArrayList<LineComponent> getAdditionalText(Client client, boolean includeTooltip,
-														 QuestHelperConfig config)
+	protected ArrayList<LineComponent> getAdditionalText(Client client, boolean includeTooltip, QuestHelperConfig config)
 	{
 		Color equipColor = config.passColour();
 
@@ -474,125 +606,90 @@ public class ItemRequirement extends AbstractRequirement
 		if (this.isEquip())
 		{
 			String equipText = "(equipped)";
-			if (!this.check(client, true))
+			if (!equipmentState)
 			{
 				equipColor = config.failColour();
 			}
 			lines.add(LineComponent.builder()
-				.left(equipText)
-				.leftColor(equipColor)
-				.build());
+					.left(equipText)
+					.leftColor(equipColor)
+					.build());
 		}
 
 		if (includeTooltip && this.getTooltip() != null && !check(client))
 		{
 			lines.add(LineComponent.builder()
-				.left("- " + this.getTooltip())
-				.leftColor(Color.WHITE)
-				.build());
+					.left("- " + this.getTooltip())
+					.leftColor(Color.WHITE)
+					.build());
 		}
 
 		return lines;
 	}
 
-	public int getMatches(Client client)
+	@Override
+	public boolean check(Client client)
 	{
-		return getMatches(client, false, new ArrayList<>());
+		// TODO: Any functions which previously called with false should call checkContainers with inv + equipped instead
+		ItemAndLastUpdated[] containers = containersToCheckDefault();
+
+		return checkContainers(client, containers);
 	}
 
-	public int getMatches(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
+	private ItemAndLastUpdated[] containersToCheckDefault()
 	{
-		List<Item> allItems = new ArrayList<>(items);
-		if (questBank != null && questBank.getBankItems() != null)
-		{
-			allItems.addAll(questBank.getBankItems());
-		}
+		List<ItemAndLastUpdated> containers = new ArrayList<>();
+		containers.add(QuestContainerManager.getEquippedData());
 
-		int remainder = 0;
+		if (!equip) containers.add(QuestContainerManager.getInventoryData());
+		if (shouldCheckBank) containers.add(QuestContainerManager.getBankData());
 
-		List<Integer> ids = getAllIds();
-		for (int alternate : ids)
-		{
-			if (exclusiveToOneItemType)
-			{
-				remainder = quantity;
-			}
-			remainder += (quantity - getRequiredItemDifference(client, alternate, checkConsideringSlotRestrictions,
-				allItems));
-		}
-		return remainder;
+		return containers.toArray(new ItemAndLastUpdated[0]);
 	}
 
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
+	private int getMaxMatchingItems(Client client, Item[] items)
 	{
-		if (!shouldDisplayText(client)) return false;
+		// TODO: Is this right to do? Misleading on number for some scenarios
+		// Perhaps additionalOptions should have some text change instead assosciated
 		if (additionalOptions != null && additionalOptions.check(client))
 		{
-			return true;
+			return quantity;
 		}
 
-		List<Item> allItems = new ArrayList<>(items);
-		if (questBank != null && questBank.getBankItems() != null)
-		{
-			allItems.addAll(questBank.getBankItems());
-		}
+		List<Item> allItems = new ArrayList<>(List.of(items));
 
-		int remainder = quantity;
+		int foundQuantity = 0;
 
 		List<Integer> ids = getAllIds();
 		for (int alternate : ids)
 		{
+			int tmpQuantity = foundQuantity;
 			if (exclusiveToOneItemType)
 			{
-				remainder = quantity;
+				tmpQuantity = 0;
 			}
-			remainder -= (quantity - getRequiredItemDifference(client, alternate, checkConsideringSlotRestrictions,
-				allItems));
-			if (remainder <= 0)
-			{
-				hadItemLastCheck = true;
-				return true;
-			}
+			tmpQuantity += getNumberOfItemFound(alternate, allItems);
+
+			if (foundQuantity < tmpQuantity) foundQuantity = tmpQuantity;
 		}
-		hadItemLastCheck = false;
-		return false;
+
+		return foundQuantity;
 	}
 
 	/**
 	 * Get the difference between the required quantity for this requirement and the amount the client has.
 	 * Any value <= 0 indicates they have the required amount
 	 */
-	public int getRequiredItemDifference(Client client, int itemID, boolean checkConsideringSlotRestrictions,
-										 List<Item> items)
+	public int getNumberOfItemFound(int itemID, List<Item> items)
 	{
-		ItemContainer equipped = client.getItemContainer(InventoryID.EQUIPMENT);
-		int tempQuantity = quantity;
-
-		if (equipped != null)
-		{
-			tempQuantity -= getNumMatches(equipped, itemID);
-		}
-
-		if (!checkConsideringSlotRestrictions || !equip)
-		{
-			ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
-			if (inventory != null)
-			{
-				tempQuantity -= getNumMatches(inventory, itemID);
-			}
-		}
+		int tempQuantity = 0;
 
 		if (items != null)
 		{
-			tempQuantity -= getNumMatches(items, itemID);
+			tempQuantity += getNumMatches(items, itemID);
 		}
 
 		return tempQuantity;
-	}
-
-	public int getNumMatches(ItemContainer items, int itemID)
-	{
-		return getNumMatches(Arrays.asList(items.getItems().clone()), itemID);
 	}
 
 	public int getNumMatches(List<Item> items, int itemID)
@@ -600,41 +697,26 @@ public class ItemRequirement extends AbstractRequirement
 		if (isChargedItem)
 		{
 			return items.stream()
-				.filter(Objects::nonNull)
-				.filter(i -> i.getId() == itemID)
-				.mapToInt(i -> {
-					ItemWithCharge itemWithCharge = ItemWithCharge.findItem(i.getId());
-					if (itemWithCharge != null)
-					{
-						return itemWithCharge.getCharges();
-					}
+					.filter(Objects::nonNull)
+					.filter(i -> i.getId() == itemID)
+					.mapToInt(i -> {
+						ItemWithCharge itemWithCharge = ItemWithCharge.findItem(i.getId());
+						if (itemWithCharge != null)
+						{
+							return itemWithCharge.getCharges();
+						}
 
-					// Fall back to using the item's quantity
-					return i.getQuantity();
-				})
-				.sum();
+						// Fall back to using the item's quantity
+						return i.getQuantity();
+					})
+					.sum();
 		}
 
 		return items.stream()
-			.filter(Objects::nonNull)
-			.filter(i -> i.getId() == itemID)
-			.mapToInt(Item::getQuantity)
-			.sum();
-	}
-
-	public boolean check(Client client)
-	{
-		return check(client, false);
-	}
-
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions)
-	{
-		return check(client, checkConsideringSlotRestrictions, new ArrayList<>());
-	}
-
-	public boolean checkBank(Client client)
-	{
-		return InventorySlots.BANK.contains(client, item -> getDisplayItemIds().contains(item.getId()));
+				.filter(Objects::nonNull)
+				.filter(i -> i.getId() == itemID)
+				.mapToInt(Item::getQuantity)
+				.sum();
 	}
 
 	public List<Integer> getDisplayItemIds()

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -630,7 +630,6 @@ public class ItemRequirement extends AbstractRequirement
 	@Override
 	public boolean check(Client client)
 	{
-		// TODO: Any functions which previously called with false should call checkContainers with inv + equipped instead
 		ItemAndLastUpdated[] containers = containersToCheckDefault();
 
 		return checkContainers(client, containers);

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -36,7 +36,6 @@ import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.ManualRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.conditional.Conditions;
-import com.questhelper.requirements.util.InventorySlots;
 import com.questhelper.requirements.util.LogicType;
 import java.awt.Color;
 import java.util.*;
@@ -128,11 +127,11 @@ public class ItemRequirement extends AbstractRequirement
 
 	int equipmentMatches;
 
-	Map<TrackedContainers, ContainerState> knownContainerStates = new HashMap<>();
+	Map<TrackedContainers, ContainerStateForRequirement> knownContainerStates = new HashMap<>();
 	{
 		for (TrackedContainers value : TrackedContainers.values())
 		{
-			knownContainerStates.put(value, new ContainerState());
+			knownContainerStates.put(value, new ContainerStateForRequirement());
 		}
 	}
 
@@ -525,7 +524,7 @@ public class ItemRequirement extends AbstractRequirement
 			{
 				continue;
 			}
-			ContainerState stateForItemInContainer = knownContainerStates.get(container.getContainerType());
+			ContainerStateForRequirement stateForItemInContainer = knownContainerStates.get(container.getContainerType());
 			// Generic container, always check
 			if (container.getContainerType() == TrackedContainers.UNDEFINED)
 			{
@@ -534,8 +533,7 @@ public class ItemRequirement extends AbstractRequirement
 			else if (stateForItemInContainer.getLastCheckedTick() < container.getLastUpdated())
 			{
 				int matchesInContainer = getMaxMatchingItems(client, container.getItems());
-				boolean containerPasses = matchesInContainer >= quantity;
-				stateForItemInContainer.set(containerPasses, matchesInContainer, client.getTickCount());
+				stateForItemInContainer.set(matchesInContainer, client.getTickCount());
 				totalFound += matchesInContainer;
 			}
 			else

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -27,6 +27,8 @@
 package com.questhelper.requirements.item;
 
 import com.questhelper.QuestHelperConfig;
+import com.questhelper.managers.ItemAndLastUpdated;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.questhelpers.QuestUtil;
 import com.questhelper.requirements.util.LogicType;
 import java.awt.Color;
@@ -98,58 +100,48 @@ public class ItemRequirements extends ItemRequirement
 	}
 
 	@Override
+	public boolean checkContainers(Client client, ItemAndLastUpdated... containers)
+	{
+		Predicate<ItemRequirement> predicate = r -> r.checkContainers(client, containers);
+		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
+		return logicType.compare(successes, itemRequirements.size());
+	}
+
+
+
+	@Override
 	public boolean check(Client client)
 	{
-		return check(client, false);
-	}
-
-	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions)
-	{
-		Predicate<ItemRequirement> predicate = r -> r.check(client, checkConsideringSlotRestrictions);
+		Predicate<ItemRequirement> predicate = r -> r.check(client);
 		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
-		hadItemLastCheck = logicType.compare(successes, itemRequirements.size());
-		return hadItemLastCheck;
-	}
-
-	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
-	{
-		Predicate<ItemRequirement> predicate = r -> r.check(client, checkConsideringSlotRestrictions, items);
-		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
-		hadItemLastCheck = logicType.compare(successes, itemRequirements.size());
-		return hadItemLastCheck;
+		return logicType.compare(successes, itemRequirements.size());
 	}
 
 	@Override
 	public Color getColor(Client client, QuestHelperConfig config)
 	{
-		return this.check(client, true) ? config.passColour() : config.failColour();
+		return this.check(client) ? config.passColour() : config.failColour();
 	}
 
 	@Override
-	public Color getColorConsideringBank(Client client, boolean checkConsideringSlotRestrictions,
-										 List<Item> bankItems, QuestHelperConfig config)
+	public Color getColorConsideringBank(Client client, QuestHelperConfig config)
 	{
-		Color color = config.failColour();
+		Color colour = config.failColour();
 		if (!this.isActualItem() && this.getItemRequirements() == null)
 		{
-			color = Color.GRAY;
+			colour = Color.GRAY;
 		}
-		else if (this.check(client, checkConsideringSlotRestrictions))
+		else if (checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData()))
 		{
-			color = config.passColour();
+			colour = config.passColour();
 		}
 
-		if (color == config.failColour() && bankItems != null)
+		if (colour == config.failColour() && checkWithBank(client))
 		{
-			if (check(client, false, bankItems))
-			{
-				color = Color.WHITE;
-			}
+			colour = Color.WHITE;
 		}
 
-		return color;
+		return colour;
 	}
 
 	@Override
@@ -198,8 +190,8 @@ public class ItemRequirements extends ItemRequirement
 	}
 
 	@Override
-	public boolean checkBank(Client client)
+	public boolean checkWithBank(Client client)
 	{
-		return logicType.test(getItemRequirements().stream(), item -> item.checkBank(client) || item.check(client, false));
+		return logicType.test(getItemRequirements().stream(), item -> item.checkWithBank(client));
 	}
 }

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -107,8 +107,6 @@ public class ItemRequirements extends ItemRequirement
 		return logicType.compare(successes, itemRequirements.size());
 	}
 
-
-
 	@Override
 	public boolean check(Client client)
 	{

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -124,6 +124,14 @@ public class ItemRequirements extends ItemRequirement
 	}
 
 	@Override
+	public boolean checkItems(Client client, List<Item> items)
+	{
+		Predicate<ItemRequirement> predicate = r -> r.checkItems(client, items);
+		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
+		return logicType.compare(successes, itemRequirements.size());
+	}
+
+	@Override
 	public Color getColorConsideringBank(Client client, QuestHelperConfig config)
 	{
 		Color colour = config.failColour();

--- a/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
@@ -28,10 +28,7 @@ import com.questhelper.collections.KeyringCollection;
 import com.questhelper.QuestHelperConfig;
 import com.questhelper.requirements.runelite.RuneliteRequirement;
 import java.awt.Color;
-import java.util.ArrayList;
-import java.util.List;
 import net.runelite.api.Client;
-import net.runelite.api.Item;
 import net.runelite.api.ItemID;
 import net.runelite.client.config.ConfigManager;
 
@@ -85,6 +82,7 @@ public class KeyringRequirement extends ItemRequirement
 		newItem.setHighlightInInventory(highlightInInventory);
 		newItem.setDisplayMatchedItemName(isDisplayMatchedItemName());
 		newItem.setConditionToHide(getConditionToHide());
+		newItem.setShouldCheckBank(isShouldCheckBank());
 		newItem.setQuestBank(getQuestBank());
 		newItem.setTooltip(getTooltip());
 		newItem.setUrlSuffix(getUrlSuffix());
@@ -93,7 +91,7 @@ public class KeyringRequirement extends ItemRequirement
 	}
 
 	@Override
-	public boolean check(Client client, boolean checkConsideringSlotRestrictions, List<Item> items)
+	public boolean check(Client client)
 	{
 		boolean match = runeliteRequirement.check(client);
 
@@ -102,29 +100,20 @@ public class KeyringRequirement extends ItemRequirement
 			return true;
 		}
 
-		return super.check(client, checkConsideringSlotRestrictions, items);
+		return super.check(client);
 	}
 
 	@Override
-	public Color getColorConsideringBank(Client client, boolean checkConsideringSlotRestrictions,
-										 List<Item> bankItems, QuestHelperConfig config)
+	public Color getColorConsideringBank(Client client, QuestHelperConfig config)
 	{
-		Color color = config.failColour();
+		Color color;
 		if (!this.isActualItem())
 		{
 			color = Color.GRAY;
 		}
-		else if (super.check(client, checkConsideringSlotRestrictions, new ArrayList<>()))
+		else
 		{
-			color = config.passColour();
-		}
-
-		if (color == config.failColour() && bankItems != null)
-		{
-			if (super.check(client, false, bankItems))
-			{
-				color = Color.WHITE;
-			}
+			color = super.getColorConsideringBank(client, config);
 		}
 
 		if (color == config.failColour())
@@ -136,6 +125,7 @@ public class KeyringRequirement extends ItemRequirement
 				color = Color.ORANGE;
 			}
 		}
+
 		return color;
 	}
 

--- a/src/main/java/com/questhelper/requirements/item/TrackedContainers.java
+++ b/src/main/java/com/questhelper/requirements/item/TrackedContainers.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.requirements.item;
+
+public enum TrackedContainers
+{
+    EQUIPPED,
+    INVENTORY,
+    BANK,
+    UNDEFINED
+}

--- a/src/main/java/com/questhelper/requirements/var/VarComparisonRequirement.java
+++ b/src/main/java/com/questhelper/requirements/var/VarComparisonRequirement.java
@@ -24,20 +24,15 @@
  */
 package com.questhelper.requirements.var;
 
-import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.AbstractRequirement;
 import com.questhelper.requirements.util.Operation;
-import java.math.BigInteger;
 import java.util.Locale;
-import java.util.function.Predicate;
-import java.util.function.ToIntBiFunction;
 
 import com.questhelper.util.Utils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
-import net.runelite.client.util.Text;
 
 import javax.annotation.Nonnull;
 

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.questhelper.bank.QuestBank;
 import com.questhelper.QuestHelperPlugin;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.steps.widget.AbstractWidgetHighlight;
 import com.questhelper.tools.QuestHelperWorldMapPoint;
@@ -820,7 +821,7 @@ public class DetailedQuestStep extends QuestStep
 			&& ((ItemRequirement) requirement).shouldRenderItemHighlights(client)
 			&& ((!considerBankForItemHighlight && !requirement.check(client)) ||
 			(considerBankForItemHighlight &&
-				!((ItemRequirement) requirement).check(client, false, questBank.getBankItems())));
+				!((ItemRequirement) requirement).checkWithBank(client)));
 	}
 
 	@Override
@@ -901,7 +902,7 @@ public class DetailedQuestStep extends QuestStep
 		return requirements.stream().anyMatch((item) ->  item instanceof ItemRequirement &&
 			type == MenuAction.GROUND_ITEM_THIRD_OPTION &&
 			((ItemRequirement) item).getAllIds().contains(itemID) &&
-			!((ItemRequirement) item).check(client, false, questBank.getBankItems()) &&
+			!((ItemRequirement) item).checkWithBank(client) &&
 			option.equals("Take"));
 	}
 

--- a/src/test/java/com/questhelper/MockedTest.java
+++ b/src/test/java/com/questhelper/MockedTest.java
@@ -92,7 +92,7 @@ public abstract class MockedTest extends MockedTestBase
 	protected PlayerStateManager playerStateManager = Mockito.mock(PlayerStateManager.class);
 
 	@Bind
-	protected QuestHelperPlugin questHelperPlugin = Mockito.mock(QuestHelperPlugin.class);
+	protected QuestHelperPlugin questHelperPlugin = Mockito.spy(QuestHelperPlugin.class);
 
 	@Bind
 	protected ClientToolbar clientToolbar = Mockito.mock(ClientToolbar.class);

--- a/src/test/java/com/questhelper/helpers/quests/thecurseofarrav/KeysAndLeversTest.java
+++ b/src/test/java/com/questhelper/helpers/quests/thecurseofarrav/KeysAndLeversTest.java
@@ -37,6 +37,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Scene;
 import net.runelite.api.Tile;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ItemContainerChanged;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -105,6 +106,8 @@ public class KeysAndLeversTest extends MockedTest
 			{}
 		});
 		when(client.getScene()).thenReturn(mockedScene);
+
+		this.questHelperPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.INVENTORY.getId(), mockedItemContainer));
 
 		this.injector.injectMembers(helper);
 		helper.setInjector(injector);

--- a/src/test/java/com/questhelper/helpers/quests/thepathofglouphrie/SolutionTest.java
+++ b/src/test/java/com/questhelper/helpers/quests/thepathofglouphrie/SolutionTest.java
@@ -126,7 +126,6 @@ public class SolutionTest extends MockedTest
 	public void testNotSolvable(List<Item> items, int puzzle1SolutionValue, int puzzle2SolutionValue)
 	{
 		solution.load(client, items, puzzle1SolutionValue, puzzle2SolutionValue, discs, valueToRequirement, valueToDoubleDiscRequirement, discToValue, valuePossibleSingleDiscExchangesRequirements);
-
 		assertFalse(solution.isGood());
 	}
 


### PR DESCRIPTION
This PR intends to improve the efficiency of ItemRequirement checks by including some caching where possible. I've tried to introduce the concept of cached containers (inventory, equipped, bank), which I hope will in the future make it easier for us to include new container concepts such as the rune pouch, POH storage, etc.

I've checked how long the checks take for the sidebar each tick for the Check all items helpers as it's the largest in terms of requirements. Generally across 1000 ticks the new method while cached is 2x faster on average. I've included a 100s sample below with in the cache, with the average for it being:

```
old: 3266746 ns
new: 1408209 ns
```
[newDiff.txt](https://github.com/user-attachments/files/17851199/newDiff.txt)
[oldDiff.txt](https://github.com/user-attachments/files/17851200/oldDiff.txt)

We're not dealing with massive values in general, though I've also not encountered the lag spikes on my computer, so I'm going on the assumption for lower spec devices this will hopefully make a bigger difference.

I need to still add in some better comments and preferably some tests for this going forwards.