### PR TITLE
Fix: Minor edit for text alignment in Making Friends with My Arm

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
+++ b/src/main/java/com/questhelper/helpers/quests/makingfriendswithmyarm/MakingFriendsWithMyArm.java
@@ -634,7 +634,7 @@ public class MakingFriendsWithMyArm extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.FIREMAKING, 66));
 		req.add(new SkillRequirement(Skill.MINING, 72, true));
 		req.add(new SkillRequirement(Skill.CONSTRUCTION, 35, true));
-		req.add(new SkillRequirement(Skill.AGILITY, 68, true, " 68 Agility (but higher is better)"));
+		req.add(new SkillRequirement(Skill.AGILITY, 68, true, "68 Agility (but higher is better)"));
 		return req;
 	}
 }


### PR DESCRIPTION
This removes a space to fix text alignment in the general requirements section of the Making Friends with My Arm quest.