### PR TITLE
Kourend Diary Rewards update

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendEasy.java
@@ -312,7 +312,9 @@ public class KourendEasy extends ComplexStateQuestHelper
 		return Arrays.asList(
 			new UnlockReward("Halved access cost for Crabclaw Isle."),
 			new UnlockReward("Doubled drop rate of Xeric's talisman, excluding stone chests."),
-			new UnlockReward("Reduced tanning prices at Eodan in Forthos Dungeon to 80%."));
+			new UnlockReward("Reduced tanning prices at Eodan in Forthos Dungeon to 80%."),
+			new UnlockReward("Access to the cooking range in the Hosidius Kitchen, which has a 5% reduced burn rate"),
+			new UnlockReward("The allotment, flower, and herb patches in Hosidius will never get diseased."));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendEasy.java
@@ -313,7 +313,7 @@ public class KourendEasy extends ComplexStateQuestHelper
 			new UnlockReward("Halved access cost for Crabclaw Isle."),
 			new UnlockReward("Doubled drop rate of Xeric's talisman, excluding stone chests."),
 			new UnlockReward("Reduced tanning prices at Eodan in Forthos Dungeon to 80%."),
-			new UnlockReward("Access to the cooking range in the Hosidius Kitchen, which has a 5% reduced burn rate"),
+			new UnlockReward("Access to the cooking range in the Hosidius Kitchen, which has a 5% reduced burn rate."),
 			new UnlockReward("The allotment, flower, and herb patches in Hosidius will never get diseased."));
 	}
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
@@ -374,7 +374,8 @@ public class KourendElite extends ComplexStateQuestHelper
 			new UnlockReward("5% increased chance to save a harvest life at the Hosidius and Farming Guild herb patches."),
 			new UnlockReward("80 free Dynamite per day from Thirus"),
 			new UnlockReward("10% additional blood runes from blood runecrafting (no additional xp)"),
-			new UnlockReward("Reduced tanning prices at Eodan in Forthos Dungeon to 20%."));
+			new UnlockReward("Reduced tanning prices at Eodan in Forthos Dungeon to 20%."),
+			new UnlockReward("10% increased chance of obtaining higher-tier ores in the Blast mine."));
 	}
 
 	@Override


### PR DESCRIPTION
Added these rewards to the Kourend Diary
**Easy Diary**
- Access to the cooking range in the Hosidius Kitchen, which has a 5% reduced burn rate
- The allotment, flower, and herb patches in Hosidius will never get diseased.
**Elite Diary**
- 10% increased chance of obtaining higher-tier ores in the Blast mine.