### PR TITLE
Feat: container check improvements

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -599,6 +599,17 @@ public interface QuestHelperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "partialSuccessColour",
+			name = "Colour of partially passed requirements/checks",
+			description = "Change the colour that will indicate a check has partially passed (such as item is in your bank)",
+			section = colorSection
+	)
+	default Color partialSuccessColour()
+	{
+		return Color.WHITE;
+	}
+
+	@ConfigItem(
 		keyName = "boostColour",
 		name = "Colour of boostable skill",
 		description = "Change the colour that will indicate a skill level check has passed",

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -104,7 +104,7 @@ public class QuestHelperBankTagService
 		{
 			recommendedItems = recommendedItems.stream()
 				.filter(Objects::nonNull)
-				.filter(i -> (!onlyGetMissingItems || !i.checkWithAllContainers(plugin.getClient())) && i.shouldDisplayText(plugin.getClient()))
+				.filter(i -> (!onlyGetMissingItems || !i.checkWithAllContainers()) && i.shouldDisplayText(plugin.getClient()))
 				.collect(Collectors.toList());
 		}
 
@@ -131,7 +131,7 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.checkWithAllContainers(plugin.getClient()))
+						|| !i.checkWithAllContainers())
 						&& i.shouldDisplayText(plugin.getClient()))
 					.collect(Collectors.toList());
 			}
@@ -143,7 +143,7 @@ public class QuestHelperBankTagService
 					.filter(ItemRequirement.class::isInstance)
 					.map(ItemRequirement.class::cast)
 					.filter(i -> (!onlyGetMissingItems
-						|| !i.checkWithAllContainers(plugin.getClient()))
+						|| !i.checkWithAllContainers())
 						&& i.shouldDisplayText(plugin.getClient()))
 					.collect(Collectors.toList());
 			}
@@ -182,7 +182,7 @@ public class QuestHelperBankTagService
 				else
 				{
 					ItemRequirement match = itemsWhichPassReq.stream()
-						.filter(r -> r.checkWithAllContainers(plugin.getClient()))
+						.filter(r -> r.checkWithAllContainers())
 						.findFirst()
 						.orElse(itemsWhichPassReq.get(0).named(itemRequirements.getName()));
 
@@ -217,6 +217,6 @@ public class QuestHelperBankTagService
 	public boolean hasItemInBankOrPotionStorage(int itemID)
 	{
 		ItemRequirement tmpReq = new ItemRequirement("tmp", itemID);
-		return tmpReq.checkWithAllContainers(client);
+		return tmpReq.checkWithAllContainers();
 	}
 }

--- a/src/main/java/com/questhelper/helpers/quests/legendsquest/LegendsQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/legendsquest/LegendsQuest.java
@@ -575,7 +575,6 @@ public class LegendsQuest extends BasicQuestHelper
 			.showConditioned(new SkillRequirement(Skill.MAGIC, 60));
 		elemental30 = new ItemRequirements(LogicType.OR, "Elemental runes", air30, water30, earth30, fire30);
 		elemental30.addAlternates(ItemID.FIRE_RUNE, ItemID.EARTH_RUNE, ItemID.AIR_RUNE);
-		elemental30.setExclusiveToOneItemType(true);
 
 		chargeOrbRunes = new ItemRequirements(LogicType.AND, "Runes for any charge orb spell you have the level to cast", cosmic3, elemental30);
 

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManI.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManI.java
@@ -181,7 +181,7 @@ public class RagAndBoneManI extends BasicQuestHelper
 		potOfVinegarNeeded.setQuantity(winesNeededQuantity.get());
 
 		int jugsNeeded = winesNeededQuantity.get();
-		jugsNeeded -= potOfVinegar.checkTotalMatchesInContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
+		jugsNeeded -= potOfVinegar.checkTotalMatchesInContainers(QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
 		potNeeded.setQuantity(jugsNeeded);
 		jugOfVinegarNeeded.setQuantity(jugsNeeded);
 

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
@@ -302,7 +302,7 @@ public class RagAndBoneManII extends BasicQuestHelper
 		potOfVinegarNeeded.setQuantity(winesNeededQuantity.get());
 
 		int jugsNeeded = winesNeededQuantity.get();
-		jugsNeeded -= potOfVinegar.checkTotalMatchesInContainers(client, QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
+		jugsNeeded -= potOfVinegar.checkTotalMatchesInContainers(QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData());
 		potNeeded.setQuantity(jugsNeeded);
 		jugOfVinegarNeeded.setQuantity(jugsNeeded);
 

--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WhileGuthixSleeps.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WhileGuthixSleeps.java
@@ -659,7 +659,6 @@ public class WhileGuthixSleeps extends BasicQuestHelper
 			.showConditioned(new SkillRequirement(Skill.MAGIC, 60));
 		ItemRequirements elemental30 = new ItemRequirements(LogicType.OR, "Elemental runes", air30, water30, earth30, fire30);
 		elemental30.addAlternates(ItemID.FIRE_RUNE, ItemID.EARTH_RUNE, ItemID.AIR_RUNE);
-		elemental30.setExclusiveToOneItemType(true);
 
 		chargeOrbSpell = new ItemRequirements(LogicType.AND, "Runes for any charge orb spell you have the level to cast", cosmic3, elemental30);
 		combatGear = new ItemRequirement("Combat gear", -1, -1).isNotConsumed();

--- a/src/main/java/com/questhelper/managers/QuestContainerManager.java
+++ b/src/main/java/com/questhelper/managers/QuestContainerManager.java
@@ -27,6 +27,8 @@ package com.questhelper.managers;
 import com.questhelper.requirements.item.TrackedContainers;
 import lombok.Getter;
 
+import java.util.List;
+
 public class QuestContainerManager
 {
     @Getter
@@ -43,4 +45,7 @@ public class QuestContainerManager
 
     @Getter
     private final static ItemAndLastUpdated groupStorageData = new ItemAndLastUpdated(TrackedContainers.GROUP_STORAGE);
+
+    @Getter
+    private final static List<ItemAndLastUpdated> orderedListOfContainers = List.of(equippedData, inventoryData, bankData, potionData, groupStorageData);
 }

--- a/src/main/java/com/questhelper/panel/QuestRequirementsPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRequirementsPanel.java
@@ -25,12 +25,14 @@
  */
 package com.questhelper.panel;
 
+import com.questhelper.QuestHelperConfig;
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.managers.QuestManager;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.NoItemRequirement;
+import com.questhelper.requirements.item.TrackedContainers;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.tools.Icon;
 import com.questhelper.util.Fonts;
@@ -141,10 +143,7 @@ public class QuestRequirementsPanel extends JPanel
 
 				panel.add(label, BorderLayout.CENTER);
 
-				if (requirement.getTooltip() != null)
-				{
-					tooltipButton = addButtonToPanel(panel, requirement.getTooltip());
-				}
+				tooltipButton = addButtonToPanel(panel, requirement.getTooltip());
 
 				var wikiUrl = requirement.getWikiUrl();
 				if (wikiUrl != null)
@@ -255,10 +254,6 @@ public class QuestRequirementsPanel extends JPanel
 			}
 
 			label.setVisible(true);
-			if (tooltipButton != null)
-			{
-				tooltipButton.setVisible(true);
-			}
 			numActive += 1;
 
 			var newText = req.getDisplayText();
@@ -280,29 +275,23 @@ public class QuestRequirementsPanel extends JPanel
 				}
 				else
 				{
-					newColor = itemRequirement.getColorConsideringBank(client, questHelperPlugin.getConfig());
+					newColor = itemRequirement.getColor(client, questHelperPlugin.getConfig());
+					String tooltip = itemRequirement.getTooltip();
+					if (tooltip != null && !tooltip.isEmpty())
+					{
+						label.setToolTipText(itemRequirement.getTooltip());
+						if (tooltipButton != null) tooltipButton.setVisible(true);
+					}
+					else
+					{
+						label.setToolTipText("");
+						if (tooltipButton != null) tooltipButton.setVisible(false);
+					}
 				}
 			}
 			else
 			{
 				newColor = req.getColor(client, questHelperPlugin.getConfig());
-			}
-
-			if (newColor == Color.WHITE)
-			{
-				label.setToolTipText("In bank");
-			}
-			else if (newColor == Color.ORANGE)
-			{
-				label.setToolTipText("On steel key ring");
-			}
-			else if (newColor == Color.LIGHT_GRAY)
-			{
-				label.setToolTipText("Possibly in Group Storage");
-			}
-			else
-			{
-				label.setToolTipText("");
 			}
 
 			label.setForeground(newColor);
