### PR TITLE
fix: Remove infinite looping makeWidgetOverlayHint from MetalDoorSolver for Curse of Arrav

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thecurseofarrav/MetalDoorSolver.java
+++ b/src/main/java/com/questhelper/helpers/quests/thecurseofarrav/MetalDoorSolver.java
@@ -429,8 +429,6 @@ public class MetalDoorSolver extends DetailedOwnerStep
 
 	public void drawDistanceUp(Graphics2D graphics, QuestHelperPlugin plugin)
 	{
-		super.makeWidgetOverlayHint(graphics, plugin);
-
 		var arrow = client.getWidget(PUZZLE_GROUP_ID, PUZZLE_BTN_DOWN_CHILD_ID);
 		if (arrow == null)
 		{
@@ -446,8 +444,6 @@ public class MetalDoorSolver extends DetailedOwnerStep
 
 	public void drawDistanceDown(Graphics2D graphics, QuestHelperPlugin plugin)
 	{
-		super.makeWidgetOverlayHint(graphics, plugin);
-
 		var arrow = client.getWidget(PUZZLE_GROUP_ID, PUZZLE_BTN_DOWN_CHILD_ID);
 		if (arrow == null)
 		{


### PR DESCRIPTION
At present this was infinitely looping to a stack overflow with:

```
	at com.questhelper.helpers.quests.thecurseofarrav.MetalDoorSolver.drawDistanceUp(MetalDoorSolver.java:436)
	at com.questhelper.steps.WidgetStep.makeWidgetOverlayHint(WidgetStep.java:93)
	at com.questhelper.steps.ConditionalStep.makeWidgetOverlayHint(ConditionalStep.java:404)
	at com.questhelper.steps.DetailedOwnerStep.makeWidgetOverlayHint(DetailedOwnerStep.java:158)
	at com.questhelper.helpers.quests.thecurseofarrav.MetalDoorSolver.drawDistanceUp(MetalDoorSolver.java:436)
```

This removes the call to the makeWidgetOverlayHint within MetalDoorSolver which was itself then passing a reference of itself down to WidgetStep to then go back to again. I haven't been able to test if this still allows the door to work highlight-wise, but it reads like it should to me as the makeWidgetOverlayHint should still be called every frame anyways.