### PR TITLE
Bank improvements

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -29,6 +29,7 @@ import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.questhelper.bank.banktab.BankTabItems;
+import com.questhelper.bank.banktab.PotionStorage;
 import com.questhelper.managers.*;
 import com.questhelper.panel.QuestHelperPanel;
 import com.questhelper.questhelpers.QuestHelper;
@@ -72,6 +73,7 @@ import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.bank.BankSearch;
+import net.runelite.client.plugins.banktags.tabs.Layout;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
@@ -156,6 +158,9 @@ public class QuestHelperPlugin extends Plugin
 	PlayerStateManager playerStateManager;
 
 	@Inject
+	PotionStorage potionStorage;
+
+	@Inject
 	public SkillIconManager skillIconManager;
 
 	private QuestHelperPanel panel;
@@ -178,6 +183,7 @@ public class QuestHelperPlugin extends Plugin
 	{
 		questBankManager.startUp(injector, eventBus);
 		QuestContainerManager.getBankData().setSpecialMethodToObtainItems(() -> questBankManager.getBankItems().toArray(new Item[0]));
+		QuestContainerManager.getPotionData().setSpecialMethodToObtainItems(() -> potionStorage.getItems());
 		eventBus.register(worldMapAreaManager);
 
 		injector.injectMembers(playerStateManager);

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -292,6 +292,7 @@ public class QuestHelperPlugin extends Plugin
 			GlobalFakeObjects.createNpcs(client, runeliteObjectManager, configManager, config);
 			newVersionManager.updateChatWithNotificationIfNewVersion();
 			questBankManager.setUnknownInitialState();
+			potionStorage.cachePotions = true;
 			clientThread.invokeAtTickEnd(() -> {
 				questManager.setupRequirements();
 				questManager.setupOnLogin();

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -73,7 +73,6 @@ import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.bank.BankSearch;
-import net.runelite.client.plugins.banktags.tabs.Layout;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
@@ -183,7 +182,6 @@ public class QuestHelperPlugin extends Plugin
 	{
 		questBankManager.startUp(injector, eventBus);
 		QuestContainerManager.getBankData().setSpecialMethodToObtainItems(() -> questBankManager.getBankItems().toArray(new Item[0]));
-		QuestContainerManager.getPotionData().setSpecialMethodToObtainItems(() -> potionStorage.getItems());
 		eventBus.register(worldMapAreaManager);
 
 		injector.injectMembers(playerStateManager);
@@ -292,7 +290,7 @@ public class QuestHelperPlugin extends Plugin
 			GlobalFakeObjects.createNpcs(client, runeliteObjectManager, configManager, config);
 			newVersionManager.updateChatWithNotificationIfNewVersion();
 			questBankManager.setUnknownInitialState();
-			potionStorage.cachePotions = true;
+			potionStorage.updateCachedPotions = true;
 			clientThread.invokeAtTickEnd(() -> {
 				questManager.setupRequirements();
 				questManager.setupOnLogin();

--- a/src/main/java/com/questhelper/bank/banktab/BankTabItem.java
+++ b/src/main/java/com/questhelper/bank/banktab/BankTabItem.java
@@ -67,7 +67,7 @@ public class BankTabItem
 		this.text = item.getName();
 		this.itemIDs = Collections.singletonList(item.getId());
 		this.details = item.getTooltip();
-		this.displayID = null;
+		this.displayID = -1;
 		this.itemRequirement = item;
 	}
 }

--- a/src/main/java/com/questhelper/bank/banktab/PotionStorage.java
+++ b/src/main/java/com/questhelper/bank/banktab/PotionStorage.java
@@ -167,42 +167,6 @@ public class PotionStorage
         return items.toArray(new Item[0]);
     }
 
-    int matches(Set<Integer> bank, int itemId)
-    {
-        if (potions == null)
-        {
-            return -1;
-        }
-
-        for (Potion potion : potions)
-        {
-            if (potion == null)
-            {
-                continue;
-            }
-
-            var potionEnum = potion.potionEnum;
-            int potionItemId1 = potionEnum.getIntValue(1);
-            int potionItemId2 = potionEnum.getIntValue(2);
-            int potionItemId3 = potionEnum.getIntValue(3);
-            int potionItemId4 = potionEnum.getIntValue(4);
-
-            if (potionItemId1 == itemId || potionItemId2 == itemId || potionItemId3 == itemId || potionItemId4 == itemId)
-            {
-                int potionStoreItem = potionEnum.getIntValue(potion.withdrawDoses);
-
-                if (log.isDebugEnabled())
-                {
-                    log.debug("Item {} matches a potion from potion store {}", itemId, itemManager.getItemComposition(potionStoreItem).getName());
-                }
-
-                return potionStoreItem;
-            }
-        }
-
-        return -1;
-    }
-
     int count(int itemId)
     {
         if (potions == null)
@@ -239,36 +203,7 @@ public class PotionStorage
         return -1;
     }
 
-    @Subscribe
-    public void onMenuOptionClicked(MenuOptionClicked event)
-    {
-        // Update widget index of the menu so withdraws work in laid out tabs.
-        if (event.getParam1() == ComponentID.BANK_ITEM_CONTAINER && questBankTabInterface.isQuestTabActive())
-        {
-            MenuEntry menu = event.getMenuEntry();
-            Widget w = menu.getWidget();
-            if (w != null && w.getItemId() > -1)
-            {
-                ItemContainer bank = client.getItemContainer(InventoryID.BANK);
-                int idx = bank.find(w.getItemId());
-                if (idx > -1 && menu.getParam0() != idx)
-                {
-                    menu.setParam0(idx);
-                    return;
-                }
-
-                idx = find(w.getItemId());
-                if (idx > -1)
-                {
-                    prepareWidgets();
-                    menu.setParam1(ComponentID.BANK_POTIONSTORE_CONTENT);
-                    menu.setParam0(idx * COMPONENTS_PER_POTION);
-                }
-            }
-        }
-    }
-
-    void prepareWidgets()
+    public void prepareWidgets()
     {
         // if the potion store hasn't been opened yet, the client components won't have been made yet.
         // they need to exist for the click to work correctly.

--- a/src/main/java/com/questhelper/bank/banktab/PotionStorage.java
+++ b/src/main/java/com/questhelper/bank/banktab/PotionStorage.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2024, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.bank.banktab;
+
+import java.util.*;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.*;
+import net.runelite.api.events.ClientTick;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.WidgetClosed;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetType;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.bank.BankSearch;
+
+class Potion
+{
+    EnumComposition potionEnum;
+    int itemId;
+    int doses;
+    int withdrawDoses;
+}
+
+@Singleton
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+@Slf4j
+public class PotionStorage
+{
+    static final int BANKTAB_POTIONSTORE = 15;
+    static final int COMPONENTS_PER_POTION = 5;
+
+    private final Client client;
+    private final ItemManager itemManager;
+    private final BankSearch bankSearch;
+
+    private Potion[] potions;
+    boolean cachePotions;
+    private boolean layout;
+    private Set<Integer> potionStoreVars;
+
+    @Setter
+    private QuestBankTabInterface questBankTabInterface;
+
+    @Subscribe
+    public void onClientTick(ClientTick event)
+    {
+        if (cachePotions)
+        {
+//            log.debug("Rebuilding potions");
+            cachePotions = false;
+            rebuildPotions();
+
+            Widget w = client.getWidget(ComponentID.BANK_POTIONSTORE_CONTENT);
+            if (w != null && potionStoreVars == null)
+            {
+                // cache varps that the potion store rebuilds on
+                int[] trigger = w.getVarTransmitTrigger();
+                potionStoreVars = new HashSet<>();
+                Arrays.stream(trigger).forEach(potionStoreVars::add);
+            }
+
+            if (layout)
+            {
+                layout = false;
+                if (questBankTabInterface.isQuestTabActive())
+                {
+                    bankSearch.layoutBank();
+                }
+            }
+        }
+    }
+
+    // Use varp change event instead of a widget change listener so that we can recache the potions prior to
+    // the cs2 vm running.
+    @Subscribe
+    public void onVarbitChanged(VarbitChanged varbitChanged)
+    {
+        if (potionStoreVars != null && potionStoreVars.contains(varbitChanged.getVarpId()))
+        {
+            cachePotions = true;
+            layout = true; // trigger a bank rebuild as the qty has changed
+        }
+    }
+
+    @Subscribe
+    public void onWidgetClosed(WidgetClosed event)
+    {
+        if (event.getGroupId() == InterfaceID.BANK && event.isUnload())
+        {
+            log.debug("Invalidating potions");
+            potions = null;
+        }
+    }
+
+    private void rebuildPotions()
+    {
+        var potionStorePotions = client.getEnum(EnumID.POTIONSTORE_POTIONS);
+        var potionStoreUnfinishedPotions = client.getEnum(EnumID.POTIONSTORE_UNFINISHED_POTIONS);
+        potions = new Potion[potionStorePotions.size() + potionStoreUnfinishedPotions.size()];
+        int potionsIdx = 0;
+        for (EnumComposition e : new EnumComposition[]{potionStorePotions, potionStoreUnfinishedPotions})
+        {
+            for (int potionEnumId : e.getIntVals())
+            {
+                var potionEnum = client.getEnum(potionEnumId);
+                client.runScript(ScriptID.POTIONSTORE_DOSES, potionEnumId);
+                int doses = client.getIntStack()[0];
+                client.runScript(ScriptID.POTIONSTORE_WITHDRAW_DOSES, potionEnumId);
+                int withdrawDoses = client.getIntStack()[0];
+
+                if (doses > 0 && withdrawDoses > 0)
+                {
+                    Potion p = new Potion();
+                    p.potionEnum = potionEnum;
+                    p.itemId = potionEnum.getIntValue(withdrawDoses);
+                    p.doses = doses;
+                    p.withdrawDoses = withdrawDoses;
+                    potions[potionsIdx] = p;
+
+                    if (log.isDebugEnabled())
+                    {
+//                        log.debug("Potion store has {} doses of {}", p.doses, itemManager.getItemComposition(p.itemId).getName());
+                    }
+                }
+
+                ++potionsIdx;
+            }
+        }
+
+        for (Potion potion : potions)
+        {
+            if (potion != null)
+            {
+                String name = itemManager.getItemComposition(potion.itemId).getName();
+                if (name.contains("Hunter"))
+                {
+//                    System.out.println(itemManager.getItemComposition(potion.itemId).getName());
+//                    System.out.println(potion.doses);
+                }
+            }
+        }
+//        System.out.println(Arrays.toString(potions));
+    }
+
+    public Item[] getItems()
+    {
+        if (potions == null)
+        {
+            return new Item[0];
+        }
+
+        List<Item> items = new ArrayList<>();
+
+        for (Potion potion : potions)
+        {
+            var potionEnum = potion.potionEnum;
+            // TODO: An issue due to potentially wanting a specific potion, or to default to full potion
+            int potionItemId = potionEnum.getIntValue(potion.withdrawDoses);
+            int quantity = potion.doses / potion.withdrawDoses;
+            items.add(new Item(potionItemId, quantity));
+        }
+
+        return items.toArray(new Item[0]);
+    }
+
+    int matches(Set<Integer> bank, int itemId)
+    {
+        if (potions == null)
+        {
+            return -1;
+        }
+
+        for (Potion potion : potions)
+        {
+            if (potion == null)
+            {
+                continue;
+            }
+
+            var potionEnum = potion.potionEnum;
+            int potionItemId1 = potionEnum.getIntValue(1);
+            int potionItemId2 = potionEnum.getIntValue(2);
+            int potionItemId3 = potionEnum.getIntValue(3);
+            int potionItemId4 = potionEnum.getIntValue(4);
+
+            if (potionItemId1 == itemId || potionItemId2 == itemId || potionItemId3 == itemId || potionItemId4 == itemId)
+            {
+                int potionStoreItem = potionEnum.getIntValue(potion.withdrawDoses);
+
+                if (log.isDebugEnabled())
+                {
+                    log.debug("Item {} matches a potion from potion store {}", itemId, itemManager.getItemComposition(potionStoreItem).getName());
+                }
+
+                return potionStoreItem;
+            }
+        }
+
+        return -1;
+    }
+
+    int count(int itemId)
+    {
+        if (potions == null)
+        {
+            return 0;
+        }
+
+        for (Potion potion : potions)
+        {
+            if (potion != null && potion.itemId == itemId)
+            {
+                return potion.doses / potion.withdrawDoses;
+            }
+        }
+        return 0;
+    }
+
+    int find(int itemId)
+    {
+        if (potions == null)
+        {
+            return -1;
+        }
+
+        int potionIdx = 0;
+        for (Potion potion : potions)
+        {
+            ++potionIdx;
+            if (potion != null && potion.itemId == itemId)
+            {
+                return potionIdx - 1;
+            }
+        }
+        return -1;
+    }
+
+    @Subscribe
+    public void onMenuOptionClicked(MenuOptionClicked event)
+    {
+        // Update widget index of the menu so withdraws work in laid out tabs.
+        if (event.getParam1() == ComponentID.BANK_ITEM_CONTAINER && questBankTabInterface.isQuestTabActive())
+        {
+            MenuEntry menu = event.getMenuEntry();
+            Widget w = menu.getWidget();
+            if (w != null && w.getItemId() > -1)
+            {
+                ItemContainer bank = client.getItemContainer(InventoryID.BANK);
+                int idx = bank.find(w.getItemId());
+                if (idx > -1 && menu.getParam0() != idx)
+                {
+                    menu.setParam0(idx);
+                    return;
+                }
+
+                idx = find(w.getItemId());
+                if (idx > -1)
+                {
+                    prepareWidgets();
+                    menu.setParam1(ComponentID.BANK_POTIONSTORE_CONTENT);
+                    menu.setParam0(idx * COMPONENTS_PER_POTION);
+                }
+            }
+        }
+    }
+
+    void prepareWidgets()
+    {
+        // if the potion store hasn't been opened yet, the client components won't have been made yet.
+        // they need to exist for the click to work correctly.
+        Widget potStoreContent = client.getWidget(ComponentID.BANK_POTIONSTORE_CONTENT);
+        if (potStoreContent.getChildren() == null)
+        {
+            int childIdx = 0;
+            for (int i = 0; i < potions.length; ++i) // NOPMD: ForLoopCanBeForeach
+            {
+                for (int j = 0; j < COMPONENTS_PER_POTION; ++j)
+                {
+                    potStoreContent.createChild(childIdx++, WidgetType.GRAPHIC);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/questhelper/bank/banktab/PotionStorage.java
+++ b/src/main/java/com/questhelper/bank/banktab/PotionStorage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Adam <Adam@sigterm.info>
+ * Copyright (c) 2025, Zoinkwiz <https://github.com/Zoinkwiz>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -502,7 +502,7 @@ public class QuestBankTab
 			// Effectively avoid dragging
 			c.setDragDeadTime(1000);
 
-			c.setName("<col=ff9040>" + def.getName() + "</col>");
+			c.setName("<col=ff9040>" + bankTabItem.getText() + "</col>");
 			c.clearActions();
 
 			// Jagex Placeholder
@@ -753,10 +753,10 @@ public class QuestBankTab
 				.append(Text.removeTags(bankTabItem.getText()))
 				.append(".");
 
-		if (!bankTabItem.getText().isEmpty())
+		if (!bankTabItem.getDetails().isEmpty())
 		{
 			message.append(ChatColorType.NORMAL)
-					.append(" " + bankTabItem.getText() + ".");
+					.append(" " + bankTabItem.getDetails() + ".");
 		}
 
 		chatMessageManager.queue(QueuedMessage.builder()

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -502,7 +502,7 @@ public class QuestBankTab
 			// Effectively avoid dragging
 			c.setDragDeadTime(1000);
 
-			c.setName("<col=ff9040>" + bankTabItem.getText() + "</col>");
+			c.setName("<col=ff9040>" + def.getName() + "</col>");
 			c.clearActions();
 
 			// Jagex Placeholder
@@ -519,6 +519,7 @@ public class QuestBankTab
 				c.setOpacity(120);
 				c.setItemQuantity(0);
 				c.setItemQuantityMode(1);
+				c.setText("<col=ff9040>" + bankTabItem.getText() + "</col>");
 				c.setAction(1, "Details");
 			}
 			else
@@ -753,7 +754,7 @@ public class QuestBankTab
 				.append(Text.removeTags(bankTabItem.getText()))
 				.append(".");
 
-		if (!bankTabItem.getDetails().isEmpty())
+		if (bankTabItem.getDetails() != null && !bankTabItem.getDetails().isEmpty())
 		{
 			message.append(ChatColorType.NORMAL)
 					.append(" " + bankTabItem.getDetails() + ".");

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -59,6 +59,7 @@ import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.Text;
 
 import static com.questhelper.bank.banktab.PotionStorage.COMPONENTS_PER_POTION;
+import static com.questhelper.bank.banktab.PotionStorage.VIAL_IDX;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.*;
 
 @Singleton
@@ -293,7 +294,13 @@ public class QuestBankTab
 				}
 
 				idx = potionStorage.find(w.getItemId());
-				if (idx > -1)
+				if (idx == VIAL_IDX)
+				{
+					potionStorage.prepareWidgets();
+					menu.setParam1(ComponentID.BANK_POTIONSTORE_CONTENT);
+					menu.setParam0(VIAL_IDX);
+				}
+				else if (idx > -1)
 				{
 					potionStorage.prepareWidgets();
 					menu.setParam1(ComponentID.BANK_POTIONSTORE_CONTENT);

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -334,7 +334,7 @@ public class QuestBankTab
 		if (addedWidgets.isEmpty()) return;
 		Widget parent = addedWidgets.get(0).getParent();
 		if (parent == null) return;
-
+		if (parent.getChildren() == null) return;
 		parent.setChildren(Arrays.copyOf(parent.getChildren(), originalContainerChildren));
 		parent.revalidate();
 

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -110,6 +110,8 @@ public class QuestBankTab
 
 	private final HashMap<Widget, BankTabItem> widgetItems = new HashMap<>();
 
+	private int originalContainerChildren = -1;
+
 	public void startUp()
 	{
 		if (questHelper.getSelectedQuest() != null)
@@ -327,11 +329,13 @@ public class QuestBankTab
 
 	private void removeAddedWidgets()
 	{
+		if (originalContainerChildren == -1) return;
+
 		if (addedWidgets.isEmpty()) return;
 		Widget parent = addedWidgets.get(0).getParent();
 		if (parent == null) return;
 
-		parent.setChildren(Arrays.copyOf(parent.getChildren(), 1248));
+		parent.setChildren(Arrays.copyOf(parent.getChildren(), originalContainerChildren));
 		parent.revalidate();
 
 		addedWidgets.clear();
@@ -363,6 +367,8 @@ public class QuestBankTab
 			return;
 		}
 
+		removeAddedWidgets();
+
 		if (!questBankTabInterface.isQuestTabActive())
 		{
 			return;
@@ -373,8 +379,8 @@ public class QuestBankTab
 		{
 			return;
 		}
-
-		removeAddedWidgets();
+		Widget[] children = itemContainer.getChildren();
+		if (children != null && originalContainerChildren == -1) originalContainerChildren = children.length;
 
 		Widget[] containerChildren = itemContainer.getDynamicChildren();
 

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -230,32 +230,6 @@ public class QuestBankTab
 		{
 			intStack[intStackSize - 1] = questBankTabInterface.isQuestTabActive() ? 1 : 0;
 		}
-		else if ("bankSearchFilter".equals(eventName))
-		{
-			final int itemId = intStack[intStackSize - 1];
-			if (!questBankTabInterface.isQuestTabActive())
-			{
-				return;
-			}
-
-			if (itemId == -1)
-			{
-				// item -1 always passes on a laid out tab so items can be dragged to it
-				return;
-			}
-			List<Integer> items = questHelperBankTagService.itemsToTagForBank();
-			if (itemId > -1 && items.contains(itemId))
-			{
-				// return true
-				intStack[intStackSize - 2] = 1;
-			}
-			else
-			{
-				// if the item isn't tagged we return false to prevent the item matching if the item name happens
-				// to contain the tag name.
-				intStack[intStackSize - 2] = 0;
-			}
-		}
 	}
 
 	@Subscribe
@@ -396,7 +370,6 @@ public class QuestBankTab
 		if (children != null && originalContainerChildren == -1) originalContainerChildren = children.length;
 
 		Widget[] containerChildren = itemContainer.getDynamicChildren();
-
 		clientThread.invokeAtTickEnd(() -> {
 			// Desired extra functionality:
 			// X - Recommended items also included in section

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -137,6 +137,7 @@ public class QuestBankTab
 
 	public void unregister(EventBus eventBus)
 	{
+		potionStorage.setQuestBankTabInterface(null);
 		eventBus.unregister(potionStorage);
 		eventBus.unregister(this);
 	}

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -181,8 +181,19 @@ public class QuestBankTab
 	@Subscribe
 	public void onScriptPreFired(ScriptPreFired event)
 	{
+		final int POTION_STORE_UPDATED = 6555;
+
 		int scriptId = event.getScriptId();
-		if (scriptId == ScriptID.BANKMAIN_FINISHBUILDING)
+
+		if (scriptId == POTION_STORE_UPDATED)
+		{
+			// Since the script vm isn't reentrant, we can't call into POTIONSTORE_DOSES/POTIONSTORE_WITHDRAW_DOSES
+			// from bankmain_finishbuilding for the layout. Instead, we record all of the potions on client tick,
+			// which is after this is run, but before the var/inv transmit listeners run, so that we will have
+			// them by the time the inv transmit listener runs.
+			potionStorage.updateCachedPotions = true;
+		}
+		else if (scriptId == ScriptID.BANKMAIN_FINISHBUILDING)
 		{
 			resetWidgets();
 			if (questBankTabInterface.isQuestTabActive())
@@ -199,12 +210,6 @@ public class QuestBankTab
 						bankTitle.setText("Tab <col=ff0000>Quest Helper</col>");
 					}
 				}
-
-				// Since the script vm isn't reentrant, we can't call into POTIONSTORE_DOSES/POTIONSTORE_WITHDRAW_DOSES
-				// from bankmain_finishbuilding for the layout. Instead, we record all of the potions on client tick,
-				// which is after this is run, but before the var/inv transmit listeners run, so that we will have
-				// them by the time the inv transmit listener runs.
-				potionStorage.cachePotions = true;
 			}
 		}
 		else if (scriptId == ScriptID.BANKMAIN_SEARCH_TOGGLE)

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -631,12 +631,7 @@ public class QuestBankTab
 
 	private int count(ItemContainer bank, int itemId)
 	{
-		int count = bank.count(itemId);
-		if (count > 0)
-		{
-			return count;
-		}
-		return potionStorage.count(itemId);
+		return bank.count(itemId) + potionStorage.count(itemId);
 	}
 
 	int currentWidgetToUse = 0;

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTabInterface.java
@@ -29,14 +29,7 @@ package com.questhelper.bank.banktab;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.api.Client;
-import net.runelite.api.ScriptEvent;
-import net.runelite.api.ScriptID;
-import net.runelite.api.SoundEffectID;
-import net.runelite.api.SpriteID;
-import net.runelite.api.VarClientInt;
-import net.runelite.api.VarClientStr;
-import net.runelite.api.Varbits;
+import net.runelite.api.*;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.JavaScriptCallback;
@@ -48,6 +41,8 @@ import net.runelite.client.plugins.bank.BankSearch;
 public class QuestBankTabInterface
 {
 	private static final String VIEW_TAB = "View tab ";
+
+	private static final int BANKTAB_POTIONSTORE = 15;
 
 	@Setter
 	@Getter
@@ -135,8 +130,9 @@ public class QuestBankTabInterface
 
 		// If click a base tab, close
 		boolean clickedTabTag = menuOption.startsWith("View tab") && !event.getMenuTarget().equals("quest-helper");
+		boolean clickPotionStorage = menuOption.startsWith("Potion store");
 		boolean clickedOtherTab = menuOption.equals("View all items") || menuOption.startsWith("View tag tab");
-		if (questTabActive && (clickedTabTag || clickedOtherTab))
+		if (questTabActive && (clickedTabTag || clickedOtherTab || clickPotionStorage))
 		{
 			closeTab();
 		}
@@ -219,6 +215,13 @@ public class QuestBankTabInterface
 		if (questTabActive)
 		{
 			return;
+		}
+
+		if (client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == BANKTAB_POTIONSTORE)
+		{
+			// Opening a tag tab with the potion store open would leave the store open in the bankground,
+			// making deposits not work. Force close the potion store.
+			client.menuAction(-1, ComponentID.BANK_POTION_STORE, MenuAction.CC_OP, 1, -1, "Potion store", "");
 		}
 
 		questBackgroundWidget.setSpriteId(SpriteID.UNKNOWN_BUTTON_SQUARE_SMALL_SELECTED);

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTabInterface.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTabInterface.java
@@ -93,8 +93,9 @@ public class QuestBankTabInterface
 
 		if (questTabActive)
 		{
+			boolean wasInPotionStorage = client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == BANKTAB_POTIONSTORE;
 			questTabActive = false;
-			clientThread.invokeLater(this::activateTab);
+			clientThread.invokeLater(() -> activateTab(wasInPotionStorage));
 		}
 	}
 
@@ -160,6 +161,7 @@ public class QuestBankTabInterface
 	{
 		if (event.getOp() == 2)
 		{
+			boolean wasInPotionStorage = client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == BANKTAB_POTIONSTORE;
 			client.setVarbit(Varbits.CURRENT_BANK_TAB, 0);
 
 			if (questTabActive)
@@ -169,7 +171,7 @@ public class QuestBankTabInterface
 			}
 			else
 			{
-				activateTab();
+				activateTab(wasInPotionStorage);
 				// openTag will reset and relayout
 			}
 
@@ -210,14 +212,14 @@ public class QuestBankTabInterface
 		}
 	}
 
-	private void activateTab()
+	private void activateTab(boolean wasInPotionStorage)
 	{
 		if (questTabActive)
 		{
 			return;
 		}
 
-		if (client.getVarbitValue(Varbits.CURRENT_BANK_TAB) == BANKTAB_POTIONSTORE)
+		if (wasInPotionStorage)
 		{
 			// Opening a tag tab with the potion store open would leave the store open in the bankground,
 			// making deposits not work. Force close the potion store.

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -25,7 +25,6 @@
 package com.questhelper.bank.banktab;
 
 import com.questhelper.QuestHelperPlugin;
-import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
@@ -39,9 +38,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.ItemID;
 
 @Singleton
 public class QuestHelperBankTagService
@@ -69,7 +65,24 @@ public class QuestHelperBankTagService
 
 		lastTickUpdatedForBank = client.getTickCount();
 
-		ArrayList<BankTabItems> sortedItems = getPluginBankTagItemsForSections(false);
+		return getItemsFromTabs(false);
+	}
+
+	public ArrayList<Integer> itemsToTag()
+	{
+		if (client.getTickCount() <= lastTickUpdated)
+		{
+			return taggedItems;
+		}
+
+		lastTickUpdated = client.getTickCount();
+
+		return getItemsFromTabs(true);
+	}
+
+	private ArrayList<Integer> getItemsFromTabs(boolean onlyGetMissingItems)
+	{
+		ArrayList<BankTabItems> sortedItems = getPluginBankTagItemsForSections(onlyGetMissingItems);
 
 		if (sortedItems == null)
 		{
@@ -87,35 +100,6 @@ public class QuestHelperBankTagService
 				.filter(id -> !taggedItemsForBank.contains(id))
 				.forEach(taggedItemsForBank::add);
 		return taggedItemsForBank;
-	}
-
-	public ArrayList<Integer> itemsToTag()
-	{
-		if (client.getTickCount() <= lastTickUpdated)
-		{
-			return taggedItems;
-		}
-
-		lastTickUpdated = client.getTickCount();
-
-		ArrayList<BankTabItems> sortedItems = getPluginBankTagItemsForSections(true);
-
-		if (sortedItems == null)
-		{
-			return null;
-		}
-
-		taggedItems = new ArrayList<>();
-
-		sortedItems.stream()
-			.map(BankTabItems::getItems)
-			.flatMap(Collection::stream)
-			.map(BankTabItem::getItemIDs)
-			.flatMap(Collection::stream)
-			.filter(Objects::nonNull) // filter non-null just in case any Integer get in the list
-			.filter(id -> !taggedItems.contains(id))
-			.forEach(taggedItems::add);
-		return taggedItems;
 	}
 
 	public ArrayList<BankTabItems> getPluginBankTagItemsForSections(boolean onlyGetMissingItems)

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -25,6 +25,7 @@
 package com.questhelper.bank.banktab;
 
 import com.questhelper.QuestHelperPlugin;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
@@ -40,6 +41,7 @@ import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
 
 @Singleton
 public class QuestHelperBankTagService
@@ -132,9 +134,7 @@ public class QuestHelperBankTagService
 		{
 			recommendedItems = recommendedItems.stream()
 				.filter(Objects::nonNull)
-				.filter(i -> (!onlyGetMissingItems
-					|| !i.checkWithBank(plugin.getClient()))
-					&& i.shouldDisplayText(plugin.getClient()))
+				.filter(i -> (!onlyGetMissingItems || !i.checkWithBank(plugin.getClient())) && i.shouldDisplayText(plugin.getClient()))
 				.collect(Collectors.toList());
 		}
 
@@ -237,19 +237,14 @@ public class QuestHelperBankTagService
 	{
 		List<Integer> itemIds = item.getDisplayItemIds();
 
-		Integer displayId = itemIds.stream().filter(this::hasItemInBank).findFirst().orElse(itemIds.get(0));
+		Integer displayId = itemIds.stream().filter(this::hasItemInBankOrPotionStorage).findFirst().orElse(itemIds.get(0));
 
 		return new BankTabItem(item, displayId);
 	}
 
-	public boolean hasItemInBank(int itemID)
+	public boolean hasItemInBankOrPotionStorage(int itemID)
 	{
-		ItemContainer bankContainer = plugin.getClient().getItemContainer(InventoryID.BANK);
-		if (bankContainer == null)
-		{
-			return false;
-		}
-
-		return bankContainer.contains(itemID);
+		ItemRequirement tmpReq = new ItemRequirement("tmp", itemID);
+		return tmpReq.checkWithBank(client);
 	}
 }

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -206,11 +206,7 @@ public class QuestHelperBankTagService
 		}
 		else
 		{
-			if (itemRequirement.getDisplayItemId() != null)
-			{
-				pluginItems.add(new BankTabItem(realItem));
-			}
-			else if (!itemRequirement.getDisplayItemIds().contains(-1))
+			if (itemRequirement.getDisplayItemId() != null || !itemRequirement.getDisplayItemIds().contains(-1))
 			{
 				pluginItems.add(makeBankTabItem(realItem));
 			}
@@ -220,8 +216,14 @@ public class QuestHelperBankTagService
 	private BankTabItem makeBankTabItem(ItemRequirement item)
 	{
 		List<Integer> itemIds = item.getDisplayItemIds();
-
-		Integer displayId = itemIds.stream().filter(this::hasItemInBankOrPotionStorage).findFirst().orElse(itemIds.get(0));
+		Integer displayId = itemIds.stream()
+				.filter(this::hasItemInBankOrPotionStorage)
+				.findFirst()
+				.orElse(item.getAllIds().stream()
+						.filter(this::hasItemInBankOrPotionStorage)
+						.findFirst()
+						.orElse(item.getAllIds().get(0))
+				);
 
 		return new BankTabItem(item, displayId);
 	}

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -54,20 +54,6 @@ public class QuestHelperBankTagService
 
 	int lastTickUpdated = 0;
 
-	int lastTickUpdatedForBank = 0;
-
-	public ArrayList<Integer> itemsToTagForBank()
-	{
-		if (client.getTickCount() <= lastTickUpdatedForBank)
-		{
-			return taggedItemsForBank;
-		}
-
-		lastTickUpdatedForBank = client.getTickCount();
-
-		return getItemsFromTabs(false);
-	}
-
 	public ArrayList<Integer> itemsToTag()
 	{
 		if (client.getTickCount() <= lastTickUpdated)
@@ -77,12 +63,12 @@ public class QuestHelperBankTagService
 
 		lastTickUpdated = client.getTickCount();
 
-		return getItemsFromTabs(true);
+		return getItemsFromTabs();
 	}
 
-	private ArrayList<Integer> getItemsFromTabs(boolean onlyGetMissingItems)
+	private ArrayList<Integer> getItemsFromTabs()
 	{
-		ArrayList<BankTabItems> sortedItems = getPluginBankTagItemsForSections(onlyGetMissingItems);
+		ArrayList<BankTabItems> sortedItems = getPluginBankTagItemsForSections(true);
 
 		if (sortedItems == null)
 		{

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -118,7 +118,7 @@ public class QuestHelperBankTagService
 		{
 			recommendedItems = recommendedItems.stream()
 				.filter(Objects::nonNull)
-				.filter(i -> (!onlyGetMissingItems || !i.checkWithBank(plugin.getClient())) && i.shouldDisplayText(plugin.getClient()))
+				.filter(i -> (!onlyGetMissingItems || !i.checkWithAllContainers(plugin.getClient())) && i.shouldDisplayText(plugin.getClient()))
 				.collect(Collectors.toList());
 		}
 
@@ -145,7 +145,7 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.checkWithBank(plugin.getClient()))
+						|| !i.checkWithAllContainers(plugin.getClient()))
 						&& i.shouldDisplayText(plugin.getClient()))
 					.collect(Collectors.toList());
 			}
@@ -157,7 +157,7 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.checkWithBank(plugin.getClient()))
+						|| !i.checkWithAllContainers(plugin.getClient()))
 						&& i.shouldDisplayText(plugin.getClient()))
 					.collect(Collectors.toList());
 			}
@@ -196,7 +196,7 @@ public class QuestHelperBankTagService
 				else
 				{
 					ItemRequirement match = itemsWhichPassReq.stream()
-						.filter(r -> r.checkWithBank(plugin.getClient()))
+						.filter(r -> r.checkWithAllContainers(plugin.getClient()))
 						.findFirst()
 						.orElse(itemsWhichPassReq.get(0).named(itemRequirements.getName()));
 
@@ -231,6 +231,6 @@ public class QuestHelperBankTagService
 	public boolean hasItemInBankOrPotionStorage(int itemID)
 	{
 		ItemRequirement tmpReq = new ItemRequirement("tmp", itemID);
-		return tmpReq.checkWithBank(client);
+		return tmpReq.checkWithAllContainers(client);
 	}
 }

--- a/src/main/java/com/questhelper/managers/QuestBankManager.java
+++ b/src/main/java/com/questhelper/managers/QuestBankManager.java
@@ -58,12 +58,12 @@ public class QuestBankManager
 	{
 		questBankTab.startUp();
 		injector.injectMembers(questBankTab);
-		eventBus.register(questBankTab);
+		questBankTab.register(eventBus);
 	}
 
 	public void shutDown(EventBus eventBus)
 	{
-		eventBus.unregister(questBankTab);
+		questBankTab.unregister(eventBus);
 		questBankTab.shutDown();
 	}
 

--- a/src/main/java/com/questhelper/managers/QuestContainerManager.java
+++ b/src/main/java/com/questhelper/managers/QuestContainerManager.java
@@ -37,4 +37,7 @@ public class QuestContainerManager
 
     @Getter
     private final static ItemAndLastUpdated bankData = new ItemAndLastUpdated(TrackedContainers.BANK);
+
+    @Getter
+    private final static ItemAndLastUpdated potionData = new ItemAndLastUpdated(TrackedContainers.POTION_STORAGE);
 }

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -110,6 +110,7 @@ public class ItemRequirement extends AbstractRequirement
 
 	protected Requirement additionalOptions;
 
+
 	Map<TrackedContainers, ContainerStateForRequirement> knownContainerStates = new HashMap<>();
 	{
 		for (TrackedContainers value : TrackedContainers.values())
@@ -389,10 +390,8 @@ public class ItemRequirement extends AbstractRequirement
 		return text.toString();
 	}
 
-	// IDEA: Have a central event which lets you know diff on inventory
 	public void setAdditionalOptions(Requirement additionalOptions)
 	{
-		// TODO: Need to register / unregister through centralised ActiveRequirementsManager
 		this.additionalOptions = additionalOptions;
 	}
 

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -540,7 +540,8 @@ public class ItemRequirement extends AbstractRequirement
 
 	public boolean checkWithBank(Client client)
 	{
-		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
+		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData()
+				, QuestContainerManager.getPotionData());
 	}
 
 	public Color getColorConsideringBank(Client client, QuestHelperConfig config)
@@ -558,6 +559,10 @@ public class ItemRequirement extends AbstractRequirement
 		if (color == config.failColour() && this.checkContainers(client, QuestContainerManager.getBankData()))
 		{
 			color = Color.WHITE;
+		}
+		if (color == config.failColour() && this.checkContainers(client, QuestContainerManager.getPotionData()))
+		{
+			color = Color.CYAN;
 		}
 
 		return color;
@@ -607,7 +612,11 @@ public class ItemRequirement extends AbstractRequirement
 		containers.add(QuestContainerManager.getEquippedData());
 
 		if (!equip) containers.add(QuestContainerManager.getInventoryData());
-		if (shouldCheckBank) containers.add(QuestContainerManager.getBankData());
+		if (shouldCheckBank)
+		{
+			containers.add(QuestContainerManager.getBankData());
+			containers.add(QuestContainerManager.getPotionData());
+		}
 
 		return containers.toArray(new ItemAndLastUpdated[0]);
 	}

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -537,7 +537,7 @@ public class ItemRequirement extends AbstractRequirement
 		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData());
 	}
 
