### PR TITLE
feat: Added sidebar highlight depth toggle for ConditionalStep

### DIFF
--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -59,6 +59,14 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 
 	protected boolean started = false;
 
+	/** 
+	 * Controls whether the sidebar highlight should consider child steps when determining what to highlight.
+	 * When true, the sidebar will highlight the most specific active step in the step hierarchy.
+	 * When false, the sidebar will only highlight this ConditionalStep itself, ignoring any active child steps.
+	 */
+	@Setter
+	protected boolean shouldConsiderSubStepsForSidebarHighlight = true;
+
 	@Setter
 	protected boolean checkAllChildStepsOnListenerCall = false;
 
@@ -423,7 +431,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	@Override
 	public QuestStep getActiveStep()
 	{
-		if (currentStep == null || !started)
+		if (currentStep == null || !started || !shouldConsiderSubStepsForSidebarHighlight)
 		{
 			return this;
 		}


### PR DESCRIPTION
Sometimes we want to use a ConditionalStep as a sidebar step, but also sometimes in another spot just a normal step which is a step within a ConditionalStep.

This usually results in the sidebar highlighting both, as the step can be active in a depth search, as well as as the higher conditionalstep being active.

This allows for full depth searching to not be done for sidebar consideration for specific conditional steps.