### PR TITLE
Fix object IDs for Runelite v1.11.6

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternMedium.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.questhelper.util.QHObjectID;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -253,12 +254,12 @@ public class WesternMedium extends ComplexStateQuestHelper
 		spiritToStronghold = new DetailedQuestStep(this, "Travel to the Gnome Stronghold by spirit tree.");
 
 		// todo more detailed chocobomb steps
-		moveToStrongFirstChoco = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		moveToStrongFirstChoco = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Climb the ladder at the Grand Tree.", gnomebowl, gianneDough, chocolateBar, equaLeaf, potOfCream, chocolateDust);
 		chocolateBomb = new DetailedQuestStep(this, "Make a chocolate bomb.", gnomebowl, gianneDough, chocolateBar,
 			equaLeaf, potOfCream, chocolateDust);
 
-		moveToStrongFirstDelivery = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		moveToStrongFirstDelivery = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Climb the ladder at the Grand Tree.");
 		completeTraining = new NpcStep(this, NpcID.ALUFT_GIANNE_SNR, new WorldPoint(2449, 3501, 1),
 			"Complete your training by talking to Blurberry and Aluft Gianne snr.");
@@ -270,7 +271,7 @@ public class WesternMedium extends ComplexStateQuestHelper
 
 		moveToStrongBase = new ObjectStep(this, ObjectID.TRAPDOOR_2446, new WorldPoint(2463, 3497, 0),
 			"Open the trapdoor to enter the underground of the Grand Tree.", pickaxe);
-		moveToStrongBase2 = new ObjectStep(this, ObjectID.LADDER_16684, new WorldPoint(2466, 3495, 1),
+		moveToStrongBase2 = new ObjectStep(this, QHObjectID.GRAND_TREE_F1_LADDER, new WorldPoint(2466, 3495, 1),
 			"Open the trapdoor to enter the underground of the Grand Tree.", pickaxe);
 		moveToStrongBase2.addDialogStep("Climb Down.");
 		moveToStrongBase.addSubSteps(moveToStrongBase2);

--- a/src/main/java/com/questhelper/helpers/miniquests/alfredgrimhandsbarcrawl/AlfredGrimhandsBarcrawl.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/alfredgrimhandsbarcrawl/AlfredGrimhandsBarcrawl.java
@@ -42,6 +42,7 @@ import com.questhelper.steps.QuestStep;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import com.questhelper.util.QHObjectID;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -177,7 +178,7 @@ public class AlfredGrimhandsBarcrawl extends ComplexStateQuestHelper
 			"Talk to the bartender in the Forester's Arms in Seers' Village.", coins18);
 		talkToForestersArms.addDialogStep("I'm doing Alfred Grimhand's Barcrawl.");
 
-		goUpToBlurberry = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		goUpToBlurberry = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Talk to Blurberry in the Grand Tree.", coins10);
 		talkToBlurberry = new NpcStep(this, NpcID.BLURBERRY, new WorldPoint(2482, 3491, 1),
 			"Talk to Blurberry in the Grand Tree.", coins10);

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessi/MonkeyMadnessI.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import com.questhelper.util.QHObjectID;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -510,11 +511,11 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		enterShipyard = new ObjectStep(this, ObjectID.GATE_2438, new WorldPoint(2945, 3041, 0), "Enter the shipyard on Karamja.", royalSeal);
 		enterShipyard.addDialogStep("I've lost my copy of the Royal Seal...");
 
-		goUpF0ToF1 = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0), "Travel to the Shipyard on Karamja.", royalSeal);
+		goUpF0ToF1 = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0), "Travel to the Shipyard on Karamja.", royalSeal);
 		goUpF0ToF1.addDialogStep("I've lost my copy of the Royal Seal...");
-		goUpF1ToF2 = new ObjectStep(this, ObjectID.LADDER_16684, new WorldPoint(2466, 3495, 1), "Travel to the Shipyard on Karamja.", royalSeal);
+		goUpF1ToF2 = new ObjectStep(this, QHObjectID.GRAND_TREE_F1_LADDER, new WorldPoint(2466, 3495, 1), "Travel to the Shipyard on Karamja.", royalSeal);
 		goUpF1ToF2.addDialogStep("Climb Up.");