-	public boolean checkWithBank(Client client)
+	public boolean checkWithAllContainers(Client client)
 	{
 		return checkContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData()
 				, QuestContainerManager.getPotionData());

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -600,13 +600,6 @@ public class ItemRequirement extends AbstractRequirement
 	@Override
 	public boolean check(Client client)
 	{
-		ItemAndLastUpdated[] containers = containersToCheckDefault();
-
-		return checkContainers(client, containers);
-	}
-
-	private ItemAndLastUpdated[] containersToCheckDefault()
-	{
 		List<ItemAndLastUpdated> containers = new ArrayList<>();
 		containers.add(QuestContainerManager.getEquippedData());
 
@@ -617,7 +610,7 @@ public class ItemRequirement extends AbstractRequirement
 			containers.add(QuestContainerManager.getPotionData());
 		}
 
-		return containers.toArray(new ItemAndLastUpdated[0]);
+		return checkContainers(client, containers.toArray(new ItemAndLastUpdated[0]));
 	}
 
 	private int getMaxMatchingItems(Client client, @NonNull Item[] items)

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -40,10 +40,8 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import com.questhelper.util.Utils;
 import lombok.Getter;
-import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
-import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class ItemRequirements extends ItemRequirement
 {
@@ -142,7 +140,7 @@ public class ItemRequirements extends ItemRequirement
 			colour = config.passColour();
 		}
 
