### PR TITLE
fix: ensure last step is reset on quest shutdown

### DIFF
--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -36,6 +36,7 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.steps.QuestStep;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.QuestState;
@@ -59,6 +60,7 @@ import java.util.stream.Collectors;
  * Responsible for initializing, updating, and shutting down quests.
  */
 @Singleton
+@Slf4j
 public class QuestManager
 {
 	@Inject
@@ -320,32 +322,6 @@ public class QuestManager
 		}
 	}
 
-	/**
-	 * Shuts down the quest from the sidebar.
-	 * Unregisters the quest and removes it from the panel.
-	 */
-	public void shutDownQuestFromSidebar()
-	{
-		if (selectedQuest != null)
-		{
-			selectedQuest.shutDown();
-			questBankManager.shutDownQuest();
-			SwingUtilities.invokeLater(panel::removeQuest);
-			unregisterQuestFromEventBus(selectedQuest);
-
-			// If closing the item checking helper and should still check in background, start it back up in background
-			if (selectedQuest.getQuest() == QuestHelperQuest.CHECK_ITEMS && config.highlightItemsBackground())
-			{
-				selectedQuest = null;
-				startUpBackgroundQuest(QuestHelperQuest.CHECK_ITEMS.getName());
-			}
-			else
-			{
-				selectedQuest = null;
-			}
-		}
-	}
-
 	private void shutDownPreviousQuest()
 	{
 		shutDownQuest(true);
@@ -370,7 +346,17 @@ public class QuestManager
 			questBankManager.shutDownQuest();
 			SwingUtilities.invokeLater(panel::removeQuest);
 			unregisterQuestFromEventBus(selectedQuest);
-			selectedQuest = null;
+
+			// If closing the item checking helper and should still check in background, start it back up in background
+			if (selectedQuest.getQuest() == QuestHelperQuest.CHECK_ITEMS && config.highlightItemsBackground())
+			{
+				selectedQuest = null;
+				startUpBackgroundQuest(QuestHelperQuest.CHECK_ITEMS.getName());
+			}
+			else
+			{
+				selectedQuest = null;
+			}
 		}
 	}
 

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -358,6 +358,8 @@ public class QuestManager
 				selectedQuest = null;
 			}
 		}
+
+		this.lastStep = null;
 	}
 
 	public void activateShortestPath()

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -375,9 +375,10 @@ public class QuestOverviewPanel extends JPanel
 		revalidate();
 	}
 
+	/// The quest helper's X is clicked
 	private void closeHelper()
 	{
-		questManager.shutDownQuestFromSidebar();
+		questManager.shutDownQuest(false);
 	}
 
 	void updateCollapseText()


### PR DESCRIPTION
Previously, when a quest was shut down, we did not reset the `lastStep` variable in `QuestManager`

The `lastStep` variable is used to check if the highlight in the quest helper's side panel should change, and if we don't reset it, then stop & start the same quest, we'll have an active but unhighlighted step.
This PR prevents this.

The first commit consolidates all public `QuestManager` "shut down quest" functions into a single one to ensure I don't have to copy paste the `lastStep` logic elsewhere. It would be good to take an extra look at this to ensure I have missed anything where maybe the background helper should actually remain closed if a quest is shut down in a special way. I tested this to the best of my ability (starting/stopping the "Check all items" quest & other quests, while toggling the "Highlight all items" option on and off) and everything seems to work as expected.
