### PR TITLE
Fix typo in lairoftarnrazorlor step

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/lairoftarnrazorlor/TarnRoute.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/lairoftarnrazorlor/TarnRoute.java
@@ -199,7 +199,7 @@ public class TarnRoute extends ConditionalStep
 		enterHauntedMine = steps.get(null);
 		enterLair = new ObjectStep(questHelper, ObjectID.LOTR_ENTRANCE_DOOR_UNBLOCKED, new WorldPoint(3424, 9661, 0), "Enter the entrance to the north.");
 
-		searchWallRoom1 = new ObjectStep(questHelper, ObjectID.LOTR_TRAP_SPEAR_WALL, new WorldPoint(3196, 4557, 0), "Follow the path west then north, and go through the door you reach.");
+		searchWallRoom1 = new ObjectStep(questHelper, ObjectID.LOTR_TRAP_SPEAR_WALL, new WorldPoint(3196, 4557, 0), "Follow the path east then north, and go through the door you reach.");
 		searchWallRoom1.setLinePoints(Arrays.asList(
 			new WorldPoint(3166, 4547, 0),
 			new WorldPoint(3166, 4550, 0),


### PR DESCRIPTION
Step 4 under "Traversing the dungeon" reads "Follow the path west then north", but I had to walk east before heading north. It's is a simple typo that this patch addresses by switching the direction in the instructions.