### PR TITLE
Fix typo in Death on the Isle

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deathontheisle/DeathOnTheIsle.java
+++ b/src/main/java/com/questhelper/helpers/quests/deathontheisle/DeathOnTheIsle.java
@@ -556,7 +556,7 @@ public class DeathOnTheIsle extends BasicQuestHelper
 		/// 36
 		var climbSecondLooseRocksToTheatre = new ObjectStep(this, ObjectID.DOTI_AGILITY_CHALLENGE_C, new WorldPoint(1474, 2923, 0), "Climb down the loose rocks in your way to the guards outside the theatre.");
 
-		talkToGuardsAtTheatre = new NpcStep(this, NpcID.DOTI_STRADIUS, new WorldPoint(1472, 2925, 0), "Talk to Stradius at the theatre backstage of the theatre.");
+		talkToGuardsAtTheatre = new NpcStep(this, NpcID.DOTI_STRADIUS, new WorldPoint(1472, 2925, 0), "Talk to Stradius at the backstage of the theatre.");
 		talkToGuardsAtTheatre.addSubSteps(headDownFromTopFloor, headDownFromMiddleFloor, climbFirstLooseRocksToTheatre, climbSecondLooseRocksToTheatre);
 		talkToGuardsAtTheatre.addSubSteps(headDownFromTopFloor);
 


### PR DESCRIPTION
The first step under the final "The show must go on" section had the word "theatre" an extra time. This change removes the redundant use of the word.

The text for this step could be more descriptive by mentioning the agility rocks to the south that have to be climbed first. It looks like there's code to do this but it wasn't functional when I went through the quest.