-		goUpF2ToF3 = new ObjectStep(this, ObjectID.LADDER_2884, new WorldPoint(2466, 3495, 2), "Travel to the Shipyard on Karamja.", royalSeal);
+		goUpF2ToF3 = new ObjectStep(this, QHObjectID.GRAND_TREE_F2_LADDER, new WorldPoint(2466, 3495, 2), "Travel to the Shipyard on Karamja.", royalSeal);
 		goUpF2ToF3.addDialogStep("Climb Up.");
 		flyGandius = new NpcStep(this, NpcID.CAPTAIN_ERRDO_10471, new WorldPoint(2464, 3501, 3), "Fly with Captain Errdo to Gandius.");
 		flyGandius.addWidgetHighlight(138, 16);
@@ -525,7 +526,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		talkToNarnodeAfterShipyard = new NpcStep(this, NpcID.KING_NARNODE_SHAREEN, new WorldPoint(2465, 3496, 0), "Return to King Narnode Shareen in the Tree Gnome Stronghold.");
 		talkToNarnodeAfterShipyard.addWidgetHighlight(138, 4);
 
-		goUpToDaero = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		goUpToDaero = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Talk to Daero on the 1st floor of the Tree Gnome Stronghold.", Collections.singletonList(narnodesOrders.hideConditioned(talkedToDaero)),
 			Arrays.asList(food, prayerPotions, antipoison, staminaPotions, escapeTeleport));
 		talkToDaero = new NpcStep(this, NpcID.DAERO, new WorldPoint(2482, 3486, 1), "Talk to Daero on the 1st floor of the Tree Gnome Stronghold. " +
@@ -608,7 +609,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 			"Teleport out to prepare for a dangerous portion. You'll want energy/stamina potions, food and prayer potions.");
 		leaveToPrepareForBar.addTeleport(escapeTeleport);
 
-		goUpToDaeroForAmuletRun = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		goUpToDaeroForAmuletRun = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Get food, antipoison, energy / stamina / prayer potions, and return to Ape Atoll.",
 			Arrays.asList(goldBar, monkeyDentures, mould), Arrays.asList(food, antipoison, prayerPotions, staminaPotions, escapeTeleport));
 		goUpToDaeroForAmuletRun.addTeleport(grandTreeTeleport);
@@ -682,7 +683,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 			"Teleport out to prepare to make the amulet. You'll want some food, prayer potions, antipoisons, the mould and the enchanted bar.");
 		leaveToPrepareForAmulet.addTeleport(escapeTeleport);
 
-		goUpToDaeroForAmuletMake = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		goUpToDaeroForAmuletMake = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Get food, antipoison, prayer potions, and return to Ape Atoll.",
 			Arrays.asList(enchantedBar, mould, ballOfWool),
 			Arrays.asList(food, antipoison, prayerPotions, staminaPotions, escapeTeleport));
@@ -790,7 +791,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		killNinja = new NpcStep(this, NpcID.MONKEY_ARCHER_5274, new WorldPoint(2756, 2789, 0),
 			"Kill a monkey archer for their bones.", true, Collections.singletonList(ninjaBones), Collections.singletonList(protectFromRanged));
 
-		goUpToDaeroForTalismanRun = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		goUpToDaeroForTalismanRun = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"Get food, antipoison, prayer potions, and return to Ape Atoll.",
 			Arrays.asList(talisman, monkeyBonesOrCorpse),
 			Arrays.asList(food, antipoison, prayerPotions, staminaPotions, ardougneTeleport));
@@ -842,7 +843,7 @@ public class MonkeyMadnessI extends BasicQuestHelper
 		talkToMinderAgain = new NpcStep(this, NpcID.MONKEY_MINDER, new WorldPoint(2608, 3278, 0),
 			"UNEQUIP the greegree, then talk to the Monkey Minder again to leave.", new NoItemRequirement("Un-equipped greegree", ItemSlots.WEAPON));
 
-		goUpToDaeroForTalkingToAwow = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0),
+		goUpToDaeroForTalkingToAwow = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0),
 			"WALK/RUN to Daero to return to Ape Atoll. If you teleport, you'll have to start again.", Arrays.asList(karamjanGreegree, amuletWorn, monkey), Collections.singletonList(staminaPotions));
 
 		talkToDaeroForTalkingToAwow = new NpcStep(this, NpcID.DAERO, new WorldPoint(2482, 3486, 1), "Travel with Daero on the 1st floor of the Tree Gnome Stronghold.", karamjanGreegree, amulet, monkey);

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/TheEyesOfGlouphrie.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import com.questhelper.util.QHObjectID;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
@@ -277,9 +278,9 @@ public class TheEyesOfGlouphrie extends BasicQuestHelper
 		talkToBrimstailAfterIllusion = new NpcStep(this, brimstailNPCs, new WorldPoint(2410, 9818, 0), "Talk to Brimstail again.");
 		talkToBrimstailAfterIllusion.addDialogStep("Phew! I've got that machine working now. What do I need to do now?");
 