-		if (colour == config.failColour() && checkWithBank(client))
+		if (colour == config.failColour() && checkWithAllContainers(client))
 		{
 			colour = Color.WHITE;
 		}
@@ -196,8 +194,8 @@ public class ItemRequirements extends ItemRequirement
 	}
 
 	@Override
-	public boolean checkWithBank(Client client)
+	public boolean checkWithAllContainers(Client client)
 	{
-		return logicType.test(getItemRequirements().stream(), item -> item.checkWithBank(client));
+		return logicType.test(getItemRequirements().stream(), item -> item.checkWithAllContainers(client));
 	}
 }

--- a/src/main/java/com/questhelper/requirements/item/TrackedContainers.java
+++ b/src/main/java/com/questhelper/requirements/item/TrackedContainers.java
@@ -29,5 +29,6 @@ public enum TrackedContainers
     EQUIPPED,
     INVENTORY,
     BANK,
+    POTION_STORAGE,
     UNDEFINED
 }

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.questhelper.bank.QuestBank;
 import com.questhelper.QuestHelperPlugin;
-import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.steps.widget.AbstractWidgetHighlight;
 import com.questhelper.tools.QuestHelperWorldMapPoint;
@@ -821,7 +820,7 @@ public class DetailedQuestStep extends QuestStep
 			&& ((ItemRequirement) requirement).shouldRenderItemHighlights(client)
 			&& ((!considerBankForItemHighlight && !requirement.check(client)) ||
 			(considerBankForItemHighlight &&
-				!((ItemRequirement) requirement).checkWithBank(client)));
+				!((ItemRequirement) requirement).checkWithAllContainers(client)));
 	}
 
 	@Override
