### PR TITLE
fix: incorrect expected items for raw snails in "In Aid of the Myreque"

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/inaidofthemyreque/FillBurghCrate.java
+++ b/src/main/java/com/questhelper/helpers/quests/inaidofthemyreque/FillBurghCrate.java
@@ -46,7 +46,7 @@ public class FillBurghCrate extends DetailedQuestStep
 		tinderbox3 = new ItemRequirement("Tinderbox", ItemID.TINDERBOX, 3);
 		bronzeAxe10 = new ItemRequirement("Bronze axe", ItemID.BRONZE_AXE, 10);
 		rawSnailsOrMackerel = new ItemRequirement("Raw mackerel or raw snail meat (random for each player)", ItemID.RAW_MACKEREL, 10);
-		rawSnailsOrMackerel.addAlternates(ItemID.THIN_SNAIL_MEAT, ItemID.LEAN_SNAIL_MEAT, ItemID.FAT_SNAIL_MEAT);
+		rawSnailsOrMackerel.addAlternates(ItemID.THIN_SNAIL, ItemID.LEAN_SNAIL, ItemID.FAT_SNAIL);
 		rawSnailsOrMackerel.setDisplayMatchedItemName(true);
 	}
 
@@ -85,7 +85,7 @@ public class FillBurghCrate extends DetailedQuestStep
 			else
 			{
 				this.setText("Fill the crate with 3 tinderboxes, 10 bronze axes, and 10 raw snails (can be lean, thin or fat).");
-				rawSnailsOrMackerel.setDisplayItemId(ItemID.FAT_SNAIL_MEAT);
+				rawSnailsOrMackerel.setDisplayItemId(ItemID.FAT_SNAIL);
 				this.setRequirements(Arrays.asList(crate, tinderbox3, bronzeAxe10, rawSnailsOrMackerel));
 			}
 		}

--- a/src/main/java/com/questhelper/helpers/quests/inaidofthemyreque/InAidOfTheMyreque.java
+++ b/src/main/java/com/questhelper/helpers/quests/inaidofthemyreque/InAidOfTheMyreque.java
@@ -233,8 +233,8 @@ public class InAidOfTheMyreque extends BasicQuestHelper
 		planks11 = new ItemRequirement("Plank", ItemID.PLANK, 11);
 		nails44 = new ItemRequirement("Any nails", ItemCollections.NAILS, 44);
 		swampPaste = new ItemRequirement("Swamp paste", ItemID.SWAMP_PASTE, 2);
-		snails10 = new ItemRequirement("Raw snail", ItemID.THIN_SNAIL_MEAT);
-		snails10.addAlternates(ItemID.FAT_SNAIL_MEAT, ItemID.LEAN_SNAIL_MEAT);
+		snails10 = new ItemRequirement("Raw snail", ItemID.THIN_SNAIL);
+		snails10.addAlternates(ItemID.FAT_SNAIL, ItemID.LEAN_SNAIL);
 		mackerel10 = new ItemRequirement("Raw mackerel", ItemID.RAW_MACKEREL, 10);
 		rawMackerelOrSnail10 = new ItemRequirements("10 Raw mackerel or raw snail meat (random for each player)",
 			mackerel10,


### PR DESCRIPTION
fixes #1859 

Proposed fix to the issue in which cooked snail meat items are expected by the helper instead of their raw counterparts.