-		climbUpToF1Tree = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0), "Kill the evil creature at the top of the Grand Tree.");
-		climbUpToF2Tree = new ObjectStep(this, ObjectID.LADDER_16684, new WorldPoint(2466, 3495, 1), "Kill the evil creature at the top of the Grand Tree.");
-		climbUpToF3Tree = new ObjectStep(this, ObjectID.LADDER_2884, new WorldPoint(2466, 3495, 2), "Kill the evil creature at the top of the Grand Tree.");
+		climbUpToF1Tree = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0), "Kill the evil creature at the top of the Grand Tree.");
+		climbUpToF2Tree = new ObjectStep(this, QHObjectID.GRAND_TREE_F1_LADDER, new WorldPoint(2466, 3495, 1), "Kill the evil creature at the top of the Grand Tree.");
+		climbUpToF3Tree = new ObjectStep(this, QHObjectID.GRAND_TREE_F2_LADDER, new WorldPoint(2466, 3495, 2), "Kill the evil creature at the top of the Grand Tree.");
 		killCreature3.addSubSteps(climbUpToF1Tree, climbUpToF2Tree, climbUpToF3Tree);
 
 		talkToNarnode = new NpcStep(this, NpcID.KING_NARNODE_SHAREEN, new WorldPoint(2465, 3496, 0), "Talk to King Narnode to finish the quest.");

--- a/src/main/java/com/questhelper/helpers/quests/thegrandtree/TheGrandTree.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegrandtree/TheGrandTree.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import com.questhelper.util.QHObjectID;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
@@ -325,20 +326,20 @@ public class TheGrandTree extends BasicQuestHelper
 
 		talkToGloughAgain = new NpcStep(this, NpcID.GLOUGH_2061, "");
 
-		climbGrandTreeF0ToF1 = new ObjectStep(this, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0), "");
-		climbGrandTreeF1ToF2 = new ObjectStep(this, ObjectID.LADDER_16684, new WorldPoint(2466, 3495, 1), "");
+		climbGrandTreeF0ToF1 = new ObjectStep(this, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0), "");
+		climbGrandTreeF1ToF2 = new ObjectStep(this, QHObjectID.GRAND_TREE_F1_LADDER, new WorldPoint(2466, 3495, 1), "");
 		climbGrandTreeF1ToF2.addDialogStep("Climb Up.");
-		climbGrandTreeF2ToF3 = new ObjectStep(this, ObjectID.LADDER_2884, new WorldPoint(2466, 3495, 2), "");
+		climbGrandTreeF2ToF3 = new ObjectStep(this, QHObjectID.GRAND_TREE_F2_LADDER, new WorldPoint(2466, 3495, 2), "");
 		climbGrandTreeF2ToF3.addDialogStep("Climb Up.");
 
 		climbToTopOfGrandTree = new ConditionalStep(this, climbGrandTreeF0ToF1);
 		climbToTopOfGrandTree.addStep(isInGrandTreeF2, climbGrandTreeF2ToF3);
 		climbToTopOfGrandTree.addStep(isInGrandTreeF1, climbGrandTreeF1ToF2);
 
-		climbGrandTreeF3ToF2 = new ObjectStep(this, ObjectID.LADDER_16679, new WorldPoint(2466, 3495, 3), "");
-		climbGrandTreeF2ToF1 = new ObjectStep(this, ObjectID.LADDER_2884, new WorldPoint(2466, 3495, 2), "");
+		climbGrandTreeF3ToF2 = new ObjectStep(this, QHObjectID.GRAND_TREE_F3_LADDER, new WorldPoint(2466, 3495, 3), "");
+		climbGrandTreeF2ToF1 = new ObjectStep(this, QHObjectID.GRAND_TREE_F2_LADDER, new WorldPoint(2466, 3495, 2), "");
 		climbGrandTreeF2ToF1.addDialogStep("Climb Down.");
