### PR TITLE
fix: ensure SkillRequirement checks doesn't try to stack boosts

### DIFF
--- a/src/main/java/com/questhelper/requirements/player/Boosts.java
+++ b/src/main/java/com/questhelper/requirements/player/Boosts.java
@@ -28,7 +28,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Getter
 public enum Boosts
 {
 	AGILITY("Agility",5),
@@ -55,6 +54,33 @@ public enum Boosts
 	THIEVING("Thieving",3),
 	WOODCUTTING("Woodcutting",3);
 
+	@Getter
 	private final String name;
+
 	private final int highestBoost;
+
+	int getHighestBoost(boolean includeSpicyStew, int currentUnboostedLevel) {
+		if (includeSpicyStew && highestBoost < 5) {
+			return 5;
+		}
+
+		else if (name.equals("Thieving"))
+		{
+			// Players only have access to Summer sq'irk juice at level 65 thieving which is the default boost value for thieving
+			if (currentUnboostedLevel < 45)
+			{
+				// Spring sq'irk
+				return 1;
+			}
+
+			if (currentUnboostedLevel < 65)
+			{
+				// Autumn sq'irk
+				return 2;
+			}
+
+		}
+
+		return highestBoost;
+	}
 }

--- a/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
+++ b/src/main/java/com/questhelper/requirements/player/SkillRequirement.java
@@ -151,19 +151,19 @@ public class SkillRequirement extends AbstractRequirement
 		return requiredLevel - highestBoost <= currentSkill;
 	}
 
-	public int checkBoosted(Client client, QuestHelperConfig config)
+	public BoostStatus checkBoosted(Client client, QuestHelperConfig config)
 	{
 		int skillLevel = canBeBoosted ? Math.max(client.getBoostedSkillLevel(skill), client.getRealSkillLevel(skill)) :
 			client.getRealSkillLevel(skill);
 
 		if (skillLevel >= requiredLevel)
 		{
-			return 1;
+			return BoostStatus.Pass;
 		} else if (canBeBoosted && checkRange(skill, requiredLevel, client, config))
 		{
-			return 2;
+			return BoostStatus.CanPassWithBoost;
 		} else {
-			return 3;
+			return BoostStatus.Fail;
 		}
 	}
 
@@ -192,14 +192,22 @@ public class SkillRequirement extends AbstractRequirement
 	@Override
 	public Color getColor(Client client, QuestHelperConfig config)
 	{
-		switch (checkBoosted(client, config)){
-			case 1:
+		switch (checkBoosted(client, config))
+		{
+			case Pass:
 				return config.passColour();
-			case 2:
+			case CanPassWithBoost:
 				return config.boostColour();
-			case 3:
+			case Fail:
 				return config.failColour();
 		}
 		return config.failColour();
+	}
+
+	enum BoostStatus
+	{
+		Pass,
+		CanPassWithBoost,
+		Fail,
 	}
 }

--- a/src/test/java/com/questhelper/requirements/player/SkillRequirementTest.java
+++ b/src/test/java/com/questhelper/requirements/player/SkillRequirementTest.java
@@ -1,0 +1,61 @@
+package com.questhelper.requirements.player;
+
+import com.questhelper.MockedTest;
+import net.runelite.api.Skill;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class SkillRequirementTest extends MockedTest
+{
+	void initFishing(int realLevel, int boostedLevel) {
+		when(client.getRealSkillLevel(Skill.FISHING)).thenReturn(realLevel);
+		when(client.getBoostedSkillLevel(Skill.FISHING)).thenReturn(boostedLevel);
+	}
+
+	@Test
+	void unboostable() {
+		var req = new SkillRequirement(Skill.FISHING, 60);
+
+		initFishing(60, 60);
+		assertEquals(SkillRequirement.BoostStatus.Pass, req.checkBoosted(client, questHelperConfig));
+		assertTrue(req.check(client));
+
+		// User has temporarily lost some stats
+		initFishing(60, 59);
+		assertEquals(SkillRequirement.BoostStatus.Pass, req.checkBoosted(client, questHelperConfig));
+		assertTrue(req.check(client));
+
+		initFishing(59, 59);
+		assertEquals(SkillRequirement.BoostStatus.Fail, req.checkBoosted(client, questHelperConfig));
+		assertFalse(req.check(client));
+
+		// User has boosted, but this requirement doesn't allow boosting
+		initFishing(59, 61);
+		assertEquals(SkillRequirement.BoostStatus.Fail, req.checkBoosted(client, questHelperConfig));
+		assertFalse(req.check(client));
+	}
+
+	@Test
+	void boostable() {
+		var req = new SkillRequirement(Skill.FISHING, 60, true);
+
+		// User is outside of boost range
+		initFishing(54, 54);
+		assertEquals(SkillRequirement.BoostStatus.Fail, req.checkBoosted(client, questHelperConfig));
+
+		// User is outside of boost range
+		initFishing(54, 59);
+		assertEquals(SkillRequirement.BoostStatus.Fail, req.checkBoosted(client, questHelperConfig));
+
+		// User can boost
+		initFishing(57, 57);
+		assertEquals(SkillRequirement.BoostStatus.CanPassWithBoost, req.checkBoosted(client, questHelperConfig));
+
+		// User has already boosted
+		initFishing(57, 62);
+		assertEquals(SkillRequirement.BoostStatus.Pass, req.checkBoosted(client, questHelperConfig));
+	}
+}


### PR DESCRIPTION
Fixes https://discord.com/channels/772056816242130964/772059156710031390/1326472562494013452

This change was split up into 2 commits
1. Add tests
2. Fix the broken test

If you run the tests on the first commit, you'll see the test on line 51 fail, and that's the one @Spaenny described in Discord.
With the second commit applied, which includes a bunch of refactoring & the actual fix, you'll see it and all other tests pass.