### PR TITLE
Add runes, Falador/Ardougne to TeleportCollections

### DIFF
--- a/src/main/java/com/questhelper/collections/TeleportCollections.java
+++ b/src/main/java/com/questhelper/collections/TeleportCollections.java
@@ -1,13 +1,16 @@
 package com.questhelper.collections;
 
+import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.item.TeleportItemRequirement;
+import com.questhelper.requirements.util.LogicType;
 import net.runelite.api.ItemID;
 
 public enum TeleportCollections
 {
 	BURTHORPE_TELEPORT()
 		{
-			public TeleportItemRequirement getItemRequirement()
+			public ItemRequirement getItemRequirement()
 			{
 				TeleportItemRequirement burthTele = new TeleportItemRequirement("Teleport to Burthorpe. Games necklace (Burthorpe [1]), minigame teleport (Burthorpe Games Room)",
 					ItemCollections.GAMES_NECKLACES);
@@ -16,24 +19,64 @@ public enum TeleportCollections
 		},
 	VARROCK_TELEPORT()
 		{
-			public TeleportItemRequirement getItemRequirement()
+			public ItemRequirement getItemRequirement()
 			{
 				TeleportItemRequirement varrockTele = new TeleportItemRequirement("Teleport to Varrock. Varrock teleport tablet/spell, Chronicle, Ring of Wealth (Grand Exchange [2])",
 					ItemID.VARROCK_TELEPORT);
 				varrockTele.addAlternates(ItemID.CHRONICLE);
 				varrockTele.addAlternates(ItemCollections.RING_OF_WEALTHS);
-				return varrockTele;
+
+				ItemRequirement varrockRunes = new ItemRequirements("Varrock teleport runes",
+					new ItemRequirement("Law rune", ItemID.LAW_RUNE, 1),
+					new ItemRequirement("Air rune", ItemID.AIR_RUNE, 3),
+					new ItemRequirement("Water rune", ItemID.WATER_RUNE, 1)
+				);
+				return new ItemRequirements(LogicType.OR, "Teleport to Varrock. Varrock teleport tablet/spell, Chronicle, Ring of Wealth (Grand Exchange [2])",
+					varrockTele, varrockRunes);
 			}
 		},
 	SOPHANEM_TELEPORT()
 		{
-			public TeleportItemRequirement getItemRequirement()
+			public ItemRequirement getItemRequirement()
 			{
 				TeleportItemRequirement sophTele = new TeleportItemRequirement("Teleport to Sophanem. Pharaoh's sceptre (Jalsavrah [1])",
 					ItemCollections.PHAROAH_SCEPTRE);
 				return sophTele;
 			}
+		},
+	ARDOUGNE_TELEPORT()
+		{
+			@Override
+			public ItemRequirement getItemRequirement()
+			{
+				TeleportItemRequirement ardougneTele = new TeleportItemRequirement("Teleport to Ardougne. Ardougne cloak, Ardougne teleport tablet/spell",
+					ItemCollections.ARDY_CLOAKS);
+				ardougneTele.addAlternates(ItemID.ARDOUGNE_TELEPORT);
+
+				ItemRequirement ardougneRunes = new ItemRequirements("Ardougne teleport runes",
+					new ItemRequirement("Law rune", ItemID.LAW_RUNE, 2),
+					new ItemRequirement("Water rune", ItemID.WATER_RUNE, 2)
+				);
+				return new ItemRequirements(LogicType.OR, "Teleport to Ardougne. Ardougne cloak, Ardougne teleport tablet/spell", ardougneTele, ardougneRunes);
+			}
+		},
+	FALADOR_TELEPORT()
+		{
+			@Override
+			public ItemRequirement getItemRequirement()
+			{
+				TeleportItemRequirement faladorTele = new TeleportItemRequirement("Teleport to Falador. Falador teleport tablet/spell",
+					ItemID.FALADOR_TELEPORT);
+
+				ItemRequirement faladorRunes = new ItemRequirements("Falador teleport runes",
+					new ItemRequirement("Law rune", ItemID.LAW_RUNE, 1),
+					new ItemRequirement("Air rune", ItemID.AIR_RUNE, 3),
+					new ItemRequirement("Water rune", ItemID.WATER_RUNE, 1)
+				);
+
+				return new ItemRequirements(LogicType.OR, "Teleport to Falador. Falador teleport tablet/spell", faladorTele, faladorRunes);
+			}
 		};
 
-	public abstract TeleportItemRequirement getItemRequirement();
+	public abstract ItemRequirement getItemRequirement();
 }

--- a/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
+++ b/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
@@ -26,6 +26,7 @@ package com.questhelper.playerquests.bikeshedder;
 
 import com.google.common.collect.ImmutableMap;
 import com.questhelper.collections.ItemCollections;
+import com.questhelper.collections.TeleportCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
@@ -47,6 +48,7 @@ import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.ComponentID;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import static com.questhelper.requirements.util.LogicHelper.or;
@@ -64,6 +66,10 @@ public class BikeShedder extends BasicQuestHelper
 	private ItemRequirement manyCoins;
 	private ObjectStep useCoinOnBush;
 	private ObjectStep useManyCoinsOnBush;
+
+	private ItemRequirement varrockTeleport;
+	private ItemRequirement ardougneTeleport;
+	private ItemRequirement faladorTeleport;
 
 	private Zone conditionalRequirementZone;
 	private ZoneRequirement conditionalRequirementZoneRequirement;
@@ -116,6 +122,10 @@ public class BikeShedder extends BasicQuestHelper
 		useLogOnBush = new ObjectStep(this, NullObjectID.NULL_10778, new WorldPoint(3223, 3217, 0), "Use log on bush", anyLog);
 		useLogOnBush.addIcon(ItemID.LOGS);
 
+		varrockTeleport = TeleportCollections.VARROCK_TELEPORT.getItemRequirement();
+		ardougneTeleport = TeleportCollections.ARDOUGNE_TELEPORT.getItemRequirement();
+		faladorTeleport = TeleportCollections.FALADOR_TELEPORT.getItemRequirement();
+
 		oneCoin = new ItemRequirement("Coins", ItemCollections.COINS, 1);
 		oneCoin.setHighlightInInventory(true);
 		useCoinOnBush = new ObjectStep(this, NullObjectID.NULL_10778, new WorldPoint(3223, 3217, 0), "Use coins on the bush.", oneCoin);
@@ -152,6 +162,11 @@ public class BikeShedder extends BasicQuestHelper
 		var upstairsInSunrisePalace = new Zone(new WorldPoint(1684, 3162, 1), new WorldPoint(1691, 3168, 1));
 		byStaircaseInSunrisePalace = new ZoneRequirement(upstairsInSunrisePalace);
 		goDownstairsInSunrisePalace = new ObjectStep(getQuest().getQuestHelper(), ObjectID.STAIRCASE_52627, new WorldPoint(1690, 3164, 1), "Climb downstairs, ensure stairs are well highlighted!");
+	}
+
+	@Override
+	public List<ItemRequirement> getItemRecommended() {
+		return Arrays.asList(varrockTeleport, ardougneTeleport, faladorTeleport);
 	}
 
 	@Override


### PR DESCRIPTION
Add runes, Falador/Ardougne to TeleportCollections.

- Added teleport runes to TeleportCollections
- Use `ItemRequirement` superclass instead of `TeleportItemRequirement` superclass so we can return any child of `ItemRequirement`
   - Additionally so we can return `ItemRequirements` when we have a logical OR condition on the requirements (e.g. need either some teleportation item OR prerequisite teleport runes)

Tested in-game, and ran all tests. 

Will follow this up in the next day or two to start migrating the quest requirements to use the `TeleportCollections` class while generating teleport requirements. 
