### PR TITLE
fix: Allow for better handling for copied instances

### DIFF
--- a/src/main/java/com/questhelper/requirements/item/ItemOnTileConsideringSceneLoadRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemOnTileConsideringSceneLoadRequirement.java
@@ -104,24 +104,26 @@ public class ItemOnTileConsideringSceneLoadRequirement implements InitializableR
 	{
 		if (worldPoint != null)
 		{
-			LocalPoint localPoint = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-			if (localPoint == null) return false;
-
-			Tile tile = client.getScene().getTiles()[client.getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
-			if (tile != null)
+			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+			for (LocalPoint localPoint : localPoints)
 			{
-				List<TileItem> items = tile.getGroundItems();
-				if (items == null) return false;
-				for (TileItem item : items)
+				if (localPoint == null) continue;
+				Tile tile = client.getTopLevelWorldView().getScene().getTiles()[client.getTopLevelWorldView().getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
+				if (tile != null)
 				{
-					if (itemID.contains(item.getId()))
+					List<TileItem> items = tile.getGroundItems();
+					if (items == null) return false;
+					for (TileItem item : items)
 					{
-						return true;
+						if (itemID.contains(item.getId()))
+						{
+							return true;
+						}
 					}
 				}
-
-				return false;
 			}
+
+			return false;
 		}
 
 		Tile[][] squareOfTiles = client.getScene().getTiles()[client.getPlane()];

--- a/src/main/java/com/questhelper/requirements/item/ItemOnTileConsideringSceneLoadRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemOnTileConsideringSceneLoadRequirement.java
@@ -107,7 +107,6 @@ public class ItemOnTileConsideringSceneLoadRequirement implements InitializableR
 			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
 			for (LocalPoint localPoint : localPoints)
 			{
-				if (localPoint == null) continue;
 				Tile tile = client.getTopLevelWorldView().getScene().getTiles()[client.getTopLevelWorldView().getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
 				if (tile != null)
 				{

--- a/src/main/java/com/questhelper/requirements/item/ItemOnTileRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemOnTileRequirement.java
@@ -88,8 +88,6 @@ public class ItemOnTileRequirement extends ConditionForStep
 			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
 			for (LocalPoint localPoint : localPoints)
 			{
-				if (localPoint == null) continue;
-
 				Tile tile = client.getTopLevelWorldView().getScene().getTiles()[client.getTopLevelWorldView().getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
 				if (tile != null)
 				{

--- a/src/main/java/com/questhelper/requirements/item/ItemOnTileRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemOnTileRequirement.java
@@ -81,28 +81,30 @@ public class ItemOnTileRequirement extends ConditionForStep
 
 	private boolean checkAllTiles(Client client)
 	{
-		if (client.getScene() == null) return false;
+		if (client.getTopLevelWorldView().getScene() == null) return false;
 
 		if (worldPoint != null)
 		{
-			LocalPoint localPoint = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-			if (localPoint == null) return false;
-
-			Tile tile = client.getScene().getTiles()[client.getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
-			if (tile != null)
+			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+			for (LocalPoint localPoint : localPoints)
 			{
-				List<TileItem> items = tile.getGroundItems();
-				if (items == null) return false;
-				for (TileItem item : items)
+				if (localPoint == null) continue;
+
+				Tile tile = client.getTopLevelWorldView().getScene().getTiles()[client.getTopLevelWorldView().getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
+				if (tile != null)
 				{
-					if (itemID.contains(item.getId()))
+					List<TileItem> items = tile.getGroundItems();
+					if (items == null) return false;
+					for (TileItem item : items)
 					{
-						return true;
+						if (itemID.contains(item.getId()))
+						{
+							return true;
+						}
 					}
 				}
-
-				return false;
 			}
+			return false;
 		}
 
 		Tile[][] squareOfTiles = client.getScene().getTiles()[client.getPlane()];

--- a/src/main/java/com/questhelper/requirements/location/TileIsLoadedRequirement.java
+++ b/src/main/java/com/questhelper/requirements/location/TileIsLoadedRequirement.java
@@ -61,7 +61,7 @@ public class TileIsLoadedRequirement extends AbstractRequirement
 		for (LocalPoint localPoint : localPoints)
 		{
 			// Final tiles of a scene do not have objects of them
-			if (localPoint != null && localPoint.getSceneX() != Constants.SCENE_SIZE - 1 && localPoint.getSceneY() != Constants.SCENE_SIZE - 1)
+			if (localPoint.getSceneX() != Constants.SCENE_SIZE - 1 && localPoint.getSceneY() != Constants.SCENE_SIZE - 1)
 			{
 				return true;
 			}

--- a/src/main/java/com/questhelper/requirements/location/TileIsLoadedRequirement.java
+++ b/src/main/java/com/questhelper/requirements/location/TileIsLoadedRequirement.java
@@ -33,6 +33,8 @@ import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+
+import java.util.List;
 import java.util.Objects;
 
 public class TileIsLoadedRequirement extends AbstractRequirement
@@ -55,12 +57,16 @@ public class TileIsLoadedRequirement extends AbstractRequirement
 	@Override
 	public boolean check(Client client)
 	{
-		LocalPoint lp = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-		if (lp == null) return false;
-		// Final tiles of a scene do not have objects of them
-		if (lp.getSceneX() == Constants.SCENE_SIZE - 1) return false;
-		if (lp.getSceneY() == Constants.SCENE_SIZE - 1) return false;
-		return true;
+		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+		for (LocalPoint localPoint : localPoints)
+		{
+			// Final tiles of a scene do not have objects of them
+			if (localPoint != null && localPoint.getSceneX() != Constants.SCENE_SIZE - 1 && localPoint.getSceneY() != Constants.SCENE_SIZE - 1)
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Nonnull

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ExtendedRuneliteObject.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ExtendedRuneliteObject.java
@@ -170,7 +170,6 @@ public class ExtendedRuneliteObject
 
 		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
 		if (localPoints.isEmpty()) return;
-		if (localPoints.get(0) == null) return;
 
 		// Set it to first found local point
 		runeliteObject.setLocation(localPoints.get(0), client.getTopLevelWorldView().getPlane());
@@ -200,14 +199,14 @@ public class ExtendedRuneliteObject
 
 	public Shape getClickbox()
 	{
-		if (QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint) == null) return null;
+		if (QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint).isEmpty()) return null;
 
 		return Perspective.getClickbox(client,
 			getRuneliteObject().getModel(),
 			getRuneliteObject().getOrientation(),
 			getRuneliteObject().getLocation().getX(),
 			getRuneliteObject().getLocation().getY(),
-			Perspective.getTileHeight(client, getRuneliteObject().getLocation(), client.getPlane()));
+			Perspective.getTileHeight(client, getRuneliteObject().getLocation(), client.getTopLevelWorldView().getPlane()));
 	}
 
 	public void setAnimation(int animation)
@@ -233,7 +232,6 @@ public class ExtendedRuneliteObject
 		this.worldPoint = worldPoint;
 		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
 		if (localPoints.isEmpty()) return;
-		if (localPoints.get(0) == null) return;
 
 		// Set it to first found local point
 		this.runeliteObject.setLocation(localPoints.get(0), client.getTopLevelWorldView().getPlane());

--- a/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ExtendedRuneliteObject.java
+++ b/src/main/java/com/questhelper/runeliteobjects/extendedruneliteobjects/ExtendedRuneliteObject.java
@@ -168,9 +168,12 @@ public class ExtendedRuneliteObject
 
 		this.worldPoint = worldPoint;
 
-		LocalPoint lp = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-		if (lp == null) return;
-		runeliteObject.setLocation(lp, client.getPlane());
+		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+		if (localPoints.isEmpty()) return;
+		if (localPoints.get(0) == null) return;
+
+		// Set it to first found local point
+		runeliteObject.setLocation(localPoints.get(0), client.getTopLevelWorldView().getPlane());
 		activate();
 	}
 
@@ -228,9 +231,12 @@ public class ExtendedRuneliteObject
 	public void setWorldPoint(WorldPoint worldPoint)
 	{
 		this.worldPoint = worldPoint;
-		LocalPoint lp = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-		if (lp == null) return;
-		this.runeliteObject.setLocation(lp, client.getPlane());
+		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+		if (localPoints.isEmpty()) return;
+		if (localPoints.get(0) == null) return;
+
+		// Set it to first found local point
+		this.runeliteObject.setLocation(localPoints.get(0), client.getTopLevelWorldView().getPlane());
 	}
 
 	public void setScaledModel(int[] model, int xScale, int yScale, int zScale)

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -295,11 +295,9 @@ public class DetailedQuestStep extends QuestStep
 			{
 				BufferedImage combatIcon = spriteManager.getSprite(location.getIconID(), 0);
 				List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-				if (localPoints.isEmpty()) continue;
 
 				for (LocalPoint localPoint : localPoints)
 				{
-					if (localPoint == null) continue;
 					OverlayUtil.renderTileOverlay(client, graphics, localPoint, combatIcon, questHelper.getConfig().targetOverlayColor());
 				}
 			}
@@ -320,11 +318,9 @@ public class DetailedQuestStep extends QuestStep
 		if (icon == null || iconItemID == -1) return;
 
 		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-		if (localPoints.isEmpty()) return;
 
 		for (LocalPoint localPoint : localPoints)
 		{
-			if (localPoint == null) continue;
 			OverlayUtil.renderTileOverlay(client, graphics, localPoint, icon, questHelper.getConfig().targetOverlayColor());
 		}
 	}
@@ -383,11 +379,9 @@ public class DetailedQuestStep extends QuestStep
 			}
 
 			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-			if (localPoints.isEmpty()) return;
 
 			for (LocalPoint localPoint : localPoints)
 			{
-				if (localPoint == null) continue;
 				Polygon poly = Perspective.getCanvasTilePoly(client, localPoint, 30);
 				if (poly == null || poly.getBounds() == null)
 				{
@@ -790,11 +784,9 @@ public class DetailedQuestStep extends QuestStep
 					{
 						BufferedImage icon = spriteManager.getSprite(iconToUseForNeededItems, 0);
 						List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-						if (localPoints.isEmpty()) return;
 
 						for (LocalPoint localPoint : localPoints)
 						{
-							if (localPoint == null) continue;
 							OverlayUtil.renderTileOverlay(client, graphics, localPoint, icon, questHelper.getConfig().targetOverlayColor());
 						}
 					}

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -294,9 +294,12 @@ public class DetailedQuestStep extends QuestStep
 			for (QuestTile location : markedTiles)
 			{
 				BufferedImage combatIcon = spriteManager.getSprite(location.getIconID(), 0);
-				LocalPoint localPoint = QuestPerspective.getInstanceLocalPointFromReal(client, location.getWorldPoint());
-				if (localPoint != null)
+				List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+				if (localPoints.isEmpty()) continue;
+
+				for (LocalPoint localPoint : localPoints)
 				{
+					if (localPoint == null) continue;
 					OverlayUtil.renderTileOverlay(client, graphics, localPoint, combatIcon, questHelper.getConfig().targetOverlayColor());
 				}
 			}
@@ -314,10 +317,15 @@ public class DetailedQuestStep extends QuestStep
 
 	protected void renderTileIcon(Graphics2D graphics)
 	{
-		LocalPoint lp = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-		if (lp != null && icon != null && iconItemID != -1)
+		if (icon == null || iconItemID == -1) return;
+
+		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+		if (localPoints.isEmpty()) return;
+
+		for (LocalPoint localPoint : localPoints)
 		{
-			OverlayUtil.renderTileOverlay(client, graphics, lp, icon, questHelper.getConfig().targetOverlayColor());
+			if (localPoint == null) continue;
+			OverlayUtil.renderTileOverlay(client, graphics, localPoint, icon, questHelper.getConfig().targetOverlayColor());
 		}
 	}
 
@@ -374,23 +382,24 @@ public class DetailedQuestStep extends QuestStep
 				return;
 			}
 
-			LocalPoint lp = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-			if (lp == null)
+			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+			if (localPoints.isEmpty()) return;
+
+			for (LocalPoint localPoint : localPoints)
 			{
-				return;
+				if (localPoint == null) continue;
+				Polygon poly = Perspective.getCanvasTilePoly(client, localPoint, 30);
+				if (poly == null || poly.getBounds() == null)
+				{
+					return;
+				}
+
+				int startX = poly.getBounds().x + (poly.getBounds().width / 2);
+				int startY = poly.getBounds().y + (poly.getBounds().height / 2);
+
+				DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(),
+						startX, startY);
 			}
-
-			Polygon poly = Perspective.getCanvasTilePoly(client, lp, 30);
-			if (poly == null || poly.getBounds() == null)
-			{
-				return;
-			}
-
-			int startX = poly.getBounds().x + (poly.getBounds().width / 2);
-			int startY = poly.getBounds().y + (poly.getBounds().height / 2);
-
-			DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(),
-				startX, startY);
 		}
 	}
 
@@ -501,7 +510,11 @@ public class DetailedQuestStep extends QuestStep
 	{
 		if (questHelper.getConfig().showMiniMapArrow())
 		{
-			DirectionArrow.renderMinimapArrow(graphics, client, worldPoint, getQuestHelper().getConfig().targetOverlayColor());
+			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+			for (LocalPoint localPoint : localPoints)
+			{
+				DirectionArrow.renderMinimapArrowFromLocal(graphics, client, localPoint, getQuestHelper().getConfig().targetOverlayColor());
+			}
 		}
 	}
 
@@ -776,9 +789,12 @@ public class DetailedQuestStep extends QuestStep
 					if (iconToUseForNeededItems != -1)
 					{
 						BufferedImage icon = spriteManager.getSprite(iconToUseForNeededItems, 0);
-						LocalPoint localPoint = QuestPerspective.getInstanceLocalPointFromReal(client, tile.getWorldLocation());
-						if (localPoint != null)
+						List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+						if (localPoints.isEmpty()) return;
+
+						for (LocalPoint localPoint : localPoints)
 						{
+							if (localPoint == null) continue;
 							OverlayUtil.renderTileOverlay(client, graphics, localPoint, icon, questHelper.getConfig().targetOverlayColor());
 						}
 					}

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -197,11 +197,9 @@ public class ObjectStep extends DetailedQuestStep
 	public void checkTileForObject(WorldPoint wp)
 	{
 		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, wp);
-		if (localPoints.isEmpty()) return;
 
 		for (LocalPoint localPoint : localPoints)
 		{
-			if (localPoint == null) continue;
 			Tile[][][] tiles = client.getTopLevelWorldView().getScene().getTiles();
 
 			Tile tile = tiles[client.getTopLevelWorldView().getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
@@ -415,7 +413,6 @@ public class ObjectStep extends DetailedQuestStep
 			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
 			for (LocalPoint localPoint : localPoints)
 			{
-
 				DirectionArrow.renderMinimapArrowFromLocal(graphics, client, localPoint, getQuestHelper().getConfig().targetOverlayColor());
 			}
 		}

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -196,21 +196,22 @@ public class ObjectStep extends DetailedQuestStep
 
 	public void checkTileForObject(WorldPoint wp)
 	{
-		LocalPoint localPoint = QuestPerspective.getInstanceLocalPointFromReal(client, wp);
+		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, wp);
+		if (localPoints.isEmpty()) return;
 
-		if (localPoint == null)
+		for (LocalPoint localPoint : localPoints)
 		{
-			return;
-		}
-		Tile[][][] tiles = client.getScene().getTiles();
+			if (localPoint == null) continue;
+			Tile[][][] tiles = client.getTopLevelWorldView().getScene().getTiles();
 
-		Tile tile = tiles[client.getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
-		if (tile != null)
-		{
-			Arrays.stream(tile.getGameObjects()).forEach(this::handleObjects);
-			handleObjects(tile.getDecorativeObject());
-			handleObjects(tile.getGroundObject());
-			handleObjects(tile.getWallObject());
+			Tile tile = tiles[client.getTopLevelWorldView().getPlane()][localPoint.getSceneX()][localPoint.getSceneY()];
+			if (tile != null)
+			{
+				Arrays.stream(tile.getGameObjects()).forEach(this::handleObjects);
+				handleObjects(tile.getDecorativeObject());
+				handleObjects(tile.getGroundObject());
+				handleObjects(tile.getWallObject());
+			}
 		}
 	}
 
@@ -396,6 +397,26 @@ public class ObjectStep extends DetailedQuestStep
 				int y = (int) boundingBox.getMinY() - 20;
 
 				DirectionArrow.drawWorldArrow(graphics, getQuestHelper().getConfig().targetOverlayColor(), x, y);
+			}
+		}
+	}
+
+	@Override
+	public void renderMinimapArrow(Graphics2D graphics)
+	{
+		if (questHelper.getConfig().showMiniMapArrow())
+		{
+			if (closestObject != null)
+			{
+				DirectionArrow.renderMinimapArrowFromLocal(graphics, client, closestObject.getLocalLocation(), getQuestHelper().getConfig().targetOverlayColor());
+				return;
+			}
+
+			List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+			for (LocalPoint localPoint : localPoints)
+			{
+
+				DirectionArrow.renderMinimapArrowFromLocal(graphics, client, localPoint, getQuestHelper().getConfig().targetOverlayColor());
 			}
 		}
 	}

--- a/src/main/java/com/questhelper/steps/overlay/DirectionArrow.java
+++ b/src/main/java/com/questhelper/steps/overlay/DirectionArrow.java
@@ -119,7 +119,6 @@ public class DirectionArrow
 		}
 
 		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
-		if (localPoints.isEmpty()) return;
 
 		for (LocalPoint localPoint : localPoints)
 		{

--- a/src/main/java/com/questhelper/steps/overlay/DirectionArrow.java
+++ b/src/main/java/com/questhelper/steps/overlay/DirectionArrow.java
@@ -33,6 +33,8 @@ import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
+import java.util.List;
+
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
@@ -56,6 +58,43 @@ public class DirectionArrow
 		return 16;
 	}
 
+	public static void renderMinimapArrowFromLocal(Graphics2D graphics, Client client, LocalPoint localPoint, Color color)
+	{
+		var maxMinimapDrawDistance = getMaxMinimapDrawDistance(client);
+		Player player = client.getLocalPlayer();
+		if (player == null)
+		{
+			return;
+		}
+
+		if (localPoint == null)
+		{
+			return;
+		}
+
+		WorldPoint playerRealLocation = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
+		WorldPoint goalRealLocation = WorldPoint.fromLocalInstance(client, localPoint);
+		if (playerRealLocation == null) return;
+
+		if (goalRealLocation.distanceTo(playerRealLocation) >= maxMinimapDrawDistance)
+		{
+			createMinimapDirectionArrow(graphics, client, playerRealLocation, goalRealLocation, color);
+			return;
+		}
+
+		Point posOnMinimap = Perspective.localToMinimap(client, localPoint);
+		if (posOnMinimap == null)
+		{
+			return;
+		}
+
+		Line2D.Double line = new Line2D.Double(posOnMinimap.getX(), posOnMinimap.getY() - 18, posOnMinimap.getX(),
+				posOnMinimap.getY() - 8);
+
+		drawMinimapArrow(graphics, line, color);
+
+	}
+
 	public static void renderMinimapArrow(Graphics2D graphics, Client client, WorldPoint worldPoint, Color color)
 	{
 		var maxMinimapDrawDistance = getMaxMinimapDrawDistance(client);
@@ -65,13 +104,13 @@ public class DirectionArrow
 			return;
 		}
 
-		WorldPoint playerRealLocation = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
-		if (playerRealLocation == null) return;
-
 		if (worldPoint == null)
 		{
 			return;
 		}
+
+		WorldPoint playerRealLocation = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
+		if (playerRealLocation == null) return;
 
 		if (worldPoint.distanceTo(playerRealLocation) >= maxMinimapDrawDistance)
 		{
@@ -79,27 +118,22 @@ public class DirectionArrow
 			return;
 		}
 
-		WorldPoint fakeDestinationWp = QuestPerspective.getInstanceWorldPointFromReal(client, worldPoint);
+		List<LocalPoint> localPoints = QuestPerspective.getInstanceLocalPointFromReal(client, worldPoint);
+		if (localPoints.isEmpty()) return;
 
-		if (fakeDestinationWp == null) return;
-
-		LocalPoint lp = LocalPoint.fromWorld(client, fakeDestinationWp);
-
-		if (lp == null)
+		for (LocalPoint localPoint : localPoints)
 		{
-			return;
+			Point posOnMinimap = Perspective.localToMinimap(client, localPoint);
+			if (posOnMinimap == null)
+			{
+				continue;
+			}
+
+			Line2D.Double line = new Line2D.Double(posOnMinimap.getX(), posOnMinimap.getY() - 18, posOnMinimap.getX(),
+					posOnMinimap.getY() - 8);
+
+			drawMinimapArrow(graphics, line, color);
 		}
-
-		Point posOnMinimap = Perspective.localToMinimap(client, lp);
-		if (posOnMinimap == null)
-		{
-			return;
-		}
-
-		Line2D.Double line = new Line2D.Double(posOnMinimap.getX(), posOnMinimap.getY() - 18, posOnMinimap.getX(),
-			posOnMinimap.getY() - 8);
-
-		drawMinimapArrow(graphics, line, color);
 	}
 
 	protected static void createMinimapDirectionArrow(Graphics2D graphics, Client client, WorldPoint playerRealWp, WorldPoint wp, Color color)

--- a/src/main/java/com/questhelper/steps/overlay/WorldLines.java
+++ b/src/main/java/com/questhelper/steps/overlay/WorldLines.java
@@ -75,12 +75,11 @@ public class WorldLines
 				continue;
 			}
 
-			LocalPoint startPoint = QuestPerspective.getInstanceLocalPointFromReal(client, currentPoint);
-			LocalPoint destinationPoint = QuestPerspective.getInstanceLocalPointFromReal(client, nextPoint);
-			if (startPoint == null || destinationPoint == null)
-			{
-				continue;
-			}
+			List<LocalPoint> startPoints = QuestPerspective.getInstanceLocalPointFromReal(client, currentPoint);
+			List<LocalPoint> destinationPoints = QuestPerspective.getInstanceLocalPointFromReal(client, nextPoint);
+			if (startPoints.isEmpty() || destinationPoints.isEmpty()) continue;
+			LocalPoint startPoint = startPoints.get(0);
+			LocalPoint destinationPoint = destinationPoints.get(0);
 
 			Point startPosOnMinimap = Perspective.localToMinimap(client, startPoint, 10000000);
 			Point destinationPosOnMinimap = Perspective.localToMinimap(client, destinationPoint, 10000000);
@@ -172,16 +171,15 @@ public class WorldLines
 			if (startWp.equals(new WorldPoint(0, 0, 0))) continue;
 			if (endWp.equals(new WorldPoint(0, 0, 0))) continue;
 			if (startWp.getPlane() != endWp.getPlane()) continue;
-			LocalPoint startLp = QuestPerspective.getInstanceLocalPointFromReal(client, startWp);
-			LocalPoint endLp = QuestPerspective.getInstanceLocalPointFromReal(client, endWp);
-			if (startLp == null && endLp == null)
-			{
-				continue;
-			}
+			List<LocalPoint> startPoints = QuestPerspective.getInstanceLocalPointFromReal(client, startWp);
+			List<LocalPoint> destinationPoints = QuestPerspective.getInstanceLocalPointFromReal(client, endWp);
+			if (startPoints.isEmpty() || destinationPoints.isEmpty()) continue;
+			LocalPoint startPoint = startPoints.get(0);
+			LocalPoint destinationPoint = destinationPoints.get(0);
 
 			int MAX_LP = 13056;
 
-			if (endLp == null)
+			if (destinationPoint == null)
 			{
 				// Work out point of intersection of loaded area
 				int xDiff = endWp.getX() - startWp.getX();
@@ -192,7 +190,7 @@ public class WorldLines
 				{
 					int goalLine = 0;
 					if (xDiff > 0) goalLine = MAX_LP;
-					changeToGetXToBorder = (goalLine - startLp.getX()) / xDiff;
+					changeToGetXToBorder = (goalLine - startPoint.getX()) / xDiff;
 				}
 				else
 				{
@@ -203,7 +201,7 @@ public class WorldLines
 				{
 					int goalLine = 0;
 					if (yDiff > 0) goalLine = MAX_LP;
-					changeToGetYToBorder =(goalLine - startLp.getY()) / yDiff;
+					changeToGetYToBorder =(goalLine - startPoint.getY()) / yDiff;
 				}
 				else
 				{
@@ -211,15 +209,15 @@ public class WorldLines
 				}
 				if (Math.abs(changeToGetXToBorder) < Math.abs(changeToGetYToBorder))
 				{
-					endLp = new LocalPoint(startLp.getX() + (xDiff * changeToGetXToBorder), startLp.getY() + (yDiff * changeToGetXToBorder));
+					destinationPoint = new LocalPoint(startPoint.getX() + (xDiff * changeToGetXToBorder), startPoint.getY() + (yDiff * changeToGetXToBorder));
 				}
 				else
 				{
-					endLp = new LocalPoint(startLp.getX() + (xDiff * changeToGetYToBorder), startLp.getY() + (yDiff * changeToGetYToBorder));
+					destinationPoint = new LocalPoint(startPoint.getX() + (xDiff * changeToGetYToBorder), startPoint.getY() + (yDiff * changeToGetYToBorder));
 				}
 			}
 
-			if (startLp == null)
+			if (startPoint == null)
 			{
 				// Work out point of intersection of loaded area
 				int xDiff = startWp.getX() - endWp.getX();
@@ -231,7 +229,7 @@ public class WorldLines
 				{
 					int goalLine = 0;
 					if (xDiff > 0) goalLine = MAX_LP;
-					changeToGetXToBorder = (goalLine - endLp.getX()) / xDiff;
+					changeToGetXToBorder = (goalLine - destinationPoint.getX()) / xDiff;
 				}
 				else
 				{
@@ -242,7 +240,7 @@ public class WorldLines
 				{
 					int goalLine = 0;
 					if (yDiff > 0) goalLine = MAX_LP;
-					changeToGetYToBorder = (goalLine - endLp.getY()) / yDiff;
+					changeToGetYToBorder = (goalLine - destinationPoint.getY()) / yDiff;
 				}
 				else
 				{
@@ -251,17 +249,17 @@ public class WorldLines
 
 				if (Math.abs(changeToGetXToBorder) < Math.abs(changeToGetYToBorder))
 				{
-					startLp = new LocalPoint(endLp.getX() + (xDiff * changeToGetXToBorder), endLp.getY() + (yDiff * changeToGetXToBorder));
+					startPoint = new LocalPoint(destinationPoint.getX() + (xDiff * changeToGetXToBorder), destinationPoint.getY() + (yDiff * changeToGetXToBorder));
 				}
 				else
 				{
-					startLp = new LocalPoint(endLp.getX() + (xDiff * changeToGetYToBorder), endLp.getY() + (yDiff * changeToGetYToBorder));
+					startPoint = new LocalPoint(destinationPoint.getX() + (xDiff * changeToGetYToBorder), destinationPoint.getY() + (yDiff * changeToGetYToBorder));
 				}
 			}
 
 			// If one is in scene, find local point we intersect with
 
-			Line2D.Double newLine = getWorldLines(client, startLp, endLp);
+			Line2D.Double newLine = getWorldLines(client, startPoint, destinationPoint);
 			if (newLine != null)
 			{
 				OverlayUtil.renderPolygon(graphics, newLine, color);

--- a/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
+++ b/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
@@ -109,29 +109,34 @@ public class QuestPerspective
 		return point;
 	}
 
-	public static LocalPoint getInstanceLocalPointFromReal(Client client, WorldPoint wp)
+	public static List<LocalPoint> getInstanceLocalPointFromReal(Client client, WorldPoint wp)
 	{
-		WorldPoint instanceWorldPoint = getInstanceWorldPointFromReal(client, wp);
-		if (instanceWorldPoint == null)
+		List<WorldPoint> instanceWorldPoint = new ArrayList<>(QuestPerspective.toLocalInstanceFromReal(client, wp));
+
+		List<LocalPoint> localPoints = new ArrayList<>();
+		for (WorldPoint worldPoint : instanceWorldPoint)
 		{
-			return null;
+			localPoints.add(LocalPoint.fromWorld(client.getTopLevelWorldView(), worldPoint));
 		}
 
-		return LocalPoint.fromWorld(client.getTopLevelWorldView(), instanceWorldPoint);
+		return localPoints;
 	}
 
 	public static WorldPoint getInstanceWorldPointFromReal(Client client, WorldPoint wp)
 	{
 		Collection<WorldPoint> points = QuestPerspective.toLocalInstanceFromReal(client, wp);
 
+		if (points.isEmpty()) return null;
+
+		WorldPoint p = null;
 		for (WorldPoint point : points)
 		{
 			if (point != null)
 			{
-				return point;
+				p = point;
 			}
 		}
-		return null;
+		return p;
 	}
 
 	public static WorldPoint getRealWorldPointFromLocal(Client client, WorldPoint wp)

--- a/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
+++ b/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
@@ -116,7 +116,11 @@ public class QuestPerspective
 		List<LocalPoint> localPoints = new ArrayList<>();
 		for (WorldPoint worldPoint : instanceWorldPoint)
 		{
-			localPoints.add(LocalPoint.fromWorld(client.getTopLevelWorldView(), worldPoint));
+			LocalPoint lp = LocalPoint.fromWorld(client.getTopLevelWorldView(), worldPoint);
+			if (lp != null)
+			{
+				localPoints.add(lp);
+			}
 		}
 
 		return localPoints;


### PR DESCRIPTION
This specifically came up in A Forgettable Tale... where the platforms with chests in the puzzle section exist a few times in the same space.

This meant sometimes the first LocalPoint found was actually the incorrect point. This change is intended to make it so that all LocalPoints can be considered by Steps before actually drawing arrows and highlights.

A note is I feel that the final section of DS2 might possibly be impacted by this, but I can't really predict in what way.