### PR TITLE
hscb added to cbow item collection

### DIFF
--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -215,7 +215,8 @@ public enum ItemCollections
 		ItemID.IRON_CROSSBOW,
 		ItemID.BRONZE_CROSSBOW,
 		ItemID.PHOENIX_CROSSBOW,
-		ItemID.CROSSBOW
+		ItemID.CROSSBOW,
+		ItemID.HUNTERS_SUNLIGHT_CROSSBOW
 	)),
 
 	SWORDS("Swords", ImmutableList.of(


### PR DESCRIPTION
### Feedback from Discord:
"also tiny thing, hscb isn't recognised as a crossbow for curse of arrav even though it is one and it can fire mith grapples"

https://oldschool.runescape.wiki/w/Hunters%27_sunlight_crossbow

### Issue: 
**Hunter's Sunlight Crossbow** is not in the **crossbows** item collection

### Implemented Solution:
add item to the collection

**The Curse of Arrav** is using `ItemCollections.CROSSBOWS` to determine whether the player has a crossbow for grappling. When investigating the item collection we see that **Hunter's Sunlight Crossbow** is not included in the collection.