### PR TITLE
Fix: improvements to Eyes of Glouphrie puzzle

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -121,6 +121,7 @@ public class QuestHelperPlugin extends Plugin
 	@Inject
 	RuneliteObjectManager runeliteObjectManager;
 
+	@Getter
 	@Inject
 	private QuestOverlayManager questOverlayManager;
 

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
@@ -33,15 +33,12 @@ import com.questhelper.steps.QuestStep;
 import com.questhelper.steps.WidgetStep;
 import com.questhelper.steps.widget.WidgetDetails;
 import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
-import net.runelite.api.gameval.InterfaceID;
-import net.runelite.api.gameval.ItemID;
-import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.*;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
@@ -96,10 +93,10 @@ public class PuzzleStep extends DetailedOwnerStep
 	public void startUp()
 	{
 		super.startUp();
-		answer1 = client.getVarbitValue(2510); // 1 input
-		answer2 = client.getVarbitValue(2511); // 2 input
-		answer3 = client.getVarbitValue(2512); // 3 input
-		answer4 = client.getVarbitValue(2513); // 4 input
+		answer1 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_1); // 1 input
+		answer2 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_2); // 2 input
+		answer3 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_3); // 3 input
+		answer4 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_4); // 4 input
 
 		updateSteps();
 	}
@@ -113,7 +110,7 @@ public class PuzzleStep extends DetailedOwnerStep
 	@Override
 	public void updateSteps()
 	{
-		if (client.getVarbitValue(2502) == 2)
+		if (client.getVarbitValue(VarbitID.EYEGLO_MACHINE_BROKEN) == 2)
 		{
 			solvePuzzle2();
 		}
@@ -141,16 +138,16 @@ public class PuzzleStep extends DetailedOwnerStep
 
 	public void solvePuzzle1()
 	{
-		int heldDisc = client.getVarpValue(856);
+		int heldDisc = client.getVarpValue(VarPlayerID.EYEGLO_COIN_SELECTED);
 		Widget insertWidget = client.getWidget(InterfaceID.LeagueTrophies.INFINITY);
 
-		if (client.getVarbitValue(2539) == answer1)
+		if (client.getVarbitValue(VarbitID.EYEGLO_UNLOCK_VAL) == answer1)
 		{
 			startUpStep(clickAnswer1);
 			return;
 		}
 
-		ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+		ItemContainer itemContainer = client.getItemContainer(InventoryID.INV);
 		if (itemContainer == null)
 		{
 			return;
@@ -208,15 +205,15 @@ public class PuzzleStep extends DetailedOwnerStep
 
 	public void solvePuzzle2()
 	{
-		int heldDisc = client.getVarpValue(856);
+		int heldDisc = client.getVarpValue(VarPlayerID.EYEGLO_COIN_SELECTED);
 
-		if (client.getVarbitValue(2540) == answer2 && client.getVarbitValue(2541) == answer3 && client.getVarbitValue(2542) == answer4)
+		if (client.getVarbitValue(VarbitID.EYEGLO_OPERATE1_VAL) == answer2 && client.getVarbitValue(VarbitID.EYEGLO_OPERATE2_VAL) == answer3 && client.getVarbitValue(VarbitID.EYEGLO_OPERATE3_VAL) == answer4)
 		{
 			startUpStep(clickAnswer2);
 			return;
 		}
 
-		ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+		ItemContainer itemContainer = client.getItemContainer(InventoryID.INV);
 		if (itemContainer == null)
 		{
 			return;
@@ -228,14 +225,14 @@ public class PuzzleStep extends DetailedOwnerStep
 
 		Widget insertWidget = client.getWidget(InterfaceID.EyegloGnomeMachineUnlocked.MACHINE_UNLOACKED_BACKGROUND);
 
-		int slot1 = client.getVarpValue(850);
+		int slot1 = client.getVarpValue(VarPlayerID.EYEGLO_OPERATE1_A);
 
-		int slot2 = client.getVarpValue(851);
-		int slot3 = client.getVarpValue(852);
+		int slot2 = client.getVarpValue(VarPlayerID.EYEGLO_OPERATE2_A);
+		int slot3 = client.getVarpValue(VarPlayerID.EYEGLO_OPERATE2_B);
 
-		int slot4 = client.getVarpValue(853);
-		int slot5 = client.getVarpValue(854);
-		int slot6 = client.getVarpValue(855);
+		int slot4 = client.getVarpValue(VarPlayerID.EYEGLO_OPERATE3_A);
+		int slot5 = client.getVarpValue(VarPlayerID.EYEGLO_OPERATE3_B);
+		int slot6 = client.getVarpValue(VarPlayerID.EYEGLO_OPERATE3_C);
 
 		newMostMatch3 = -1;
 		mostMatch4 = -1;

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
@@ -53,8 +53,6 @@ public class PuzzleStep extends DetailedOwnerStep
 	@Inject
 	protected Client client;
 
-	protected QuestStep currentStep;
-
 	HashMap<Integer, ItemRequirement> shapeValues = new HashMap<>();
 
 	HashMap<Integer, List<List<ItemRequirement>>> shapeValues3 = new HashMap<>();
@@ -85,7 +83,7 @@ public class PuzzleStep extends DetailedOwnerStep
 
 	public PuzzleStep(QuestHelper questHelper)
 	{
-		super(questHelper, "Insert and swap discs to make the sum indicated on the machine");
+		super(questHelper, "Insert and swap discs to make the sum indicated on the machine.");
 		setupShapes();
 	}
 
@@ -127,10 +125,10 @@ public class PuzzleStep extends DetailedOwnerStep
 		getPieces = new ObjectStep(getQuestHelper(), ObjectID.EYEGLO_CHANGE_MACHINE_MULTILOC, new WorldPoint(2391, 9826, 0), "Swap in" +
 				" your pieces for the indicated pieces. You can also drop the discs then talk to Brimstail for more " +
 				"tokens.");
-		clickAnswer1 = new WidgetStep(getQuestHelper(), "Click the submit button.", 445, 36);
+		clickAnswer1 = new WidgetStep(getQuestHelper(), "Click the submit button.", InterfaceID.EyegloGnomeMachineLocked.ARROW_MIDDLE);
 		clickAnswer2 = new WidgetStep(getQuestHelper(), "Click the submit button.", 189, 39);
-		insertDisc = new WidgetStep(getQuestHelper(), "Insert the correct discs.", 449, 0);
-		clickDiscHole = new WidgetStep(getQuestHelper(), "Insert the disc.", 445, 31);
+		insertDisc = new WidgetStep(getQuestHelper(), "Insert the correct discs.", InterfaceID.EyegloGnomeMachineLocked.UNLOCK_COMP_INSERT);
+		clickDiscHole = new WidgetStep(getQuestHelper(), "Insert the disc.", InterfaceID.EyegloGnomeMachineLocked.UNLOCK_COMP_INSERT);
 		clickDiscHole2 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 24);
 		clickDiscHole3 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 25);
 		clickDiscHole4 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 26);
@@ -139,7 +137,7 @@ public class PuzzleStep extends DetailedOwnerStep
 	public void solvePuzzle1()
 	{
 		int heldDisc = client.getVarpValue(VarPlayerID.EYEGLO_COIN_SELECTED);
-		Widget insertWidget = client.getWidget(InterfaceID.LeagueTrophies.INFINITY);
+		Widget insertWidget = client.getWidget(InterfaceID.EyegloSide.INV_LAYER);
 
 		if (client.getVarbitValue(VarbitID.EYEGLO_UNLOCK_VAL) == answer1)
 		{
@@ -188,8 +186,7 @@ public class PuzzleStep extends DetailedOwnerStep
 			if (currentInv != null)
 			{
 				List<WidgetDetails> ids = new ArrayList<>();
-
-				ids = getClickableItems(ids, new ArrayList<>(items1));
+				ids = getClickableItems(ids, List.of(items1));
 
 				insertDisc.setWidgetDetails(ids);
 				insertDisc.setRequirements(Collections.singletonList(shapes.get(items1)));
@@ -483,11 +480,12 @@ public class PuzzleStep extends DetailedOwnerStep
 
 	public List<WidgetDetails> getClickableItems(List<WidgetDetails> ids, List<Integer> items)
 	{
+		System.out.println(items.size());
 		for (int j = 0; j < currentInv.length; j++)
 		{
 			if (items.contains(currentInv[j].getId()))
 			{
-				ids.add(new WidgetDetails(449, 0, j));
+				ids.add(new WidgetDetails(InterfaceID.EYEGLO_SIDE, 0, j));
 			}
 		}
 		return ids;
@@ -508,11 +506,10 @@ public class PuzzleStep extends DetailedOwnerStep
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getContainerId() == 440)
+		if (event.getContainerId() == InventoryID.EYEGLO_INV_SIDE)
 		{
 			ItemContainer container = event.getItemContainer();
 			currentInv = container.getItems();
-
 		}
 	}
 
@@ -617,43 +614,6 @@ public class PuzzleStep extends DetailedOwnerStep
 					shapeValues4.get(i + j + k).add(Arrays.asList(shape1, shape2, shape3));
 				}
 			}
-		}
-	}
-
-	protected void startUpStep(QuestStep step)
-	{
-		if (step.equals(currentStep)) return;
-
-		if (currentStep != null)
-		{
-			shutDownStep();
-		}
-
-		eventBus.register(step);
-		step.startUp();
-		currentStep = step;
-	}
-
-	protected void shutDownStep()
-	{
-		if (currentStep != null)
-		{
-			eventBus.unregister(currentStep);
-			currentStep.shutDown();
-			currentStep = null;
-		}
-	}
-
-	@Override
-	public QuestStep getActiveStep()
-	{
-		if (currentStep != null)
-		{
-			return currentStep.getActiveStep();
-		}
-		else
-		{
-			return this;
 		}
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/theeyesofglouphrie/PuzzleStep.java
@@ -66,8 +66,6 @@ public class PuzzleStep extends DetailedOwnerStep
 
 	ObjectStep solvePuzzle, getPieces;
 
-	int answer1, answer2, answer3, answer4;
-
 	int items1;
 
 	List<ItemRequirement> items2 = new ArrayList<>();
@@ -91,11 +89,6 @@ public class PuzzleStep extends DetailedOwnerStep
 	public void startUp()
 	{
 		super.startUp();
-		answer1 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_1); // 1 input
-		answer2 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_2); // 2 input
-		answer3 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_3); // 3 input
-		answer4 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_4); // 4 input
-
 		updateSteps();
 	}
 
