### PR TITLE
Add tooltip to logs requirement for Throne of Miscellania

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/throneofmiscellania/ThroneOfMiscellania.java
+++ b/src/main/java/com/questhelper/helpers/quests/throneofmiscellania/ThroneOfMiscellania.java
@@ -212,6 +212,7 @@ public class ThroneOfMiscellania extends BasicQuestHelper
 		ironBar = new ItemRequirement("Iron bar", ItemID.IRON_BAR);
 		logs = new ItemRequirement("Logs", ItemID.LOGS);
 		logs.setHighlightInInventory(true);
+		logs.setTooltip("You can chop logs on Miscellania if you bring an axe.");
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES).isNotConsumed();
 		rake = new ItemRequirement("Rake", ItemID.RAKE).isNotConsumed();
 		axe = new ItemRequirement("Any axe", ItemCollections.AXES).isNotConsumed();


### PR DESCRIPTION
# Throne of Miscellania required items (logs) tooltip update

## Change made:

I added a tooltip to the `logs` required item for the Throne of Miscellania quest, adding context that there are trees available to be chopped on Miscellania.

## Reason for change:

This tooltip can save users time, and is more consistent with the `flowers` tooltip, which informs users that they can be bought on Miscellania.

## Relevant issue:

N/A