@@ -315,7 +304,10 @@ public class QuestRequirementsPanel extends JPanel
 	{
 		JButton b = new JButton(INFO_ICON);
 		b.setPreferredSize(new Dimension(10, 10));
-		b.setToolTipText(tooltipText);
+		if (tooltipText != null)
+		{
+			b.setToolTipText(tooltipText);
+		}
 		b.setBorderPainted(false);
 		b.setFocusPainted(false);
 		b.setBorderPainted(false);

--- a/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
+++ b/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
@@ -30,7 +30,10 @@ import com.questhelper.collections.TeleportCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.player.SpellbookRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.util.Spellbook;
 import com.questhelper.requirements.widget.WidgetTextRequirement;
 import com.questhelper.requirements.zone.Zone;
@@ -41,10 +44,7 @@ import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
 import com.questhelper.steps.widget.NormalSpells;
-import net.runelite.api.ItemID;
-import net.runelite.api.NpcID;
-import net.runelite.api.NullObjectID;
-import net.runelite.api.ObjectID;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.ComponentID;
 import java.util.ArrayList;
@@ -83,7 +83,10 @@ public class BikeShedder extends BasicQuestHelper
 	private WidgetTextRequirement lookAtCooksAssistantTextRequirement;
 	private ZoneRequirement byStaircaseInSunrisePalace;
 	private ObjectStep goDownstairsInSunrisePalace;
+	private DetailedQuestStep haveRunes;
 	private ItemRequirement lightbearer;
+	private ItemRequirement elemental30Unique;
+	private ItemRequirement elemental30;
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
@@ -94,6 +97,7 @@ public class BikeShedder extends BasicQuestHelper
 		var steps = new ConditionalStep(this, confuseHans);
 		steps.addStep(byStaircaseInSunrisePalace, goDownstairsInSunrisePalace);
 		steps.addStep(outsideLumbridge, moveToLumbridge);
+		steps.addStep(new ZoneRequirement(new WorldPoint(3224, 3218, 0)), haveRunes);
 		steps.addStep(new ZoneRequirement(new WorldPoint(3222, 3218, 0)), equipLightbearer);
 		steps.addStep(new ZoneRequirement(new WorldPoint(3223, 3218, 0)), useLogOnBush);
 		steps.addStep(new ZoneRequirement(new WorldPoint(3222, 3217, 0)), useCoinOnBush);
@@ -119,6 +123,7 @@ public class BikeShedder extends BasicQuestHelper
 		equipLightbearer = new DetailedQuestStep(this, "Equip a Lightbearer", lightbearer.equipped());
 
 		anyLog = new ItemRequirement("Any log", ItemCollections.LOGS_FOR_FIRE).highlighted();
+
 		useLogOnBush = new ObjectStep(this, NullObjectID.NULL_10778, new WorldPoint(3223, 3217, 0), "Use log on bush", anyLog);
 		useLogOnBush.addIcon(ItemID.LOGS);
 
@@ -162,11 +167,27 @@ public class BikeShedder extends BasicQuestHelper
 		var upstairsInSunrisePalace = new Zone(new WorldPoint(1684, 3162, 1), new WorldPoint(1691, 3168, 1));
 		byStaircaseInSunrisePalace = new ZoneRequirement(upstairsInSunrisePalace);
 		goDownstairsInSunrisePalace = new ObjectStep(getQuest().getQuestHelper(), ObjectID.STAIRCASE_52627, new WorldPoint(1690, 3164, 1), "Climb downstairs, ensure stairs are well highlighted!");
+
+
+		var fire30 = new ItemRequirement("Fire runes", ItemID.FIRE_RUNE, 30)
+				.showConditioned(new SkillRequirement(Skill.MAGIC, 63));
+		var air30 = new ItemRequirement("Air runes", ItemID.AIR_RUNE, 30)
+				.showConditioned(new SkillRequirement(Skill.MAGIC, 66));
+		var water30 = new ItemRequirement("Water runes", ItemID.WATER_RUNE, 30)
+				.showConditioned(new SkillRequirement(Skill.MAGIC, 56));
+		var earth30 = new ItemRequirement("Earth runes", ItemID.EARTH_RUNE, 30)
+				.showConditioned(new SkillRequirement(Skill.MAGIC, 60));
+		elemental30Unique = new ItemRequirements(LogicType.OR, "Elemental runes as ItemRequirements OR", air30, water30, earth30, fire30);
+		elemental30Unique.addAlternates(ItemID.FIRE_RUNE, ItemID.EARTH_RUNE, ItemID.AIR_RUNE);
+		elemental30 = new ItemRequirement("Elemental rune as ItemRequirement", List.of(ItemID.AIR_RUNE, ItemID.EARTH_RUNE, ItemID.WATER_RUNE,
+				ItemID.FIRE_RUNE),	30);
+		elemental30.setTooltip("You have potato");
+		haveRunes = new DetailedQuestStep(this, "Compare rune checks for ItemRequirement and ItemRequirements with OR.", elemental30, elemental30Unique);
 	}
 
 	@Override
 	public List<ItemRequirement> getItemRecommended() {
-		return Arrays.asList(varrockTeleport, ardougneTeleport, faladorTeleport);
+		return Arrays.asList(varrockTeleport, ardougneTeleport, faladorTeleport, elemental30, elemental30Unique);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -459,7 +459,7 @@ public class ItemRequirement extends AbstractRequirement
 		{
 			basicTooltip += "\n";
 		}
-		// TODO: Sidebar info tip isn't appearing properly
+
 		return basicTooltip + "Items can be found in your: " + containers.stream()
 				// Convert enum name to title case
 				.map(Text::titleCase)

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -37,7 +37,6 @@ import com.questhelper.requirements.ManualRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
-
 import java.awt.*;
 import java.util.*;
 import java.util.List;
@@ -52,64 +51,116 @@ import net.runelite.client.util.Text;
 import org.jetbrains.annotations.Nullable;
 import javax.annotation.Nonnull;
 
+/**
+ * Represents a requirement for a specific item within the quest helper.
+ * <p>
+ * This class checks if the player possesses a certain item (or one of its alternate items)
+ * in various containers (inventory, equipped, bank, etc.) while also supporting additional options,
+ * quantity checks (including charged items), and display customizations.
+ * </p>
+ */
 public class ItemRequirement extends AbstractRequirement
 {
+	/**
+	 * The primary item id for this requirement.
+	 */
 	@Setter
 	@Getter
 	private int id;
 
+	/**
+	 * The display name for this item requirement.
+	 */
 	@Setter
 	private String name;
 
+	/**
+	 * The item id used for display purposes, if specified.
+	 */
 	@Setter
 	@Getter
 	private Integer displayItemId;
 
+	/**
+	 * The required quantity of the item.
+	 */
 	@Setter
 	@Getter
 	protected int quantity;
 
+	/**
+	 * Indicates whether the item must be equipped.
+	 */
 	@Getter
 	@Setter
 	protected boolean equip;
 
+	/**
+	 * Whether the item should be highlighted in the inventory.
+	 */
 	@Setter
 	protected boolean highlightInInventory;
 
+	/**
+	 * Alternate item ids that satisfy this requirement.
+	 */
 	protected final List<Integer> alternateItems = new ArrayList<>();
 
+	/**
+	 * Determines whether the matched item name should be displayed.
+	 */
 	@Setter
 	@Getter
 	private boolean displayMatchedItemName;
 
-	// This is defaulted to a ManualRequirement so that we can use a null state to better detect issues
+	/**
+	 * A condition that, if met, hides this requirement.
+	 * Defaulted to a ManualRequirement to allow a null state to be better detected.
+	 */
 	@Setter
 	@Getter
 	protected Requirement conditionToHide = new ManualRequirement();
 
+	/**
+	 * The quest bank used for additional bank checks.
+	 */
 	@Setter
 	@Getter
 	private QuestBank questBank;
 
+	/**
+	 * Flag to indicate whether the bank should be checked.
+	 */
 	@Setter
-	@Getter
 	private boolean shouldCheckBank;
 
+	/**
+	 * Indicates whether this item is consumed.
+	 */
 	@Getter
 	protected boolean isConsumedItem = true;
 
+	/**
+	 * Determines whether the item count should be aggregated from multiple sources.
+	 */
 	protected boolean shouldAggregate = true;
 
 	/**
-	 * Denotes whether the quantity-check should take into consideration item charges.
-	 * With this enabled, 1xRing of dueling(7) will count as 7 quantity.
+	 * Denotes whether the quantity-check should consider item charges.
+	 * For example, a charged item like a Ring of dueling (7) will count as 7 quantity.
 	 */
 	@Setter
 	@Getter
 	protected boolean isChargedItem = false;
 
+	/**
+	 * Additional options that can further modify the requirement.
+	 */
 	protected Requirement additionalOptions;
 
+	/**
+	 * Stores the last known state for each container type for this requirement.
+	 */
 	Map<TrackedContainers, ContainerStateForRequirement> knownContainerStates = new HashMap<>();
 	{
 		for (TrackedContainers value : TrackedContainers.values())
@@ -118,11 +169,25 @@ public class ItemRequirement extends AbstractRequirement
 		}
 	}
 
+	/**
+	 * Constructs a new ItemRequirement with the specified name and item id,
+	 * requiring a default quantity of 1.
+	 *
+	 * @param name the display name of the item requirement
+	 * @param id   the primary item id for the requirement
+	 */
 	public ItemRequirement(String name, int id)
 	{
 		this(name, id, 1);
 	}
 
+	/**
+	 * Constructs a new ItemRequirement with the specified name, item id, and required quantity.
+	 *
+	 * @param name     the display name of the item requirement
+	 * @param id       the primary item id for the requirement
+	 * @param quantity the required quantity of the item
+	 */
 	public ItemRequirement(String name, int id, int quantity)
 	{
 		this.id = id;
@@ -131,46 +196,90 @@ public class ItemRequirement extends AbstractRequirement
 		equip = false;
 	}
 
+	/**
+	 * Constructs a new ItemRequirement with the specified name, item id, required quantity, and equipment requirement.
+	 *
+	 * @param name     the display name of the item requirement
+	 * @param id       the primary item id for the requirement
+	 * @param quantity the required quantity of the item
+	 * @param equip    {@code true} if the item must be equipped, {@code false} otherwise
+	 */
 	public ItemRequirement(String name, int id, int quantity, boolean equip)
 	{
 		this(name, id, quantity);
 		this.equip = equip;
 	}
 
+	/**
+	 * Constructs a new ItemRequirement with an option to highlight the item in the inventory.
+	 *
+	 * @param highlightInInventory {@code true} if the item should be highlighted in the inventory
+	 * @param name                 the display name of the item requirement
+	 * @param id                   the primary item id for the requirement
+	 */
 	public ItemRequirement(boolean highlightInInventory, String name, int id)
 	{
 		this(name, id);
 		this.highlightInInventory = highlightInInventory;
 	}
 
+	/**
+	 * Constructs a new ItemRequirement using a list of item ids. The first id is used as the primary id,
+	 * and the remaining ids are considered alternate items.
+	 *
+	 * @param name  the display name of the item requirement
+	 * @param items the list of item ids, where the first element is the primary id
+	 * @throws AssertionError if any item in the list is {@code null}
+	 */
 	public ItemRequirement(String name, List<Integer> items)
 	{
 		this(name, items.get(0), 1);
-
-		assert(items.stream().noneMatch(Objects::isNull));
-
+		assert (items.stream().noneMatch(Objects::isNull));
 		this.addAlternates(items.subList(1, items.size()));
 	}
 
+	/**
+	 * Constructs a new ItemRequirement using a list of item ids with a specified quantity.
+	 * The first id in the list is used as the primary id, and the remaining are considered alternates.
+	 *
+	 * @param name     the display name of the item requirement
+	 * @param items    the list of item ids, where the first element is the primary id
+	 * @param quantity the required quantity of the item
+	 * @throws AssertionError if any item in the list is {@code null}
+	 */
 	public ItemRequirement(String name, List<Integer> items, int quantity)
 	{
 		this(name, items.get(0), quantity);
-
-		assert(items.stream().noneMatch(Objects::isNull));
-
+		assert (items.stream().noneMatch(Objects::isNull));
 		this.addAlternates(items.subList(1, items.size()));
 	}
 
+	/**
+	 * Constructs a new ItemRequirement using a list of item ids with a specified quantity and equipment flag.
+	 * The first id in the list is used as the primary id, and the remaining are considered alternates.
+	 *
+	 * @param name     the display name of the item requirement
+	 * @param items    the list of item ids, where the first element is the primary id
+	 * @param quantity the required quantity of the item
+	 * @param equip    {@code true} if the item must be equipped, {@code false} otherwise
+	 * @throws AssertionError if any item in the list is {@code null}
+	 */
 	public ItemRequirement(String name, List<Integer> items, int quantity, boolean equip)
 	{
 		this(name, items.get(0), quantity);
-
-		assert(items.stream().noneMatch(Objects::isNull));
-
+		assert (items.stream().noneMatch(Objects::isNull));
 		this.equip = equip;
 		this.addAlternates(items.subList(1, items.size()));
 	}
 
+	/**
+	 * Constructs a new ItemRequirement using an {@link ItemCollections} object.
+	 * The primary item id is the first item in the collection, and alternate items are added from the remainder.
+	 * Also sets the URL suffix for the wiki lookup.
+	 *
+	 * @param name           the display name of the item requirement
+	 * @param itemCollection the {@link ItemCollections} containing item ids and wiki term information
+	 */
 	public ItemRequirement(String name, ItemCollections itemCollection)
 	{
 		this(name, itemCollection.getItems().get(0), 1);
@@ -178,6 +287,15 @@ public class ItemRequirement extends AbstractRequirement
 		this.addAlternates(itemCollection.getItems().subList(1, itemCollection.getItems().size()));
 	}
 
+	/**
+	 * Constructs a new ItemRequirement using an {@link ItemCollections} object and a specified quantity.
+	 * The primary item id is the first item in the collection, and alternate items are added from the remainder.
+	 * Also sets the URL suffix for the wiki lookup.
+	 *
+	 * @param name           the display name of the item requirement
+	 * @param itemCollection the {@link ItemCollections} containing item ids and wiki term information
+	 * @param quantity       the required quantity of the item
+	 */
 	public ItemRequirement(String name, ItemCollections itemCollection, int quantity)
 	{
 		this(name, itemCollection.getItems().get(0), quantity);
@@ -185,6 +303,16 @@ public class ItemRequirement extends AbstractRequirement
 		this.addAlternates(itemCollection.getItems().subList(1, itemCollection.getItems().size()));
 	}
 
+	/**
+	 * Constructs a new ItemRequirement using an {@link ItemCollections} object, a specified quantity, and an equipment flag.
+	 * The primary item id is the first item in the collection, and alternate items are added from the remainder.
+	 * Also sets the URL suffix for the wiki lookup.
+	 *
+	 * @param name           the display name of the item requirement
+	 * @param itemCollection the {@link ItemCollections} containing item ids and wiki term information
+	 * @param quantity       the required quantity of the item
+	 * @param equip          {@code true} if the item must be equipped, {@code false} otherwise
+	 */
 	public ItemRequirement(String name, ItemCollections itemCollection, int quantity, boolean equip)
 	{
 		this(name, itemCollection.getItems().get(0), quantity);
@@ -193,26 +321,51 @@ public class ItemRequirement extends AbstractRequirement
 		this.addAlternates(itemCollection.getItems().subList(1, itemCollection.getItems().size()));
 	}
 
+	/**
+	 * Adds a list of alternate item ids to this requirement.
+	 *
+	 * @param alternates the list of alternate item ids
+	 */
 	public void addAlternates(List<Integer> alternates)
 	{
 		this.alternateItems.addAll(alternates);
 	}
 
+	/**
+	 * Adds alternate item ids from an {@link ItemCollections} object.
+	 *
+	 * @param alternates the {@link ItemCollections} containing alternate item ids
+	 */
 	public void addAlternates(ItemCollections alternates)
 	{
 		this.alternateItems.addAll(alternates.getItems());
 	}
 
+	/**
+	 * Adds alternate item ids to this requirement.
+	 *
+	 * @param alternates an array of alternate item ids
+	 */
 	public void addAlternates(Integer... alternates)
 	{
 		this.alternateItems.addAll(Arrays.asList(alternates));
 	}
 
+	/**
+	 * Determines whether the quantity should be displayed.
+	 *
+	 * @return {@code true} if the quantity is not -1, {@code false} otherwise
+	 */
 	public boolean showQuantity()
 	{
 		return quantity != -1;
 	}
 
+	/**
+	 * Returns a copy of this requirement with the {@code highlightInInventory} flag set to {@code true}.
+	 *
+	 * @return a new {@link ItemRequirement} instance with highlighting enabled
+	 */
 	public ItemRequirement highlighted()
 	{
 		ItemRequirement newItem = copy();
@@ -220,12 +373,23 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Configures this requirement to check the specified quest bank. Needs to not need {@link QuestBank} in the future as it no longer uses it.
+	 *
+	 * @param questBank the {@link QuestBank} to use for bank checks; if {@code null}, bank checks are disabled
+	 */
 	public void useQuestBank(QuestBank questBank)
 	{
 		this.shouldCheckBank = questBank != null;
 		this.questBank = questBank;
 	}
 
+	/**
+	 * Returns a copy of this requirement that also checks the specified quest bank. Needs to not need {@link QuestBank} in the future as it no longer uses it.
+	 *
+	 * @param questBank the {@link QuestBank} to use for additional bank checks
+	 * @return a new {@link ItemRequirement} instance configured to check the bank
+	 */
 	public ItemRequirement alsoCheckBank(QuestBank questBank)
 	{
 		ItemRequirement newItem = copy();
@@ -233,6 +397,12 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with a new display name.
+	 *
+	 * @param name the new display name
+	 * @return a new {@link ItemRequirement} instance with the updated name
+	 */
 	public ItemRequirement named(String name)
 	{
 		ItemRequirement newItem = copy();
@@ -240,6 +410,11 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with the equipment flag set to {@code true}.
+	 *
+	 * @return a new {@link ItemRequirement} instance marked as equipped
+	 */
 	public ItemRequirement equipped()
 	{
 		ItemRequirement newItem = copy();
@@ -247,6 +422,11 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with the consumed flag set to {@code false}.
+	 *
+	 * @return a new {@link ItemRequirement} instance that is not considered a consumed item
+	 */
 	public ItemRequirement isNotConsumed()
 	{
 		ItemRequirement newItem = copy();
@@ -254,6 +434,11 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with aggregation disabled.
+	 *
+	 * @return a new {@link ItemRequirement} instance with aggregation turned off
+	 */
 	public ItemRequirement doNotAggregate()
 	{
 		ItemRequirement newItem = copy();
@@ -261,6 +446,12 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with an updated required quantity.
+	 *
+	 * @param newQuantity the new required quantity
+	 * @return a new {@link ItemRequirement} instance with the updated quantity
+	 */
 	public ItemRequirement quantity(int newQuantity)
 	{
 		ItemRequirement newItem = copy();
@@ -268,6 +459,12 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with a condition that hides the requirement if met.
+	 *
+	 * @param condition the condition that determines whether to hide this requirement
+	 * @return a new {@link ItemRequirement} instance with the hide condition applied
+	 */
 	public ItemRequirement hideConditioned(Requirement condition)
 	{
 		ItemRequirement newItem = copy();
@@ -275,6 +472,12 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Returns a copy of this requirement with a condition that shows the requirement only when not met.
+	 *
+	 * @param condition the condition to evaluate for showing the requirement
+	 * @return a new {@link ItemRequirement} instance with the show condition applied
+	 */
 	public ItemRequirement showConditioned(Requirement condition)
 	{
 		ItemRequirement newItem = copy();
@@ -282,6 +485,15 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Creates a copy of this requirement.
+	 * <p>
+	 * Subclasses should override this method to return a copy of their own type.
+	 * </p>
+	 *
+	 * @return a copy of this {@link ItemRequirement}
+	 * @throws UnsupportedOperationException if the class is not exactly {@link ItemRequirement}
+	 */
 	protected ItemRequirement copyOfClass()
 	{
 		if (this.getClass() != ItemRequirement.class)
@@ -291,6 +503,11 @@ public class ItemRequirement extends AbstractRequirement
 		return new ItemRequirement(name, id, quantity, equip);
 	}
 
+	/**
+	 * Creates a deep copy of this {@link ItemRequirement}, including all alternate items and additional options.
+	 *
+	 * @return a new {@link ItemRequirement} instance that is a copy of this one
+	 */
 	public ItemRequirement copy()
 	{
 		ItemRequirement newItem = copyOfClass();
@@ -314,21 +531,39 @@ public class ItemRequirement extends AbstractRequirement
 		return newItem;
 	}
 
+	/**
+	 * Determines if this requirement represents a valid item.
+	 *
+	 * @return {@code true} if the item id and quantity are valid (not -1), {@code false} otherwise
+	 */
 	public boolean isActualItem()
 	{
 		return id != -1 && quantity != -1;
 	}
 
+	/**
+	 * Appends a tooltip indicating that the item can be obtained during the quest.
+	 */
 	public void canBeObtainedDuringQuest()
 	{
 		appendToTooltip("Can be obtained during the quest.");
 	}
 
+	/**
+	 * Returns the display name of this item requirement.
+	 *
+	 * @return the name of the item requirement
+	 */
 	public String getName()
 	{
 		return name;
 	}
 
+	/**
+	 * Retrieves a list of all item ids associated with this requirement, including alternates.
+	 *
+	 * @return a {@link List} of unique item ids
+	 */
 	public List<Integer> getAllIds()
 	{
 		List<Integer> items = new ArrayList<>(Collections.singletonList(id));
@@ -337,6 +572,13 @@ public class ItemRequirement extends AbstractRequirement
 		return items.stream().distinct().collect(Collectors.toList());
 	}
 
+	/**
+	 * Generates the overlay display text for this item requirement.
+	 *
+	 * @param client the {@link Client} for which to generate the display text
+	 * @param config the {@link QuestHelperConfig} containing configuration settings
+	 * @return a {@link List} of {@link LineComponent} objects representing the display text
+	 */
 	@Override
 	protected List<LineComponent> getOverlayDisplayText(Client client, QuestHelperConfig config)
 	{
@@ -372,6 +614,11 @@ public class ItemRequirement extends AbstractRequirement
 		return lines;
 	}
 
+	/**
+	 * Returns the display text for this item requirement, which includes the quantity (if applicable) and the item name.
+	 *
+	 * @return the display text for this requirement
+	 */
 	@Nonnull
 	@Override
 	public String getDisplayText()
@@ -388,11 +635,21 @@ public class ItemRequirement extends AbstractRequirement
 		return text.toString();
 	}
 
+	/**
+	 * Sets additional options for this requirement.
+	 *
+	 * @param additionalOptions an additional {@link Requirement} to be applied
+	 */
 	public void setAdditionalOptions(Requirement additionalOptions)
 	{
 		this.additionalOptions = additionalOptions;
 	}
 
+	/**
+	 * Retrieves the wiki URL for this item based on the URL suffix or item id.
+	 *
+	 * @return the wiki URL as a {@link String}, or {@code null} if not available
+	 */
 	@Nullable
 	@Override
 	public String getWikiUrl()
@@ -408,12 +665,26 @@ public class ItemRequirement extends AbstractRequirement
 		return null;
 	}
 
+	/**
+	 * Determines whether the text for this requirement should be displayed,
+	 * based on the hide condition.
+	 *
+	 * @param client the {@link Client} for which to evaluate the condition
+	 * @return {@code true} if the text should be displayed, {@code false} otherwise
+	 */
 	@Override
 	public boolean shouldDisplayText(Client client)
 	{
 		return conditionToHide == null || !conditionToHide.check(client);
 	}
 
+	/**
+	 * Determines the display color for this item requirement based on the client's state.
+	 *
+	 * @param client the {@link Client} for which the color is determined
+	 * @param config the {@link QuestHelperConfig} containing color configuration
+	 * @return the {@link Color} representing the state of the requirement
+	 */
 	@Override
 	public Color getColor(Client client, QuestHelperConfig config)
 	{
@@ -433,6 +704,11 @@ public class ItemRequirement extends AbstractRequirement
 		return color;
 	}
 
+	/**
+	 * Generates a tooltip for this item requirement, indicating which containers may have the required items.
+	 *
+	 * @return the tooltip text as a {@link String}, or {@code null} if not applicable
+	 */
 	@Override
 	public String getTooltip()
 	{
@@ -447,6 +723,12 @@ public class ItemRequirement extends AbstractRequirement
 		return null;
 	}
 
+	/**
+	 * Constructs a tooltip message from a set of tracked containers.
+	 *
+	 * @param containers the set of {@link TrackedContainers} where the item is found
+	 * @return a tooltip {@link String} indicating which containers contain the item
+	 */
 	protected String getTooltipFromEnumSet(Set<TrackedContainers> containers)
 	{
 		containers.removeAll(getOnPlayerContainers());
@@ -466,7 +748,12 @@ public class ItemRequirement extends AbstractRequirement
 				.collect(Collectors.joining(", "));
 	}
 
-	/** Find the first item that this requirement allows that the player has, or -1 if they don't have any item(s) */
+	/**
+	 * Finds the first item id from the list of allowed items that the player has,
+	 * based on the quantity required.
+	 *
+	 * @return the matching item id if found; otherwise, -1
+	 */
 	private int findItemID()
 	{
 		int remainder = getNumberOfItemFound(id, null);
@@ -486,16 +773,30 @@ public class ItemRequirement extends AbstractRequirement
 		return -1;
 	}
 
+	/**
+	 * Checks if the provided list of items satisfies this requirement.
+	 *
+	 * @param client the {@link Client} for which the check is performed
+	 * @param items  a {@link List} of {@link Item} objects to check
+	 * @return {@code true} if the total matching items meet or exceed the required quantity, {@code false} otherwise
+	 */
 	public boolean checkItems(Client client, List<Item> items)
 	{
 		return getMaxMatchingItems(items.toArray(new Item[0])) >= quantity;
 	}
 
+	/**
+	 * Checks the total number of matching items across the specified containers.
+	 *
+	 * @param containers an array of {@link ItemAndLastUpdated} representing different item containers
+	 * @return the total number of matching items found in the containers
+	 */
 	public int checkTotalMatchesInContainers(ItemAndLastUpdated... containers)
 	{
 		int totalFound = 0;
 
-		// Consideration: If any have changed, AND ItemRequirement requires unique item, then we do need to aggregate all the results
+		// Consideration: If any container has changed and a unique item is required,
+		// we need to aggregate all the results.
 		for (ItemAndLastUpdated container : containers)
 		{
 			if (container.getItems() == null)
@@ -511,7 +812,8 @@ public class ItemRequirement extends AbstractRequirement
 			else if (stateForItemInContainer.getLastCheckedTick() <= container.getLastUpdated())
 			{
 				int matchesInContainer = getMaxMatchingItems(container.getItems());
-				// Won't represent actual last checked, but ensures it's after the current state for comparison
+				// Update the container state (won't represent the actual last checked tick,
+				// but ensures it's after the current state for comparison)
 				stateForItemInContainer.set(matchesInContainer, container.getLastUpdated() + 1);
 				totalFound += matchesInContainer;
 			}
@@ -524,24 +826,51 @@ public class ItemRequirement extends AbstractRequirement
 		return totalFound;
 	}
 
-	// This will ignore any defined conditions for what to consider, and will check across all
-	// containers passed in for the item
+	/**
+	 * Checks whether the total number of matching items across the specified containers meets the required quantity.
+	 *
+	 * @param containers an array of {@link ItemAndLastUpdated} representing different item containers
+	 * @return {@code true} if the total matches are greater than or equal to the required quantity, {@code false} otherwise
+	 */
 	public boolean checkContainers(ItemAndLastUpdated... containers)
 	{
 		return checkTotalMatchesInContainers(containers) >= quantity;
 	}
 
+	/**
+	 * Checks whether the player has the required items in their equipped and inventory containers.
+	 *
+	 * @param client the {@link Client} for which to perform the check
+	 * @return {@code true} if the required items are found on the player, {@code false} otherwise
+	 */
 	private boolean checkContainersOnPlayer(Client client)
 	{
 		return checkContainers(QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData());
 	}
 
+	/**
+	 * Checks whether the total number of matching items across all relevant containers (equipped, inventory, bank, potion, group storage)
+	 * meets the required quantity.
+	 *
+	 * @return {@code true} if the total matches are sufficient, {@code false} otherwise
+	 */
 	public boolean checkWithAllContainers()
 	{
-		return checkContainers(QuestContainerManager.getEquippedData(), QuestContainerManager.getInventoryData(), QuestContainerManager.getBankData()
-				, QuestContainerManager.getPotionData(), QuestContainerManager.getGroupStorageData());
+		return checkContainers(QuestContainerManager.getEquippedData(),
+				QuestContainerManager.getInventoryData(),
+				QuestContainerManager.getBankData(),
+				QuestContainerManager.getPotionData(),
+				QuestContainerManager.getGroupStorageData());
 	}
 
+	/**
+	 * Retrieves a set of tracked containers that contain the required items.
+	 * <p>
+	 * The method checks the containers in order and returns once the cumulative count meets the required quantity.
+	 * </p>
+	 *
+	 * @return a {@link Set} of {@link TrackedContainers} where the item is present, or an empty set if not enough items are found
+	 */
 	public Set<TrackedContainers> getContainersWithItem()
 	{
 		if (!isActualItem())
@@ -552,7 +881,7 @@ public class ItemRequirement extends AbstractRequirement
 		Set<TrackedContainers> containersWithItem = new LinkedHashSet<>();
 		int totalFoundAcrossContainers = 0;
 
-		// This is relying on the order in the enum to determine priority of container checks
+		// This relies on the order in the enum to determine the priority of container checks.
 		for (ItemAndLastUpdated container : QuestContainerManager.getOrderedListOfContainers())
 		{
 			int totalFoundInCurrentContainer = checkTotalMatchesInContainers(container);
@@ -567,15 +896,21 @@ public class ItemRequirement extends AbstractRequirement
 			}
 		}
 
-		// If not enough across containers, return failed?
-		// Consideration: Still return partial success instead?
+		// Not enough items found across containers; return an empty set.
 		return new LinkedHashSet<>();
 	}
 
+	/**
+	 * Generates additional overlay text components for this item requirement, such as equipped status and tooltip.
+	 *
+	 * @param client         the {@link Client} for which the overlay is generated
+	 * @param includeTooltip {@code true} to include tooltip information if applicable
+	 * @param config         the {@link QuestHelperConfig} containing display configurations
+	 * @return an {@link ArrayList} of {@link LineComponent} objects representing the additional text
+	 */
 	protected ArrayList<LineComponent> getAdditionalText(Client client, boolean includeTooltip, QuestHelperConfig config)
 	{
 		Color equipColor = config.passColour();
-
 		ArrayList<LineComponent> lines = new ArrayList<>();
 
 		if (this.isEquip())
@@ -602,10 +937,17 @@ public class ItemRequirement extends AbstractRequirement
 		return lines;
 	}
 
+	/**
+	 * Checks whether this item requirement is satisfied for the given client,
+	 * taking into account additional options and various containers.
+	 *
+	 * @param client the {@link Client} for which the check is performed
+	 * @return {@code true} if the requirement is met, {@code false} otherwise
+	 */
 	@Override
 	public boolean check(Client client)
 	{
-		// This may need to apply to other forms of checking on containers. Future consideration.
+		// If additional options are present and pass, then the requirement is met.
 		if (additionalOptions != null && additionalOptions.check(client))
 		{
 			return true;
@@ -614,7 +956,10 @@ public class ItemRequirement extends AbstractRequirement
 		List<ItemAndLastUpdated> containers = new ArrayList<>();
 		containers.add(QuestContainerManager.getEquippedData());
 
-		if (!equip) containers.add(QuestContainerManager.getInventoryData());
+		if (!equip)
+		{
+			containers.add(QuestContainerManager.getInventoryData());
+		}
 		if (shouldCheckBank)
 		{
 			containers.add(QuestContainerManager.getBankData());
@@ -625,12 +970,17 @@ public class ItemRequirement extends AbstractRequirement
 		return checkContainers(containers.toArray(new ItemAndLastUpdated[0]));
 	}
 
+	/**
+	 * Determines the maximum number of matching items from the given array.
+	 *
+	 * @param items an array of {@link Item} objects to evaluate
+	 * @return the total count of matching items found
+	 */
 	private int getMaxMatchingItems(@NonNull Item[] items)
 	{
 		List<Item> allItems = new ArrayList<>(List.of(items));
 
 		int foundQuantity = 0;
-
 		List<Integer> ids = getAllIds();
 		for (int alternate : ids)
 		{
@@ -641,8 +991,12 @@ public class ItemRequirement extends AbstractRequirement
 	}
 
 	/**
-	 * Get the difference between the required quantity for this requirement and the amount the client has.
-	 * Any value <= 0 indicates they have the required amount
+	 * Calculates the number of items found for the specified item id in the given list.
+	 * Any value <= 0 indicates the required quantity is not met.
+	 *
+	 * @param itemID the item id to search for
+	 * @param items  a {@link List} of {@link Item} objects; can be {@code null}
+	 * @return the total quantity found for the specified item id
 	 */
 	public int getNumberOfItemFound(int itemID, List<Item> items)
 	{
@@ -656,6 +1010,16 @@ public class ItemRequirement extends AbstractRequirement
 		return tempQuantity;
 	}
 
+	/**
+	 * Counts the number of matches for a specific item id in the provided list of items.
+	 * <p>
+	 * If the item is charged, the method sums up the charges; otherwise, it sums the item quantities.
+	 * </p>
+	 *
+	 * @param items  a {@link List} of {@link Item} objects to search through
+	 * @param itemID the item id to match
+	 * @return the total quantity or charge count for the matching items
+	 */
 	public int getNumMatches(List<Item> items, int itemID)
 	{
 		if (isChargedItem)
@@ -669,7 +1033,6 @@ public class ItemRequirement extends AbstractRequirement
 						{
 							return itemWithCharge.getCharges();
 						}
-
 						// Fall back to using the item's quantity
 						return i.getQuantity();
 					})
@@ -683,6 +1046,11 @@ public class ItemRequirement extends AbstractRequirement
 				.sum();
 	}
 
+	/**
+	 * Retrieves the list of item ids to display, prioritizing the display item id if set.
+	 *
+	 * @return a {@link List} of item ids for display purposes
+	 */
 	public List<Integer> getDisplayItemIds()
 	{
 		if (displayItemId == null)
@@ -693,17 +1061,35 @@ public class ItemRequirement extends AbstractRequirement
 		return Collections.singletonList(displayItemId);
 	}
 
+	/**
+	 * Determines whether item highlights should be rendered for the client,
+	 * based on the hide condition.
+	 *
+	 * @param client the {@link Client} for which to evaluate the condition
+	 * @return {@code true} if highlights should be rendered, {@code false} otherwise
+	 */
 	public boolean shouldRenderItemHighlights(Client client)
 	{
 		return conditionToHide == null || !conditionToHide.check(client);
 	}
 
+	/**
+	 * Determines whether the item should be highlighted in the player's inventory.
+	 *
+	 * @param client the {@link Client} for which to perform the check
+	 * @return {@code true} if highlighting is enabled and conditions are met, {@code false} otherwise
+	 */
 	public boolean shouldHighlightInInventory(Client client)
 	{
 		return highlightInInventory && shouldRenderItemHighlights(client);
 	}
 
-	// TODO: This will have a conditional for seeing if a Rune Pouch is on the player
+	/**
+	 * Retrieves the set of containers considered as belonging to the player (typically equipped and inventory).
+	 *
+	 * @return a {@link Set} of {@link TrackedContainers} representing the player's containers
+	 */
+	// TODO: This may later include additional conditions (e.g., checking for a Rune Pouch on the player)
 	protected Set<TrackedContainers> getOnPlayerContainers()
 	{
 		return new LinkedHashSet<>(List.of(TrackedContainers.EQUIPPED, TrackedContainers.INVENTORY));

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -47,7 +47,6 @@ import lombok.NonNull;
 import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
-import net.runelite.api.ItemID;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.util.Text;
 import org.jetbrains.annotations.Nullable;
@@ -429,7 +428,7 @@ public class ItemRequirement extends AbstractRequirement
 		}
 		else if (this.checkWithAllContainers())
 		{
-			color = Color.WHITE;
+			color = config.partialSuccessColour();
 		}
 		return color;
 	}

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -132,6 +132,7 @@ public class ItemRequirement extends AbstractRequirement
 	 * Flag to indicate whether the bank should be checked.
 	 */
 	@Setter
+	@Getter
 	private boolean shouldCheckBank;
 
 	/**

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -37,8 +37,10 @@ import com.questhelper.requirements.ManualRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.util.LogicType;
-import java.awt.Color;
+
+import java.awt.*;
 import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.NonNull;
@@ -594,7 +596,7 @@ public class ItemRequirement extends AbstractRequirement
 		{
 			lines.add(LineComponent.builder()
 					.left("- " + this.getTooltip())
-					.leftColor(Color.WHITE)
+					.leftColor(Color.GRAY)
 					.build());
 		}
 

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -154,7 +154,6 @@ public class ItemRequirements extends ItemRequirement
 		ItemRequirements newItem = new ItemRequirements(getLogicType(), getName(), getItemRequirements());
 		newItem.addAlternates(alternateItems);
 		newItem.setDisplayItemId(getDisplayItemId());
-		newItem.setExclusiveToOneItemType(exclusiveToOneItemType);
 		newItem.setHighlightInInventory(highlightInInventory);
 		newItem.setDisplayMatchedItemName(isDisplayMatchedItemName());
 		newItem.setConditionToHide(getConditionToHide());

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -138,7 +138,7 @@ public class ItemRequirements extends ItemRequirement
 			return config.passColour();
 		}
 
-		return Color.WHITE;
+		return config.partialSuccessColour();
 	}
 
 	private Set<TrackedContainers> findBestContainersForOr()

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -28,7 +28,6 @@ package com.questhelper.requirements.item;
 
 import com.questhelper.QuestHelperConfig;
 import com.questhelper.managers.ItemAndLastUpdated;
-import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.questhelpers.QuestUtil;
 import com.questhelper.requirements.util.LogicType;
 import java.awt.Color;
@@ -40,29 +39,62 @@ import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 
+/**
+ * Represents a composite item requirement that aggregates multiple
+ * {@link ItemRequirement} objects and evaluates them using a specified logical operator (AND/OR).
+ */
 public class ItemRequirements extends ItemRequirement
 {
+	/**
+	 * The list of item requirements that are aggregated by this composite requirement.
+	 */
 	@Getter
-	ArrayList<ItemRequirement> itemRequirements = new ArrayList<>();
+	private final ArrayList<ItemRequirement> itemRequirements = new ArrayList<>();
 
+	/**
+	 * The logical operator used to combine the results of the aggregated item requirements.
+	 * Typically, this is either LogicType.AND or LogicType.OR.
+	 */
 	@Getter
-	LogicType logicType;
+	private final LogicType logicType;
 
+	/**
+	 * Constructs an ItemRequirements instance with no name and a default logical operator (AND).
+	 *
+	 * @param requirements an array of {@link ItemRequirement} objects to aggregate.
+	 */
 	public ItemRequirements(ItemRequirement... requirements)
 	{
 		this("", requirements);
 	}
 
+	/**
+	 * Constructs an ItemRequirements instance with the given name and default logical operator (AND).
+	 *
+	 * @param name             the name of the item requirement.
+	 * @param itemRequirements an array of {@link ItemRequirement} objects to aggregate.
+	 * @throws AssertionError if any of the provided requirements is {@code null}.
+	 */
 	public ItemRequirements(String name, ItemRequirement... itemRequirements)
 	{
+		// Uses the id of the first requirement to initialize the parent ItemRequirement.
 		super(name, itemRequirements[0].getId(), -1);
 
+		// Ensure none of the requirements are null.
 		assert (Utils.varargsNotNull(itemRequirements));
 
 		this.itemRequirements.addAll(Arrays.asList(itemRequirements));
 		this.logicType = LogicType.AND;
 	}
 
+	/**
+	 * Constructs an ItemRequirements instance with the given logical type, name, and item requirements.
+	 *
+	 * @param logicType      the logical operator (AND/OR) to combine the requirements.
+	 * @param name           the name of the item requirement.
+	 * @param itemRequirements an array of {@link ItemRequirement} objects to aggregate.
+	 * @throws AssertionError if any of the provided requirements is {@code null}.
+	 */
 	public ItemRequirements(LogicType logicType, String name, ItemRequirement... itemRequirements)
 	{
 		super(name, itemRequirements[0].getId(), -1);
@@ -73,44 +105,97 @@ public class ItemRequirements extends ItemRequirement
 		this.logicType = logicType;
 	}
 
+	/**
+	 * Constructs an ItemRequirements instance with the given logical type, name, and a list of item requirements.
+	 *
+	 * @param logicType      the logical operator (AND/OR) to combine the requirements.
+	 * @param name           the name of the item requirement.
+	 * @param itemRequirements a {@link List} of {@link ItemRequirement} objects to aggregate.
+	 * @throws AssertionError if any of the requirements in the list is {@code null}.
+	 */
 	public ItemRequirements(LogicType logicType, String name, List<ItemRequirement> itemRequirements)
 	{
 		super(name, itemRequirements.get(0).getId(), -1);
 
+		// Ensure no null requirements are present.
 		assert (itemRequirements.stream().noneMatch(Objects::isNull));
 
 		this.itemRequirements.addAll(itemRequirements);
 		this.logicType = logicType;
 	}
 
+	/**
+	 * Constructs an ItemRequirements instance with the given logical type and no name.
+	 *
+	 * @param logicType    the logical operator (AND/OR) to combine the requirements.
+	 * @param requirements an array of {@link ItemRequirement} objects to aggregate.
+	 */
 	public ItemRequirements(LogicType logicType, ItemRequirement... requirements)
 	{
 		this(logicType, "", requirements);
 	}
 
+	/**
+	 * Determines if this composite requirement represents an actual item.
+	 * This is the case when there is at least one valid aggregated requirement.
+	 *
+	 * @return {@code true} if the item is considered "actual" (i.e. valid), {@code false} otherwise.
+	 */
 	@Override
 	public boolean isActualItem()
 	{
-		return getItemRequirements() != null && LogicType.OR.test(getItemRequirements().stream(),
-				item -> !item.getAllIds().contains(-1) && item.getQuantity() >= 0);
+		// Check if any of the aggregated requirements represent a valid item.
+		return getItemRequirements() != null &&
+				LogicType.OR.test(getItemRequirements().stream(),
+						item -> !item.getAllIds().contains(-1) && item.getQuantity() >= 0);
 	}
 
+	/**
+	 * Checks whether the aggregated item requirements are satisfied using the provided containers.
+	 *
+	 * @param containers an array of {@link ItemAndLastUpdated} objects representing the item containers.
+	 * @return {@code true} if the number of satisfied requirements meets the criteria defined by {@link LogicType},
+	 *         {@code false} otherwise.
+	 */
 	@Override
 	public boolean checkContainers(ItemAndLastUpdated... containers)
 	{
 		Predicate<ItemRequirement> predicate = r -> r.checkContainers(containers);
-		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
+		int successes = (int) itemRequirements.stream()
+				.filter(Objects::nonNull)
+				.filter(predicate)
+				.count();
 		return logicType.compare(successes, itemRequirements.size());
 	}
 
+	/**
+	 * Checks whether the aggregated item requirements are satisfied for the specified client.
+	 *
+	 * @param client the {@link Client} for which to perform the check.
+	 * @return {@code true} if the requirements are met based on the {@link LogicType}, {@code false} otherwise.
+	 */
 	@Override
 	public boolean check(Client client)
 	{
 		Predicate<ItemRequirement> predicate = r -> r.check(client);
-		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
+		int successes = (int) itemRequirements.stream()
+				.filter(Objects::nonNull)
+				.filter(predicate)
+				.count();
 		return logicType.compare(successes, itemRequirements.size());
 	}
 
+	/**
+	 * Determines the display color for this item requirement based on the client's progress.
+	 * <p>
+	 * If the item is not valid, it returns {@link Color#GRAY}. Otherwise, it compares the tracked containers
+	 * with the player's containers and returns the corresponding color from the configuration.
+	 * </p>
+	 *
+	 * @param client the client for which the color is determined.
+	 * @param config the {@link QuestHelperConfig} providing color configuration.
+	 * @return the appropriate {@link Color} representing the requirement's state.
+	 */
 	@Override
 	public Color getColor(Client client, QuestHelperConfig config)
 	{
@@ -121,16 +206,31 @@ public class ItemRequirements extends ItemRequirement
 
 		Set<TrackedContainers> containers = getContainersWithItem();
 
-		if (containers.isEmpty()) return config.failColour();
+		// If no containers contain the item, return the failure color.
+		if (containers.isEmpty())
+		{
+			return config.failColour();
+		}
 
+		// If all required containers are on the player's list, return the pass color.
 		if (getOnPlayerContainers().containsAll(containers))
 		{
 			return config.passColour();
 		}
 
+		// Otherwise, return the partial success color.
 		return config.partialSuccessColour();
 	}
 
+	/**
+	 * Finds the best set of tracked containers when using OR logic.
+	 * <p>
+	 * The method selects a set of containers such that if a perfect match is found (all on player's containers),
+	 * that set is immediately returned. Otherwise, it selects the set with the fewest non-player containers.
+	 * </p>
+	 *
+	 * @return a {@link Set} of {@link TrackedContainers} that best matches the requirement, or an empty set if none are found.
+	 */
 	private Set<TrackedContainers> findBestContainersForOr()
 	{
 		Set<TrackedContainers> containers = new LinkedHashSet<>();
@@ -138,24 +238,41 @@ public class ItemRequirements extends ItemRequirement
 		for (ItemRequirement itemRequirement : itemRequirements)
 		{
 			Set<TrackedContainers> currentItemContainers = itemRequirement.getContainersWithItem();
-			if (currentItemContainers.isEmpty()) continue;
-			// Found perfect match on player
+			if (currentItemContainers.isEmpty())
+			{
+				continue;
+			}
+			// Found perfect match on player's containers; return immediately.
 			if (getOnPlayerContainers().containsAll(currentItemContainers))
 			{
 				return currentItemContainers;
 			}
+
+			// Count the number of containers that are not INVENTORY or EQUIPPED.
 			long count = currentItemContainers.stream()
 					.filter(container -> container != TrackedContainers.INVENTORY && container != TrackedContainers.EQUIPPED)
 					.distinct()
 					.count();
-			if (containers.size() == 0 || count < containers.size()) containers = currentItemContainers;
+
+			// If this set has fewer non-player containers than the current best, update it.
+			if (containers.isEmpty() || count < containers.size())
+			{
+				containers = currentItemContainers;
+			}
 		}
 
 		return containers;
 	}
 
-	// Defined behaviour? Return a set of things if ItemRequirements passes.
-	// Return empty is failed to find
+	/**
+	 * Retrieves the set of tracked containers that currently contain the required items.
+	 * <p>
+	 * If the logical type is AND, the method aggregates the containers for all requirements.
+	 * If OR, it uses {@link #findBestContainersForOr()} to select the best match.
+	 * </p>
+	 *
+	 * @return a {@link Set} of {@link TrackedContainers} containing the items; may be empty if requirements are not met.
+	 */
 	@Override
 	public Set<TrackedContainers> getContainersWithItem()
 	{
@@ -171,10 +288,15 @@ public class ItemRequirements extends ItemRequirement
 			for (ItemRequirement itemRequirement : itemRequirements)
 			{
 				Set<TrackedContainers> containersForRequirement = itemRequirement.getContainersWithItem();
-				if (containersForRequirement.isEmpty()) return new LinkedHashSet<>();
+				// If any requirement fails to find a container, return an empty set.
+				if (containersForRequirement.isEmpty())
+				{
+					return new LinkedHashSet<>();
+				}
 				containers.addAll(containersForRequirement);
 			}
-		} else if (logicType == LogicType.OR)
+		}
+		else if (logicType == LogicType.OR)
 		{
 			containers = findBestContainersForOr();
 		}
@@ -182,14 +304,32 @@ public class ItemRequirements extends ItemRequirement
 		return containers;
 	}
 
+	/**
+	 * Checks whether the provided list of items satisfies the aggregated item requirements for the given client.
+	 *
+	 * @param client the {@link Client} for which the check is performed.
+	 * @param items  a {@link List} of {@link Item} objects representing the items to check.
+	 * @return {@code true} if the check passes based on the logic defined in {@link LogicType}, {@code false} otherwise.
+	 */
 	@Override
 	public boolean checkItems(Client client, List<Item> items)
 	{
 		Predicate<ItemRequirement> predicate = r -> r.checkItems(client, items);
-		int successes = (int) itemRequirements.stream().filter(Objects::nonNull).filter(predicate).count();
+		int successes = (int) itemRequirements.stream()
+				.filter(Objects::nonNull)
+				.filter(predicate)
+				.count();
 		return logicType.compare(successes, itemRequirements.size());
 	}
 
+	/**
+	 * Creates a deep copy of this {@code ItemRequirements} instance.
+	 * <p>
+	 * The copy includes all alternate items, display options, and additional options.
+	 * </p>
+	 *
+	 * @return a new {@link ItemRequirement} object that is a copy of this instance.
+	 */
 	@Override
 	public ItemRequirement copy()
 	{
@@ -201,12 +341,16 @@ public class ItemRequirements extends ItemRequirement
 		newItem.setConditionToHide(getConditionToHide());
 		newItem.setQuestBank(getQuestBank());
 		newItem.setTooltip(getTooltip());
-		newItem.logicType = logicType;
 		newItem.additionalOptions = additionalOptions;
 
 		return newItem;
 	}
 
+	/**
+	 * Retrieves a consolidated list of all IDs from the aggregated item requirements.
+	 *
+	 * @return a {@link List} of {@link Integer} IDs.
+	 */
 	@Override
 	public List<Integer> getAllIds()
 	{
@@ -216,34 +360,56 @@ public class ItemRequirements extends ItemRequirement
 				.collect(QuestUtil.collectToArrayList());
 	}
 
+	/**
+	 * Marks all aggregated item requirements as equipped and returns a new instance with the equipped flag set.
+	 *
+	 * @return a new {@link ItemRequirement} instance with the equip flag set.
+	 */
 	@Override
 	public ItemRequirement equipped()
 	{
 		ItemRequirements newItem = (ItemRequirements) copy();
 
-		newItem.itemRequirements.forEach((itemRequirement -> itemRequirement.setEquip(true)));
+		// Set the equip flag on all aggregated requirements.
+		newItem.itemRequirements.forEach(itemRequirement -> itemRequirement.setEquip(true));
 		equip = true;
 		return newItem;
 	}
 
+	/**
+	 * Sets the equip flag for all aggregated item requirements.
+	 *
+	 * @param shouldEquip {@code true} to mark the items as equipped; {@code false} otherwise.
+	 */
 	@Override
 	public void setEquip(boolean shouldEquip)
 	{
-		itemRequirements.forEach((itemRequirement -> itemRequirement.setEquip(true)));
+		itemRequirements.forEach(itemRequirement -> itemRequirement.setEquip(true));
 		equip = shouldEquip;
 	}
 
+	/**
+	 * Generates a tooltip for this item requirement.
+	 * <p>
+	 * For AND logic, it checks across all containers. For OR logic, it attempts to find one which passes,
+	 * favoring those with the most items already in the player's inventory or equipped.
+	 * </p>
+	 *
+	 * @return a tooltip {@link String} if applicable; otherwise, {@code null} or the parent's tooltip.
+	 */
 	@Override
 	public String getTooltip()
 	{
-		// If AND, check across all containers
-
-		// If OR, find one which passes, with the most already in your inventory/equipped
-
+		// Determine the set of containers that contain the required item(s).
 		Set<TrackedContainers> containers = getContainersWithItem();
 
-		if (containers.size() == 0) return super.getTooltip();
+		// If no containers are found, use the default tooltip.
+		if (containers.isEmpty())
+		{
+			return super.getTooltip();
+		}
 
+		// If not all required containers are on the player's list, generate a custom tooltip.
 		if (!getOnPlayerContainers().containsAll(containers))
 		{
 			return getTooltipFromEnumSet(containers);
@@ -252,6 +418,11 @@ public class ItemRequirements extends ItemRequirement
 		return null;
 	}
 
+	/**
+	 * Checks whether the aggregated item requirements are satisfied across all available containers.
+	 *
+	 * @return {@code true} if all container checks pass based on the logic defined by {@link LogicType}, {@code false} otherwise.
+	 */
 	@Override
 	public boolean checkWithAllContainers()
 	{

--- a/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
@@ -24,14 +24,21 @@
  */
 package com.questhelper.requirements.item;
 
-import com.questhelper.collections.KeyringCollection;
 import com.questhelper.QuestHelperConfig;
+import com.questhelper.collections.KeyringCollection;
+import com.questhelper.managers.ItemAndLastUpdated;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.requirements.runelite.RuneliteRequirement;
-import java.awt.Color;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.client.config.ConfigManager;
 
+// TODO: Convert this to be a TrackedContainer instead?
 public class KeyringRequirement extends ItemRequirement
 {
 	RuneliteRequirement runeliteRequirement;
@@ -103,29 +110,15 @@ public class KeyringRequirement extends ItemRequirement
 	}
 
 	@Override
-	public Color getColorConsideringBank(Client client, QuestHelperConfig config)
+	public Color getColor(Client client, QuestHelperConfig config)
 	{
-		Color color;
-		if (!this.isActualItem())
+		boolean isKeyOnKeyring = runeliteRequirement.check(client);
+		if (isKeyOnKeyring)
 		{
-			color = Color.GRAY;
-		}
-		else
-		{
-			color = super.getColorConsideringBank(client, config);
+			return keyring.getColor(client, config);
 		}
 
-		if (color == config.failColour())
-		{
-			boolean match = runeliteRequirement.check(client);
-
-			if (match)
-			{
-				color = Color.ORANGE;
-			}
-		}
-
-		return color;
+		return this.check(client) ? config.passColour() : config.failColour();
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
@@ -78,7 +78,6 @@ public class KeyringRequirement extends ItemRequirement
 		KeyringRequirement newItem = new KeyringRequirement(getName(), configManager, keyringCollection);
 		newItem.addAlternates(alternateItems);
 		newItem.setDisplayItemId(getDisplayItemId());
-		newItem.setExclusiveToOneItemType(exclusiveToOneItemType);
 		newItem.setHighlightInInventory(highlightInInventory);
 		newItem.setDisplayMatchedItemName(isDisplayMatchedItemName());
 		newItem.setConditionToHide(getConditionToHide());

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -820,7 +820,7 @@ public class DetailedQuestStep extends QuestStep
 			&& ((ItemRequirement) requirement).shouldRenderItemHighlights(client)
 			&& ((!considerBankForItemHighlight && !requirement.check(client)) ||
 			(considerBankForItemHighlight &&
-				!((ItemRequirement) requirement).checkWithAllContainers(client)));
+				!((ItemRequirement) requirement).checkWithAllContainers()));
 	}
 
 	@Override
@@ -901,7 +901,7 @@ public class DetailedQuestStep extends QuestStep
 		return requirements.stream().anyMatch((item) ->  item instanceof ItemRequirement &&
 			type == MenuAction.GROUND_ITEM_THIRD_OPTION &&
 			((ItemRequirement) item).getAllIds().contains(itemID) &&
-			!((ItemRequirement) item).checkWithAllContainers(client) &&
+			!((ItemRequirement) item).checkWithAllContainers() &&
 			option.equals("Take"));
 	}
 


### PR DESCRIPTION
This generally looks to add a more consistent means of conveying information of which containers an item is in, and starts work towards making ItemRequirements have more defined of a state.

The sidebar now for items will always be white, or whatever you've set your 'partial success' config colour to be, if you have items generally to pass a condition, just not on you. The tooltip will let you know which containers have it.

![Screenshot 2025-02-11 170749](https://github.com/user-attachments/assets/200c7aaf-9134-4b10-a8ed-601d280cc565)

The overlay does the same now. It may need some reconsideration in terms of default colours and readability.

![Screenshot 2025-02-11 170942](https://github.com/user-attachments/assets/7d0f6bf9-ba1c-473e-86da-821ed6de95e0)

Currently if you are missing some of an ItemRequirement or ItemRequirements, it will simply indicate 'failed', and not give any hints as to where what bits you do have are.