@@ -123,19 +116,26 @@ public class PuzzleStep extends DetailedOwnerStep
 	{
 		solvePuzzle = new ObjectStep(getQuestHelper(), ObjectID.EYEGLO_GNOME_MACHINE_02_MULTILOC, new WorldPoint(2390, 9826, 0), "Put in the correct pieces.");
 		getPieces = new ObjectStep(getQuestHelper(), ObjectID.EYEGLO_CHANGE_MACHINE_MULTILOC, new WorldPoint(2391, 9826, 0), "Swap in" +
-				" your pieces for the indicated pieces. You can also drop the discs then talk to Brimstail for more " +
-				"tokens.");
+				" your pieces for the indicated pieces. You can also drop the discs then talk to Brimstail for more tokens.");
 		clickAnswer1 = new WidgetStep(getQuestHelper(), "Click the submit button.", InterfaceID.EyegloGnomeMachineLocked.ARROW_MIDDLE);
-		clickAnswer2 = new WidgetStep(getQuestHelper(), "Click the submit button.", 189, 39);
+		clickAnswer1.setShouldOverlayWidget(true);
+		clickAnswer2 = new WidgetStep(getQuestHelper(), "Click the submit button.", InterfaceID.EyegloGnomeMachineUnlocked.CORRECT);
+		clickAnswer2.setShouldOverlayWidget(true);
 		insertDisc = new WidgetStep(getQuestHelper(), "Insert the correct discs.", InterfaceID.EyegloGnomeMachineLocked.UNLOCK_COMP_INSERT);