-		climbGrandTreeF1ToF0 = new ObjectStep(this, ObjectID.LADDER_16684, new WorldPoint(2466, 3495, 1), "");
+		climbGrandTreeF1ToF0 = new ObjectStep(this, QHObjectID.GRAND_TREE_F1_LADDER, new WorldPoint(2466, 3495, 1), "");
 		climbGrandTreeF1ToF0.addDialogStep("Climb Down.");
 
 		climbToBottomOfGrandTree = new ConditionalStep(this, goToStronghold);

--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/sections/InformKingBolren.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/sections/InformKingBolren.java
@@ -34,6 +34,7 @@ import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
 import java.util.List;
+import com.questhelper.util.QHObjectID;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
@@ -72,9 +73,9 @@ public class InformKingBolren
 		// Talk to Gianne Junior in Tree Gnome Stronghold
 		talkToGianneJnr = new NpcStep(quest, NpcID.GIANNE_JNR, new WorldPoint(2439, 3502, 1), "Talk to Gianne jnr. in Tree Gnome Stronghold to ask for Longramble's whereabouts.");
 		// Floor 0 to Floor 1
-		var climbUpToGianneJnr = new ObjectStep(quest, ObjectID.LADDER_16683, new WorldPoint(2466, 3495, 0), "");
-		var climbGrandTreeF3ToF2 = new ObjectStep(quest, ObjectID.LADDER_16679, new WorldPoint(2466, 3495, 3), "");
-		var climbGrandTreeF2ToF1 = new ObjectStep(quest, ObjectID.LADDER_2884, new WorldPoint(2466, 3495, 2), "");
+		var climbUpToGianneJnr = new ObjectStep(quest, QHObjectID.GRAND_TREE_F0_LADDER, new WorldPoint(2466, 3495, 0), "");
+		var climbGrandTreeF3ToF2 = new ObjectStep(quest, QHObjectID.GRAND_TREE_F3_LADDER, new WorldPoint(2466, 3495, 3), "");
+		var climbGrandTreeF2ToF1 = new ObjectStep(quest, QHObjectID.GRAND_TREE_F2_LADDER, new WorldPoint(2466, 3495, 2), "");
 		climbGrandTreeF2ToF1.addDialogStep("Climb Down.");
 		climbUpToGianneJnr.setText(talkToGianneJnr.getText());
 		climbUpToGianneJnr.addTeleport(teleToStronghold);

--- a/src/main/java/com/questhelper/util/QHObjectID.java
+++ b/src/main/java/com/questhelper/util/QHObjectID.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, Zoinkwiz <https://github.com/Zoinkwiz>
+ * Copyright (c) 2025, pajlada <https://github.com/pajlada>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.util;
+
+import net.runelite.api.ObjectID;
+
+public class QHObjectID
+{
+	/**
+	 * Ladder used at the bottom floor of the Grand Tree in the Tree Gnome Stronghold
+	 */
+	public static final int GRAND_TREE_F0_LADDER = ObjectID.LADDER_4458;
+	/**
+	 * Ladder used at the first floor of the Grand Tree in the Tree Gnome Stronghold
+	 */
+	public static final int GRAND_TREE_F1_LADDER = ObjectID.LADDER_56233;
+	/**
+	 * Ladder used at the second floor of the Grand Tree in the Tree Gnome Stronghold
+	 */
+	public static final int GRAND_TREE_F2_LADDER = ObjectID.LADDER_56232;
+	/**
+	 * Ladder used at the top floor of the Grand Tree in the Tree Gnome Stronghold
+	 */
+	public static final int GRAND_TREE_F3_LADDER = ObjectID.LADDER_56229;
+}


### PR DESCRIPTION
Quite a lot of object IDs to update - I _believe_ I caught them all.
Not all of these changes were required for things to update, but that's only because only one of the ladders actually broke.
Ladders at all floors have updated and would have failed to highlight.

I found the ladders by grepping for the coords `2466, 3495`, and updating the IDs depending on the plane.

Bottom floor:
![image](https://github.com/user-attachments/assets/483a50f4-80bd-4d8a-9dbc-8df706bbf65c)


Floor 1:
![image](https://github.com/user-attachments/assets/fb141c5b-0915-4c8f-a328-3fa62660375d)


Floor 2:
![image](https://github.com/user-attachments/assets/5076dbf6-613a-4ae3-b69c-fe9e7262bbab)


Top floor:
![image](https://github.com/user-attachments/assets/a4a48de7-9825-4153-845d-745d48c8c70a)


Released as part of https://github.com/Zoinkwiz/quest-helper/compare/release/v4.7.6.3 in https://github.com/runelite/plugin-hub/pull/7797