### PR TITLE
fix: Added combat xp from Cold War and Desert Easy Diary required actions as rewards

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertEasy.java
@@ -40,6 +40,7 @@ import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.rewards.ItemReward;
+import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.UnlockReward;
 import com.questhelper.steps.*;
 import net.runelite.api.Skill;
@@ -284,6 +285,13 @@ public class DesertEasy extends ComplexStateQuestHelper
 			new ItemReward("Desert amulet 1", ItemID.DESERT_AMULET_EASY),
 			new ItemReward("2,500 Exp. Lamp (Any skill over 30)", ItemID.THOSF_REWARD_LAMP)
 		);
+	}
+
+	@Override
+	public List<ExperienceReward> getExperienceRewards()
+	{
+		return Arrays.asList(
+				new ExperienceReward(Skill.STRENGTH, 20));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/helpers/quests/coldwar/ColdWar.java
@@ -445,7 +445,8 @@ public class ColdWar extends BasicQuestHelper
 		return Arrays.asList(
 				new ExperienceReward(Skill.CRAFTING, 2000),
 				new ExperienceReward(Skill.AGILITY, 5000),
-				new ExperienceReward(Skill.CONSTRUCTION, 1500));
+				new ExperienceReward(Skill.CONSTRUCTION, 1500),
+				new ExperienceReward(Skill.ATTACK, 40));
 	}
 
 	@Override


### PR DESCRIPTION
The primary goal of these changes is to ensure these quests do not appear when filtering out attack and strength.

Cold War provides 40-120 attack experience depending on how many icelords you are required to kill. I wasn't sure what amount to put, so I did the minimum.

Desert Easy Diary provides 20 strength experience when opening the sarcophagus.

Fixes #1829 