### PR TITLE
chore(ci): also build with RuneLite's snapshot

### DIFF
--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -1,0 +1,20 @@
+name: Build with Snapshot RuneLite
+on: pull_request
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build using latest runelite snapshot version
+        run: ./gradlew --refresh-dependencies -Puse.snapshot clean build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = 'latest.release'
-
 dependencies {
+	def runeLiteVersion = "latest." + (project.hasProperty("use.snapshot") ? "integration" : "release")
+
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
 	compileOnly 'org.projectlombok:lombok:1.18.30'


### PR DESCRIPTION
To verify that it works:

### Build like normal

```sh
./gradlew dependencyInsight --configuration compileClasspath --dependency net.runelite:client
```

output includes: `net.runelite:client:latest.release -> 1.10.47`

### Build snapshot version

```sh
./gradlew dependencyInsight -Puse.snapshot --configuration compileClasspath --dependency net.runelite:client
```

output includes: `net.runelite:client:latest.integration -> 1.10.48-SNAPSHOT`


From @iProdigy 's work in https://github.com/pajlads/DinkPlugin/pull/640 and https://github.com/pajlads/DinkPlugin/pull/641