+		insertDisc.setShouldOverlayWidget(true);
 		clickDiscHole = new WidgetStep(getQuestHelper(), "Insert the disc.", InterfaceID.EyegloGnomeMachineLocked.UNLOCK_COMP_INSERT);
-		clickDiscHole2 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 24);
-		clickDiscHole3 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 25);
-		clickDiscHole4 = new WidgetStep(getQuestHelper(), "Insert the disc.", 189, 26);
+		clickDiscHole.setShouldOverlayWidget(true);
+		clickDiscHole2 = new WidgetStep(getQuestHelper(), "Insert the disc.", InterfaceID.EyegloGnomeMachineUnlocked.SET_1_COINSLOT);
+		clickDiscHole2.setShouldOverlayWidget(true);
+		clickDiscHole3 = new WidgetStep(getQuestHelper(), "Insert the disc.", InterfaceID.EyegloGnomeMachineUnlocked.SET_2_COINSLOT);
+		clickDiscHole3.setShouldOverlayWidget(true);
+		clickDiscHole4 = new WidgetStep(getQuestHelper(), "Insert the disc.", InterfaceID.EyegloGnomeMachineUnlocked.SET_3_COINSLOT);
+		clickDiscHole4.setShouldOverlayWidget(true);
 	}
 
 	public void solvePuzzle1()
 	{
+		int answer1 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_1);
 		int heldDisc = client.getVarpValue(VarPlayerID.EYEGLO_COIN_SELECTED);
 		Widget insertWidget = client.getWidget(InterfaceID.EyegloSide.INV_LAYER);
 
