### PR TITLE
fix: update NPC IDs for RuneLite 1.11.2

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaElite.java
@@ -226,7 +226,7 @@ public class MorytaniaElite extends ComplexStateQuestHelper
 		moveToSlayer3 = new ObjectStep(this, ObjectID.STAIRCASE_2119, new WorldPoint(3415, 3541, 1),
 			"Climb the stairs or the Spikey chains in the Slayer tower to ascend to the higher level.", combatGear,
 			food);
-		abyssalDemon = new NpcStep(this, NpcID.ABYSSAL_DEMON_415, new WorldPoint(3420, 3569, 2),
+		abyssalDemon = new NpcStep(this, NpcID.ABYSSAL_DEMON, new WorldPoint(3420, 3569, 2),
 			"Kill an Abyssal demon.", combatGear, food);
 
 		moveToCanifisBank = new DetailedQuestStep(this, new WorldPoint(3511, 3480, 0),

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
@@ -519,7 +519,7 @@ public class RagAndBoneManII extends BasicQuestHelper
 		((NpcStep) killRabbit).addAlternateNpcs(NpcID.BUNNY_3903);
 		enterFremmyDungeon = new ObjectStep(this, ObjectID.CAVE_ENTRANCE_2123, new WorldPoint(2798, 3615, 0),
 			"Enter the Fremennik Slayer Dungeon.", mirrorShield.equipped());
-		killBasilisk = new NpcStep(this, NpcID.BASILISK_417, new WorldPoint(2743, 10010, 0),
+		killBasilisk = new NpcStep(this, NpcID.BASILISK, new WorldPoint(2743, 10010, 0),
 			"Kill basilisks in the middle of the dungeon.", true, mirrorShield.equipped(),
 			new SkillRequirement(Skill.SLAYER,
 			40,	true));


### PR DESCRIPTION
Already released as v4.7.6.2

Abyssal demon ID confirmed
![image](https://github.com/user-attachments/assets/01213172-251a-45f9-8184-e4c3c13eaf1a)

Basilisk ID confirmed
![image](https://github.com/user-attachments/assets/4836754c-ad25-4f46-93bb-03175cc4b1dd)