### PR TITLE
fix: scroll to top of quest after the quest is selected

### DIFF
--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -579,6 +579,8 @@ public class QuestHelperPanel extends PluginPanel
 		questOverviewPanel.addQuest(quest, isActive);
 		questActive = true;
 
+		SwingUtilities.invokeLater(() -> scrollableContainer.getVerticalScrollBar().setValue(0));
+
 		repaint();
 		revalidate();
 	}


### PR DESCRIPTION
I don't know of a better way to do this in Swing, but this worked and is barely noticeable and a big improvement over every new quest scrolling to a random spot towards the end of the quest. Not sure what introduced it originally, I tried disabling a bunch of JTextArea behaviours but nothing changed.