### PR TITLE
fix: Ensure base tooltip used when copying in ItemRequirement

### DIFF
--- a/src/main/java/com/questhelper/requirements/AbstractRequirement.java
+++ b/src/main/java/com/questhelper/requirements/AbstractRequirement.java
@@ -34,7 +34,7 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 
 public abstract class AbstractRequirement implements Requirement
 {
-	private String tooltip;
+	protected String tooltip;
 	
 	private String urlSuffix;
 

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -524,7 +524,8 @@ public class ItemRequirement extends AbstractRequirement
 		newItem.questBank = questBank;
 		newItem.isConsumedItem = isConsumedItem;
 		newItem.shouldAggregate = shouldAggregate;
-		newItem.setTooltip(getTooltip());
+		// Need to get actual tooltip or we get the appended containers info
+		newItem.setTooltip(tooltip);
 		newItem.setUrlSuffix(getUrlSuffix());
 		newItem.additionalOptions = additionalOptions;
 		newItem.isChargedItem = isChargedItem;

--- a/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirements.java
@@ -340,7 +340,7 @@ public class ItemRequirements extends ItemRequirement
 		newItem.setDisplayMatchedItemName(isDisplayMatchedItemName());
 		newItem.setConditionToHide(getConditionToHide());
 		newItem.setQuestBank(getQuestBank());
-		newItem.setTooltip(getTooltip());
+		newItem.setTooltip(tooltip);
 		newItem.additionalOptions = additionalOptions;
 
 		return newItem;


### PR DESCRIPTION
When copying we were getting the tooltip with getTooltip(), which would include info on what containers the item was in.

This ensures the tooltip that's copied is the base tooltip, so that we don't get duplicate 'you can find it in...' info when using say '.highlighted()'.