### PR TITLE
fix: Check ConditionalStep for if started for highlighting

### DIFF
--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -403,18 +403,19 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	@Override
 	public QuestStep getActiveStep()
 	{
-		if (currentStep != null)
+		if (currentStep == null || !started)
 		{
-			return currentStep.getActiveStep();
+			return this;
 		}
 
-		return this;
+		return currentStep.getActiveStep();
 	}
 
 	@Override
 	public boolean containsSteps(QuestStep questStep, Set<QuestStep> checkedSteps)
 	{
 		if (super.containsSteps(questStep, checkedSteps)) return true;
+		if (!started) return false;
 
 		Set<QuestStep> stepSet = new HashSet<>(steps.values());
 		stepSet.removeAll(checkedSteps);


### PR DESCRIPTION
This should ensure we only try highlighting wrapper steps like ConditionalStep and its children if is is active.

This is important for some quests like Another Slice of H.A.M, where the same steps are used for different ConditionalSteps, but we only want the active section to highlight in the sidebar.