@@ -204,7 +204,12 @@ public class PuzzleStep extends DetailedOwnerStep
 	{
 		int heldDisc = client.getVarpValue(VarPlayerID.EYEGLO_COIN_SELECTED);
 
-		if (client.getVarbitValue(VarbitID.EYEGLO_OPERATE1_VAL) == answer2 && client.getVarbitValue(VarbitID.EYEGLO_OPERATE2_VAL) == answer3 && client.getVarbitValue(VarbitID.EYEGLO_OPERATE3_VAL) == answer4)
+		int answer1 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_2); // 1 input
+		int answer2 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_3); // 2 input
+		int answer3 = client.getVarbitValue(VarbitID.EYEGLO_COIN_VALUE_4); // 3 input
+
+
+		if (client.getVarbitValue(VarbitID.EYEGLO_OPERATE1_VAL) == answer1 && client.getVarbitValue(VarbitID.EYEGLO_OPERATE2_VAL) == answer2 && client.getVarbitValue(VarbitID.EYEGLO_OPERATE3_VAL) == answer3)
 		{
 			startUpStep(clickAnswer2);
 			return;
@@ -239,9 +244,9 @@ public class PuzzleStep extends DetailedOwnerStep
 		// Puzzle 2
 
 		// Loop through all shapes which have equal value to goal
-		for (Integer id : shapeValues.get(answer2).getAllIds())
+		for (Integer id : shapeValues.get(answer1).getAllIds())
 		{
-			items2 = Collections.singletonList(shapeValues.get(answer2));
+			items2 = Collections.singletonList(shapeValues.get(answer1));
 			int match = checkForItems(inventoryItems, id);
 
 			// If found item in inventory
@@ -273,7 +278,7 @@ public class PuzzleStep extends DetailedOwnerStep
 		List<ItemRequirement> newReq3 = new ArrayList<>();
 		List<Item> newInventory3 = new ArrayList<>(inventoryItems);
 		List<Item> tmpInventory3;
-		for (List<ItemRequirement> reqs : shapeValues3.get(answer3))
+		for (List<ItemRequirement> reqs : shapeValues3.get(answer2))
 		{
 			// Each duo
 			List<Integer> currentSlotIDs3 = new ArrayList<>(Arrays.asList(slot2, slot3));
@@ -342,7 +347,7 @@ public class PuzzleStep extends DetailedOwnerStep
 		// Puzzle 4
 		List<ItemRequirement> newReq4 = new ArrayList<>();
 		List<Item> tmpInventory4;
-		for (List<ItemRequirement> reqs : shapeValues4.get(answer4))
+		for (List<ItemRequirement> reqs : shapeValues4.get(answer3))
 		{
 			List<Integer> currentSlotIDs4 = new ArrayList<>(Arrays.asList(slot4, slot5, slot6));
 			// Each duo
@@ -427,7 +432,7 @@ public class PuzzleStep extends DetailedOwnerStep
 		{
 			for (ItemRequirement itemRequirement : items2)
 			{
-				if (itemRequirement.getId() == heldDisc)
+				if (itemRequirement.getAllIds().contains(heldDisc))
 				{
 					startUpStep(clickDiscHole2);
 					return;
@@ -435,7 +440,7 @@ public class PuzzleStep extends DetailedOwnerStep
 			}
 			for (ItemRequirement itemRequirement : items3)
 			{
-				if (itemRequirement.getId() == heldDisc)
+				if (itemRequirement.getAllIds().contains(heldDisc))
 				{
 					startUpStep(clickDiscHole3);
 					return;
@@ -443,7 +448,7 @@ public class PuzzleStep extends DetailedOwnerStep
 			}
 			for (ItemRequirement itemRequirement : items4)
 			{
-				if (itemRequirement.getId() == heldDisc)
+				if (itemRequirement.getAllIds().contains(heldDisc))
 				{
 					startUpStep(clickDiscHole4);
 					return;
@@ -480,7 +485,6 @@ public class PuzzleStep extends DetailedOwnerStep
 
 	public List<WidgetDetails> getClickableItems(List<WidgetDetails> ids, List<Integer> items)
 	{
-		System.out.println(items.size());
 		for (int j = 0; j < currentInv.length; j++)
 		{
 			if (items.contains(currentInv[j].getId()))

--- a/src/main/java/com/questhelper/managers/QuestOverlayManager.java
+++ b/src/main/java/com/questhelper/managers/QuestOverlayManager.java
@@ -71,6 +71,11 @@ public class QuestOverlayManager
 		overlayManager.add(questHelperTooltipOverlay);
 	}
 
+	public void updateOverlay()
+	{
+		overlayManager.saveOverlay(questHelperOverlay);
+	}
+
 	public void shutDown()
 	{
 		overlayManager.remove(questHelperOverlay);

--- a/src/main/java/com/questhelper/overlays/QuestHelperOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperOverlay.java
@@ -29,6 +29,7 @@ package com.questhelper.overlays;
 
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPriority;
 
@@ -46,7 +47,8 @@ public class QuestHelperOverlay extends OverlayPanel
 	public QuestHelperOverlay(QuestHelperPlugin plugin)
 	{
 		this.plugin = plugin;
-		setPriority(OverlayPriority.HIGHEST);
+		setLayer(OverlayLayer.UNDER_WIDGETS);
+		setPriority(PRIORITY_HIGHEST);
 	}
 
 	@Override
@@ -61,6 +63,17 @@ public class QuestHelperOverlay extends OverlayPanel
 		if (questHelper == null || questHelper.getCurrentStep() == null)
 		{
 			return null;
+		}
+
+		if (questHelper.getCurrentStep().getActiveStep().isShouldOverlayWidget() && getLayer() != OverlayLayer.ALWAYS_ON_TOP)
+		{
+			setLayer(OverlayLayer.ALWAYS_ON_TOP);
+			plugin.getQuestOverlayManager().updateOverlay();
+		}
+		else if (getLayer() != OverlayLayer.UNDER_WIDGETS)
+		{
+			setLayer(OverlayLayer.UNDER_WIDGETS);
+			plugin.getQuestOverlayManager().updateOverlay();
 		}
 		questHelper.getCurrentStep().makeOverlayHint(panelComponent, plugin, new ArrayList<>(), new ArrayList<>());
 

--- a/src/main/java/com/questhelper/steps/PuzzleWrapperStep.java
+++ b/src/main/java/com/questhelper/steps/PuzzleWrapperStep.java
@@ -108,7 +108,7 @@ public class PuzzleWrapperStep extends ConditionalStep
 	@Override
 	public void makeOverlayHint(PanelComponent panelComponent, QuestHelperPlugin plugin, @NonNull List<String> additionalText, @NonNull List<Requirement> additionalRequirements)
 	{
-		if (questHelperConfig.solvePuzzles())
+		if (currentStep != null && questHelperConfig.solvePuzzles())
 		{
 			currentStep.makeOverlayHint(panelComponent, plugin, additionalText, additionalRequirements);
 		}

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -164,6 +164,10 @@ public abstract class QuestStep implements Module
 	@Getter
 	protected String backgroundWorldTooltipText;
 
+	@Getter
+	@Setter
+	protected boolean shouldOverlayWidget;
+
 	public QuestStep(QuestHelper questHelper)
 	{
 		this.questHelper = questHelper;

--- a/src/main/java/com/questhelper/steps/WidgetStep.java
+++ b/src/main/java/com/questhelper/steps/WidgetStep.java
@@ -43,6 +43,12 @@ public class WidgetStep extends DetailedQuestStep
 
 	protected List<BiConsumer<Graphics2D, QuestHelperPlugin>> extraWidgetOverlayHintFunctions = new ArrayList<>();
 
+	public WidgetStep(QuestHelper questHelper, String text, int interfaceID)
+	{
+		super(questHelper, text);
+		widgetDetails.add(new WidgetDetails(interfaceID));
+	}
+
 	public WidgetStep(QuestHelper questHelper, String text, int groupID, int childID)
 	{
 		super(questHelper, text);


### PR DESCRIPTION
This PR looks at the render order of the overlay for the puzzle with a new method in QuestStep, updating some details to gamevals, and a few small improvements to make it work a bit better, namely ensuring it considers all viable insertion discs properly when prompting the player to click a new disc to add to their hand image.