### PR TITLE
Added horror from the deep to general req list - Frem. Med. Diary

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikMedium.java
@@ -418,6 +418,7 @@ public class FremennikMedium extends ComplexStateQuestHelper
 		req.add(olafsQuest);
 		req.add(eaglesPeak);
 		req.add(betweenARock);
+		req.add(horrorFromTheDeep);
 		return req;
 	}
 


### PR DESCRIPTION
Horror from the Deep added to list of general requirements.

Mentioned on Discord,

>  "Suggestion - Completion of Horror from the Deep should be added to general requirements; it's properly listed in the "Waterbirth to Lighthouse" step, but isn't mentioned in the general requirements"

Suggestion is reflected by the information on the wiki.