### PR TITLE
The Fremennik Exiles: Minor polish

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
@@ -70,6 +70,7 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.QuestStep;
+import static com.questhelper.requirements.util.LogicHelper.and;
 
 public class TheFremennikExiles extends BasicQuestHelper
 {
@@ -132,8 +133,8 @@ public class TheFremennikExiles extends BasicQuestHelper
 		investigate.addStep(new Conditions(hasReadLetter, fang), searchBoxes);
 		investigate.addStep(hasReadLetter, searchRockslide);
 		investigate.addStep(letter, readLetter);
+		investigate.addStep(and(killedYoungling, letterNearby), pickupLetter);
 		investigate.addStep(killedYoungling, searchSandpitForLetter);
-		investigate.addStep(letterNearby, pickupLetter);
 		investigate.addStep(younglingNearby, killYoungling);
 		steps.put(15, investigate);
 

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
@@ -537,7 +537,7 @@ public class TheFremennikExiles extends BasicQuestHelper
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
 		allSteps.add(new PanelDetails("Investigating", Arrays.asList(buyKegs, talkToBrundt, talkToFreygerd,
-			searchSandpit, killYoungling, pickupLetter, readLetter, searchRockslide, searchSandpit,
+			searchSandpit, killYoungling, pickupLetter, readLetter, searchRockslide,
 			talkToFreygardWithItems, talkToBrundtAgain, talkToBrundtSouthEastOfRellekka), combatGear, mirrorShield));
 
 		PanelDetails shieldPanel = new PanelDetails("A Fremennik Shield", Collections.singletonList(getFremennikShield),

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
@@ -537,7 +537,7 @@ public class TheFremennikExiles extends BasicQuestHelper
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
 		allSteps.add(new PanelDetails("Investigating", Arrays.asList(buyKegs, talkToBrundt, talkToFreygerd,
-			searchSandpit, killYoungling, pickupLetter, readLetter, searchRockslide,
+			searchSandpit, killYoungling, pickupLetter, readLetter, searchRockslide, searchBoxes,
 			talkToFreygardWithItems, talkToBrundtAgain, talkToBrundtSouthEastOfRellekka), combatGear, mirrorShield));
 
 		PanelDetails shieldPanel = new PanelDetails("A Fremennik Shield", Collections.singletonList(getFremennikShield),

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
@@ -71,6 +71,7 @@ import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.QuestStep;
 import static com.questhelper.requirements.util.LogicHelper.and;
+import static com.questhelper.requirements.util.LogicHelper.not;
 
 public class TheFremennikExiles extends BasicQuestHelper
 {
@@ -114,6 +115,7 @@ public class TheFremennikExiles extends BasicQuestHelper
 
 	//Zones
 	Zone lunarMine, yagaHouse, isleOfStone, typhorRoom;
+	private ConditionalStep talkToBrundtSouthEastOfRellekkaCond;
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
@@ -142,8 +144,8 @@ public class TheFremennikExiles extends BasicQuestHelper
 		steps.put(25, talkToBrundtAgain);
 		steps.put(30, talkToBrundtAgain);
 
-		steps.put(35, talkToBrundtSouthEastOfRellekka);
-		steps.put(40, talkToBrundtSouthEastOfRellekka);
+		steps.put(35, talkToBrundtSouthEastOfRellekkaCond);
+		steps.put(40, talkToBrundtSouthEastOfRellekkaCond);
 
 		goMakeGlass = new ConditionalStep(this, enterYagaHouse);
 		goMakeGlass.addStep(moltenGlassI, makeLunarGlass);
@@ -168,7 +170,7 @@ public class TheFremennikExiles extends BasicQuestHelper
 		goGetShield = new ConditionalStep(this, getFremennikShield);
 		goGetShield.setLockingCondition(fremennikShield);
 
-		ConditionalStep goMakeShield = new ConditionalStep(this, talkToBrundtSouthEastOfRellekka);
+		ConditionalStep goMakeShield = new ConditionalStep(this, talkToBrundtSouthEastOfRellekkaCond);
 		goMakeShield.addStep(vShield, talkToBrundtWithShield);
 		goMakeShield.addStep(new Conditions(askedAboutAllShieldParts, fremennikShield, lunarGlass, sigilE, polishedRock), createShield);
 		goMakeShield.addStep(new Conditions(askedAboutAllShieldParts, fremennikShield, lunarGlass, sigilE), goMakeRock);
@@ -374,6 +376,12 @@ public class TheFremennikExiles extends BasicQuestHelper
 			"Talk to Brundt south east of Rellekka, asking him all available questions.");
 		askAboutSigil.addDialogSteps("How do I make V's Sigil?");
 		talkToBrundtSouthEastOfRellekka.addSubSteps(askAboutShield, askAboutGlass, askAboutRock, askAboutSigil);
+
+		talkToBrundtSouthEastOfRellekkaCond = new ConditionalStep(this, talkToBrundtSouthEastOfRellekka);
+		talkToBrundtSouthEastOfRellekkaCond.addStep(not(askedAboutShield), askAboutShield);
+		talkToBrundtSouthEastOfRellekkaCond.addStep(not(askedAboutGlass), askAboutGlass);
+		talkToBrundtSouthEastOfRellekkaCond.addStep(not(askedAboutRock), askAboutRock);
+		talkToBrundtSouthEastOfRellekkaCond.addStep(not(askedAboutSigil), askAboutSigil);
 
 		enterYagaHouse = new NpcStep(this, NpcID.HOUSE, new WorldPoint(2085, 3931, 0),
 			"Talk to Baba Yaga in the chicken-legged house in the north of Lunar Isle's town.", sealOfPassage, moltenGlass);

--- a/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremennikexiles/TheFremennikExiles.java
@@ -356,6 +356,7 @@ public class TheFremennikExiles extends BasicQuestHelper
 		talkToBrundtAgain = new NpcStep(this, NpcID.BRUNDT_THE_CHIEFTAIN_9263, new WorldPoint(2658, 3669, 0),
 			"Return to Brundt in Rellekka's longhall.");
 		talkToBrundtAgain.addDialogStep("Ask about the investigation.");
+		talkToBrundtAgain.addDialogStep("Ask about the Jormungand.");
 
 		talkToBrundtSouthEastOfRellekka = new NpcStep(this, NpcID.BRUNDT_THE_CHIEFTAIN_9266, new WorldPoint(2705, 3634, 0),
 			"Talk to Brundt south east of Rellekka, asking him all available questions.");


### PR DESCRIPTION
 - Removed the duplicate sidebar step as noted in [this discord message](https://discord.com/channels/772056816242130964/772056861934354433/1309374830411255838)
 - Added the missing sidebar step as noticed by the sidebar step test (and also noted by the above discord message)
 - Prioritized the "Pick up letter" part of the first quest section, ensuring the user isn't told to search the sandpit if the letter is on the ground.
 - Add a missing dialog step that you might need to click if you cancel out of a conversation at the start of the investigation with Brundt
 - Re-implemented the "talk about the shield with Brundt" substeps. I tested all of these during the quest & everything worked as expected, with the fallback step just being "talk to him about everything".

Fixes #1928