### PR TITLE
fix: speed up sidepanel responsiveness to quest state changes

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -231,7 +231,9 @@ public class QuestHelperPlugin extends Plugin
 		GlobalFakeObjects.setInitialized(false);
 	}
 
-	@Subscribe
+	// Run our base game tick checks later than other Quest Helper checks
+	// This allows steps/requirements/conditions to run their checks first before we try to update the side panel
+	@Subscribe(priority=-1.0f)
 	public void onGameTick(GameTick event)
 	{
 		questBankManager.loadInitialStateFromConfig(client);


### PR DESCRIPTION
When progressing through a quest, the sidepanel is currently a bit slow at progressing.

This PR tries to avoid this by ensuring the event that triggers sidepanel updates is done at the end of the GameTick event

Before:

https://github.com/user-attachments/assets/f5c77bcc-dbde-475f-a31a-e7880e7650ba

After:

https://github.com/user-attachments/assets/80035f8b-ceb9-45a9-b6dd-c159ee04c9e8


This is probably one of these things that'd be good to get some testing with to ensure it doesn't silently break something