### PR TITLE
Add Translation Book to Item Requirements

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/MonkeyMadnessII.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/MonkeyMadnessII.java
@@ -651,7 +651,7 @@ public class MonkeyMadnessII extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(lemon, grape, pestle, pickaxe, logs, lightSource, hammerSidebar, chiselSidebar, mspeakAmulet, talismanOr1000Coins, ninjaGreegree);
+		return Arrays.asList(lemon, grape, pestle, pickaxe, logs, lightSource, translationBook, hammerSidebar, chiselSidebar, mspeakAmulet, talismanOr1000Coins, ninjaGreegree);
 	}
 
 	@Override


### PR DESCRIPTION
Noticed in the quest that the item requirement for Translation Book in Starting Off is not in the overall item requirements. Figured to add it. 