### PR TITLE
fix: add alternate Turael npcID's to animal magnetism

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/animalmagnetism/AnimalMagnetism.java
+++ b/src/main/java/com/questhelper/helpers/quests/animalmagnetism/AnimalMagnetism.java
@@ -238,6 +238,7 @@ public class AnimalMagnetism extends BasicQuestHelper
 		talkToTurael = new NpcStep(this, NpcID.TURAEL, new WorldPoint(2931, 3536, 0),
 			"Talk to Turael in Burthorpe twice, giving him the Mithril axe and Holy symbol.",
 			mithrilAxe, holySymbol);
+		((NpcStep) talkToTurael).addAlternateNpcs(NpcID.TURAEL_13434, NpcID.TURAEL_13560, NpcID.TURAEL_13618, NpcID.AYA);
 		talkToTurael.addDialogSteps("I'm here about a quest.", "Hello, I'm here about those trees again.",
 			"I'd love one, thanks.");
 		cutTree = new NpcStep(this, NpcID.UNDEAD_TREE,


### PR DESCRIPTION
I didn't test this, I assumed it to be `TURAEL_13434` based on the 0 info we had from the original reporter, but `[proc,cluehelper_infobox_target_display].cs2` calls `TURAEL_13618` so I just added all of them.

hub plugin privilege do whatever and it probably works

Fixes #1674 