### PR TITLE
At First Light: Handle prepared players who bring Jerboa tails

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/atfirstlight/AtFirstLight.java
+++ b/src/main/java/com/questhelper/helpers/quests/atfirstlight/AtFirstLight.java
@@ -117,7 +117,7 @@ public class AtFirstLight extends BasicQuestHelper
 
 		ConditionalStep goFindFox = new ConditionalStep(this, buyBoxTrap);
 		goFindFox.addStep(inGuild, goUpTree);
-		goFindFox.addStep(boxTrap, talkToFox);
+		goFindFox.addStep(jerboaTail2OrBoxTrap, talkToFox);
 		steps.put(4, goFindFox);
 
 		ConditionalStep goMakePoultice = new ConditionalStep(this, takeLeaf);


### PR DESCRIPTION
If a player brought 2 Jerboa Tails, they would still be told to buy a box trap.

This PR fixes that

Original report from Discord by shadowsence https://discord.com/channels/772056816242130964/772225322354475059/1279268827779305514
