### PR TITLE
Herb Run Helper: Hide seed dibber when barbarian farming training is completed

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/herbrun/HerbRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/herbrun/HerbRun.java
@@ -51,6 +51,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.timetracking.Tab;
@@ -184,7 +185,7 @@ public class HerbRun extends ComplexStateQuestHelper
 		accessToVarlamore = new QuestRequirement(QuestHelperQuest.CHILDREN_OF_THE_SUN, QuestState.FINISHED);
 
 		spade = new ItemRequirement("Spade", ItemID.SPADE);
-		dibber = new ItemRequirement("Seed dibber", ItemID.DIBBER);
+		dibber = new ItemRequirement("Seed dibber", ItemID.DIBBER).hideConditioned(new VarbitRequirement(VarbitID.BRUT_MINIQUEST, true, 0));
 		rake = new ItemRequirement("Rake", ItemID.RAKE).hideConditioned(new VarbitRequirement(Varbits.AUTOWEED, 2));
 
 		seed = new ItemRequirement("Seeds of your choice", ItemID.GUAM_SEED);


### PR DESCRIPTION
Varbit 9613 is BRUT_MINIQUEST. My account which has completed all steps of barbarian training has a varbit value of 9. A friend who has completed all steps except for bare-handed planting has a value of 8. This leads me to believe that the least significant bit of this varbit indicates whether or not the bare-handed planting of barbarian training has been completed.