### PR TITLE
fremennik easy diary: correct giant dwarf requirement

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikEasy.java
@@ -165,7 +165,7 @@ public class FremennikEasy extends ComplexStateQuestHelper
 
 		food = new ItemRequirement("Food", ItemCollections.GOOD_EATING_FOOD, -1);
 		fremennikTrials = new QuestRequirement(QuestHelperQuest.THE_FREMENNIK_TRIALS, QuestState.FINISHED);
-		giantDwarf = new QuestRequirement(QuestHelperQuest.THE_GIANT_DWARF, QuestState.FINISHED);
+		giantDwarf = new QuestRequirement(QuestHelperQuest.THE_GIANT_DWARF, QuestState.IN_PROGRESS);
 		trollStronghold = new QuestRequirement(QuestHelperQuest.TROLL_STRONGHOLD, QuestState.FINISHED);
 		deathPlateau = new QuestRequirement(QuestHelperQuest.DEATH_PLATEAU, QuestState.FINISHED);
 


### PR DESCRIPTION
[Completing the quest is not required to do the fremennik diary](https://oldschool.runescape.wiki/w/Fremennik_Diary#Easy). The current requirement made me confused in leagues because completing the giant dwarf requires asgarnia, which would be weird to lock the fremennik diary behind.