### PR TITLE
fix: Allow item highlights to work for ConditionalStep

### DIFF
--- a/src/main/java/com/questhelper/overlays/QuestHelperWidgetOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperWidgetOverlay.java
@@ -55,11 +55,11 @@ public class QuestHelperWidgetOverlay extends Overlay
 	{
 		QuestHelper quest = plugin.getSelectedQuest();
 
-		if (quest != null && quest.getCurrentStep() != null && quest.getCurrentStep().getActiveStep() != null)
+		if (quest != null && quest.getCurrentStep() != null)
 		{
 			if (plugin.getConfig().showWidgetHints())
 			{
-				quest.getCurrentStep().getActiveStep().makeWidgetOverlayHint(graphics, plugin);
+				quest.getCurrentStep().makeWidgetOverlayHint(graphics, plugin);
 			}
 		}
 		plugin.getRuneliteObjectManager().makeWidgetOverlayHint(graphics);

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -27,15 +27,20 @@ package com.questhelper.steps;
 import com.google.inject.Inject;
 import com.questhelper.requirements.MultiChatMessageRequirement;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.npc.DialogRequirement;
 import com.questhelper.requirements.runelite.RuneliteRequirement;
 import com.questhelper.requirements.conditional.InitializableRequirement;
 import java.awt.Graphics2D;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.questhelper.steps.widget.AbstractWidgetHighlight;
 import lombok.NonNull;
 import lombok.Setter;
 import net.runelite.api.GameState;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -388,6 +393,25 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 		if (currentStep != null)
 		{
 			currentStep.makeWorldLineOverlayHint(graphics, plugin);
+		}
+	}
+
+	@Override
+	public void makeWidgetOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
+	{
+		if (currentStep != null)
+		{
+			currentStep.makeWidgetOverlayHint(graphics, plugin);
+		}
+		WorldPoint activeWp = (currentStep instanceof DetailedQuestStep) ? ((DetailedQuestStep) currentStep).getWorldPoint() : null;
+		List<ItemRequirement> itemRequirements = requirements.stream()
+				.filter(ItemRequirement.class::isInstance)
+				.map(ItemRequirement.class::cast)
+				.collect(Collectors.toList());
+		renderInventory(graphics, activeWp, itemRequirements, false);
+		for (AbstractWidgetHighlight widgetHighlights : widgetsToHighlight)
+		{
+			widgetHighlights.highlightChoices(graphics, client, plugin);
 		}
 	}
 

--- a/src/main/java/com/questhelper/steps/DetailedOwnerStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedOwnerStep.java
@@ -35,10 +35,8 @@ import java.util.Collection;
 import java.util.List;
 import lombok.NonNull;
 import net.runelite.api.Client;
-import net.runelite.api.MenuEntry;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.ui.overlay.components.PanelComponent;
-import org.apache.commons.lang3.ArrayUtils;
 
 public class DetailedOwnerStep extends QuestStep implements OwnerStep
 {
@@ -149,6 +147,15 @@ public class DetailedOwnerStep extends QuestStep implements OwnerStep
 		if (currentStep != null)
 		{
 			currentStep.makeWorldLineOverlayHint(graphics, plugin);
+		}
+	}
+
+	@Override
+	public void makeWidgetOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
+	{
+		if (currentStep != null)
+		{
+			currentStep.makeWidgetOverlayHint(graphics, plugin);
 		}
 	}
 

--- a/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
+++ b/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
@@ -122,6 +122,7 @@ public class QuestPerspective
 
 	public static WorldPoint getInstanceWorldPointFromReal(Client client, WorldPoint wp)
 	{
+		if (wp == null) return null;
 		Collection<WorldPoint> points = QuestPerspective.toLocalInstanceFromReal(client, wp);
 
 		for (WorldPoint point : points)


### PR DESCRIPTION
This should ensure that a parent step with requirements like DetailedOwnerStep and ConditionalStep have access to item highlighting. Also simplifies the divide between teleport item highlighting and normal item highlighting.