### PR TITLE
fix: tree helper unit test

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
@@ -162,6 +162,7 @@ public class TreeRun extends ComplexStateQuestHelper
 	@Override
 	public QuestStep loadStep()
 	{
+		initializeRequirements();
 		setupSteps();
 		farmingHandler = new FarmingHandler(client, configManager);
 


### PR DESCRIPTION
technically a bit of a code stink - in a normal quest helper run, initializeRequirements gets called by the QuestManager when the user logs in or they change their profile.
We don't call that for this unit test, but it's not a problem for most unit tests because they defensively call initializeRequirements in more places.
