### PR TITLE
Fix experience rewards list for Cold War

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/coldwar/ColdWar.java
+++ b/src/main/java/com/questhelper/helpers/quests/coldwar/ColdWar.java
@@ -445,8 +445,7 @@ public class ColdWar extends BasicQuestHelper
 		return Arrays.asList(
 				new ExperienceReward(Skill.CRAFTING, 2000),
 				new ExperienceReward(Skill.AGILITY, 5000),
-				new ExperienceReward(Skill.CONSTRUCTION, 1500),
-				new ExperienceReward(Skill.ATTACK, 40));
+				new ExperienceReward(Skill.CONSTRUCTION, 1500));
 	}
 
 	@Override


### PR DESCRIPTION
The "Rewards:" section lists "40 Attack Experience" as a reward but this isn't listed on [the wiki](https://oldschool.runescape.wiki/w/Cold_War#Rewards) and I also didn't see that award when I completed the quest today.

This change removes the line from the rewards list.