### PR TITLE
fix: Update container state for ItemRequirement on same tick

### DIFF
--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -484,7 +484,7 @@ public class ItemRequirement extends AbstractRequirement
 			{
 				totalFound += getMaxMatchingItems(client, container.getItems());
 			}
-			else if (stateForItemInContainer.getLastCheckedTick() < container.getLastUpdated())
+			else if (stateForItemInContainer.getLastCheckedTick() <= container.getLastUpdated())
 			{
 				int matchesInContainer = getMaxMatchingItems(client, container.getItems());
 				stateForItemInContainer.set(matchesInContainer, client.getTickCount());


### PR DESCRIPTION
This might fix an issue where an inventory change occurs on the same tick as the check occurs.

My theory is that the item added event occurs after the inventory check for an ItemRequirement on the same tick.

This has been observed to occur for receiving items in Throne of Miscellania, and for At First Light. Ideally we can test those.