@@ -902,7 +901,7 @@ public class DetailedQuestStep extends QuestStep
 		return requirements.stream().anyMatch((item) ->  item instanceof ItemRequirement &&
 			type == MenuAction.GROUND_ITEM_THIRD_OPTION &&
 			((ItemRequirement) item).getAllIds().contains(itemID) &&
-			!((ItemRequirement) item).checkWithBank(client) &&
+			!((ItemRequirement) item).checkWithAllContainers(client) &&
 			option.equals("Take"));
 	}
 


### PR DESCRIPTION
This PR allows for the potion storage to be considered for requirements, as well as for the bank filtering for removing/adding potions from it. The bank work is based on the way the core Bank Tags plugin has done it for Layouts.

In tandem based on this, this also moves the Quest Helper filter for the bank from moving real bank items around to instead just making items into the items we're interested in, now that it's an allowed method due to implementation in the core client. This generally means quite a lot less processing per bank event.

~~Widgets which are still made (section headers and dividers, numbers for quantities needed) will now be trimmed off the size of the bank. From across my accounts the max element in BANK_ITEM_CONTAINER is always 1248, BUT this is a bit sketchy as it's possible that 1. this might change, making quest helper cut stuff off improperly, or 2. It's already wrong for some people (maybe more possible with more bank extension things?). Maybe looking at capturing the size on load before doing anything may be a better play here to ensure it's correct in more scenarios.~~
- I've updated this now to be dynamic based on initial load.

Finally, to help further with performance, I've removed the non-bank items from being part of quest filtered bank.

Across these changes I'm seeing a massive performance improvement when adding/removing items, so hopefully this is a good step in the right direction, in addition to it being good to support a new container.

Note: The quest bank can wiggle a little bit when removing items, hopefully not a big change needed to fix this but would be good to before releasing.