### PR TITLE
Reduce redundant helper text in Enakhra's Lament

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/enakhraslament/EnakhrasLament.java
+++ b/src/main/java/com/questhelper/helpers/quests/enakhraslament/EnakhrasLament.java
@@ -354,7 +354,7 @@ public class EnakhrasLament extends BasicQuestHelper
 		useChiselOn20Sandstone = new DetailedQuestStep(this, "Use a chisel on the sandstone 20kg.", chiselHighlighted, sandstone20);
 		placeBody = new ObjectStep(this, ObjectID.ENAKH_STATUE_EAST_MULTILOC, new WorldPoint(3190, 2926, 0), "Place the body on the sandstone base.", body);
 		talkToLazimToChooseHead = new NpcStep(this, NpcID.ENAKH_LAZIM, new WorldPoint(3190, 2925, 0), "Talk to Lazim and choose the head you'd like the statue to have.");
-		getGranite = new NpcStep(this, NpcID.ENAKH_LAZIM, new WorldPoint(3190, 2925, 0), "Get 2 x granite 5kg, and then craft one into the head you chose. You can mine some nearby.", granite2);
+		getGranite = new NpcStep(this, NpcID.ENAKH_LAZIM, new WorldPoint(3190, 2925, 0), "Get 2 x granite (5kg). You can mine some nearby.", granite2);
 
 		// TODO: Change head highlight text based on choice
 		craftHead = new DetailedQuestStep(this, "Use a chisel on a piece of granite 5kg, and choose the head you decided on to craft.", chiselHighlighted, granite);


### PR DESCRIPTION
Near the end of the "Craft a statue" section the text between two steps is redundant. The programmed logic works fine but the redundant text can cause confusion. This change removes the redundant text from the first step because the following step effectively guides the player on what to do next. This change also formats the weight of the granite in parentheses to match the name of the item.