### PR TITLE
fix: add missing boost information for Wilderness diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessEasy.java
@@ -262,7 +262,7 @@ public class WildernessEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 15));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 15, true));
 		reqs.add(new SkillRequirement(Skill.MAGIC, 21, true));
 		reqs.add(new SkillRequirement(Skill.MINING, 15, true));
 
@@ -312,7 +312,7 @@ public class WildernessEasy extends ComplexStateQuestHelper
 		allSteps.add(eggsSteps);
 
 		PanelDetails earthWarriorSteps = new PanelDetails("Earth Warrior", Arrays.asList(moveToEdgeEarth, earthWarrior),
-			new SkillRequirement(Skill.AGILITY, 15), combatGear, food);
+			new SkillRequirement(Skill.AGILITY, 15, true), combatGear, food);
 		earthWarriorSteps.setDisplayCondition(notEarthWarrior);
 		earthWarriorSteps.setLockingStep(earthWarriorTask);
 		allSteps.add(earthWarriorSteps);
@@ -324,7 +324,7 @@ public class WildernessEasy extends ComplexStateQuestHelper
 
 		/* Starting to go up from Edgeville */
 		PanelDetails ironOreSteps = new PanelDetails("Iron Ore", Collections.singletonList(ironOre),
-			new SkillRequirement(Skill.MINING, 15), pickaxe);
+			new SkillRequirement(Skill.MINING, 15, true), pickaxe);
 		ironOreSteps.setDisplayCondition(notIronOre);
 		ironOreSteps.setLockingStep(ironOreTask);
 		allSteps.add(ironOreSteps);
@@ -342,7 +342,7 @@ public class WildernessEasy extends ComplexStateQuestHelper
 		allSteps.add(chaosSteps);
 
 		PanelDetails alchSteps = new PanelDetails("Free Low Alchemy", Arrays.asList(moveToFount, lowAlch),
-			new SkillRequirement(Skill.MAGIC, 21), normalBook, alchable);
+			new SkillRequirement(Skill.MAGIC, 21, true), normalBook, alchable);
 		alchSteps.setDisplayCondition(notLowAlch);
 		alchSteps.setLockingStep(lowAlchTask);
 		allSteps.add(alchSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessElite.java
@@ -289,15 +289,15 @@ public class WildernessElite extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(enterGodwars);
-		reqs.add(new SkillRequirement(Skill.COOKING, 90));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 75));
-		reqs.add(new SkillRequirement(Skill.FISHING, 85));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 96));
-		reqs.add(new SkillRequirement(Skill.MINING, 85));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 83));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 90));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 84));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 75));
+		reqs.add(new SkillRequirement(Skill.COOKING, 90, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 75, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 85, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 96, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 85, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 83, true));
+		reqs.add(new SkillRequirement(Skill.SMITHING, 90, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 84, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 75, true));
 
 		reqs.add(desertTreasure);
 
@@ -339,29 +339,29 @@ public class WildernessElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails tpSteps = new PanelDetails("Teleport to Ghorrock", Collections.singletonList(tPGhorrock),
-			new SkillRequirement(Skill.MAGIC, 96), desertTreasure, ancientBook, lawRune.quantity(2),
+			new SkillRequirement(Skill.MAGIC, 96, true), desertTreasure, ancientBook, lawRune.quantity(2),
 			waterRune.quantity(8));
 		tpSteps.setDisplayCondition(notTPGhorrock);
 		tpSteps.setLockingStep(tpGhorrockTask);
 		allSteps.add(tpSteps);
 
 		PanelDetails magicSteps = new PanelDetails("Chop and Burn Magic Logs", Arrays.asList(moveToResource1, magicLogs,
-			burnLogs), new SkillRequirement(Skill.FIREMAKING, 75), new SkillRequirement(Skill.WOODCUTTING, 75),
+			burnLogs), new SkillRequirement(Skill.FIREMAKING, 75, true), new SkillRequirement(Skill.WOODCUTTING, 75, true),
 			coins.quantity(6000), axe, tinderbox);
 		magicSteps.setDisplayCondition(notMagicLogs);
 		magicSteps.setLockingStep(magicLogsTask);
 		allSteps.add(magicSteps);
 
 		PanelDetails scimSteps = new PanelDetails("Rune Scimitar in Resource Area",
-			Arrays.asList(moveToResource2, runiteGolem, smeltBar, runeScim), new SkillRequirement(Skill.MINING, 85),
-			new SkillRequirement(Skill.SMITHING, 90), coins.quantity(6000), combatGear, food, pickaxe,
+			Arrays.asList(moveToResource2, runiteGolem, smeltBar, runeScim), new SkillRequirement(Skill.MINING, 85, true),
+			new SkillRequirement(Skill.SMITHING, 90, true), coins.quantity(6000), combatGear, food, pickaxe,
 			coal.quantity(16), hammer);
 		scimSteps.setDisplayCondition(notRuneScim);
 		scimSteps.setLockingStep(runeScimTask);
 		allSteps.add(scimSteps);
 
 		PanelDetails crabSteps = new PanelDetails("Dark Crab in Resource Area", Arrays.asList(moveToResource3, darkCrab,
-			cookDarkCrab), new SkillRequirement(Skill.COOKING, 90), new SkillRequirement(Skill.FISHING, 85),
+			cookDarkCrab), new SkillRequirement(Skill.COOKING, 90, true), new SkillRequirement(Skill.FISHING, 85, true),
 			coins.quantity(6000), lobsterPot, darkFishingBait);
 		crabSteps.setDisplayCondition(notDarkCrab);
 		crabSteps.setLockingStep(darkCrabTask);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessHard.java
@@ -174,7 +174,7 @@ public class WildernessHard extends ComplexStateQuestHelper
 		burningAmulet = new ItemRequirement("Burning amulet", ItemCollections.BURNING_AMULETS);
 
 		enterGodwars = new ComplexRequirement(LogicType.OR, "60 Agility or Strength",
-			new SkillRequirement(Skill.AGILITY, 60), new SkillRequirement(Skill.STRENGTH, 60));
+			new SkillRequirement(Skill.AGILITY, 60, true), new SkillRequirement(Skill.STRENGTH, 60, true));
 
 		inEdge = new ZoneRequirement(edge);
 		inAir = new ZoneRequirement(air);
@@ -270,12 +270,12 @@ public class WildernessHard extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(enterGodwars);
-		reqs.add(new SkillRequirement(Skill.AGILITY, 64));
-		reqs.add(new SkillRequirement(Skill.FISHING, 53));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 67));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 66));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 68));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 75));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 64, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 53, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 67, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 66, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 68, true));
+		reqs.add(new SkillRequirement(Skill.SMITHING, 75, true));
 
 		reqs.add(deathPlateau);
 		reqs.add(mageArena);
@@ -324,13 +324,13 @@ public class WildernessHard extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails airSteps = new PanelDetails("Air Orb", Arrays.asList(moveToEdge, moveToAir, airOrb),
-			new SkillRequirement(Skill.MAGIC, 60), airRune.quantity(30), cosmicRune.quantity(3), unpoweredOrb);
+			new SkillRequirement(Skill.MAGIC, 60, true), airRune.quantity(30), cosmicRune.quantity(3), unpoweredOrb);
 		airSteps.setDisplayCondition(notAirOrb);
 		airSteps.setLockingStep(airOrbTask);
 		allSteps.add(airSteps);
 
 		PanelDetails sallySteps = new PanelDetails("Black Salamander", Collections.singletonList(blackSally),
-			new SkillRequirement(Skill.HUNTER, 67), smallFishingNet, rope);
+			new SkillRequirement(Skill.HUNTER, 67, true), smallFishingNet, rope);
 		sallySteps.setDisplayCondition(notBlackSally);
 		sallySteps.setLockingStep(blackSallyTask);
 		allSteps.add(sallySteps);
@@ -342,26 +342,26 @@ public class WildernessHard extends ComplexStateQuestHelper
 		allSteps.add(lavaSteps);
 
 		PanelDetails rawLavaEelSteps = new PanelDetails("Fishing a Raw Lava Eel", Collections.singletonList(rawLavaEel),
-			new SkillRequirement(Skill.FISHING, 53), oilyRod, fishingBait, knife);
+			new SkillRequirement(Skill.FISHING, 53, true), oilyRod, fishingBait, knife);
 		rawLavaEelSteps.setDisplayCondition(notRawLavaEel);
 		rawLavaEelSteps.setLockingStep(rawLavaEelTask);
 		allSteps.add(rawLavaEelSteps);
 
 		PanelDetails warrSteps = new PanelDetails("Spiritual Warrior", Arrays.asList(moveToGodWars1, moveToGodWars2,
 			sprirtualWarrior),
-			enterGodwars, new SkillRequirement(Skill.SLAYER, 68), combatGear, food, godEquip);
+			enterGodwars, new SkillRequirement(Skill.SLAYER, 68, true), combatGear, food, godEquip);
 		warrSteps.setDisplayCondition(notSprirtualWarrior);
 		warrSteps.setLockingStep(sprirtualWarriorTask);
 		allSteps.add(warrSteps);
 
 		PanelDetails trollSteps = new PanelDetails("Agility Shortcut", Collections.singletonList(trollWildy),
-			new SkillRequirement(Skill.AGILITY, 64), deathPlateau);
+			new SkillRequirement(Skill.AGILITY, 64, true), deathPlateau);
 		trollSteps.setDisplayCondition(notTrollWildy);
 		trollSteps.setLockingStep(trollWildyTask);
 		allSteps.add(trollSteps);
 
 		PanelDetails scimSteps = new PanelDetails("Adamant Scimitar in Resource Area", Arrays.asList(moveToResource,
-			addyScim), new SkillRequirement(Skill.SMITHING, 75), barsOrPick, hammer);
+			addyScim), new SkillRequirement(Skill.SMITHING, 75, true), barsOrPick, hammer);
 		scimSteps.setDisplayCondition(notAddyScim);
 		scimSteps.setLockingStep(addyScimTask);
 		allSteps.add(scimSteps);
@@ -378,7 +378,7 @@ public class WildernessHard extends ComplexStateQuestHelper
 		allSteps.add(bossesSteps);
 
 		PanelDetails godSpellSteps = new PanelDetails("God Spell on Player", Collections.singletonList(godSpells),
-			new SkillRequirement(Skill.MAGIC, 60), godStaff, godRunes);
+			new SkillRequirement(Skill.MAGIC, 60, false), godStaff, godRunes);
 		godSpellSteps.setDisplayCondition(notGodSpells);
 		godSpellSteps.setLockingStep(godSpellsTask);
 		allSteps.add(godSpellSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessMedium.java
@@ -288,12 +288,12 @@ public class WildernessMedium extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(enterGodwars);
-		reqs.add(new SkillRequirement(Skill.AGILITY, 52));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 60));
-		reqs.add(new SkillRequirement(Skill.MINING, 55));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 50));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 50));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 61));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 52, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 60, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 55, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 50, true));
+		reqs.add(new SkillRequirement(Skill.SMITHING, 50, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 61, true));
 
 		reqs.add(betweenARock);
 
@@ -337,7 +337,7 @@ public class WildernessMedium extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails entSteps = new PanelDetails("Ent Yew", Collections.singletonList(entYew),
-			new SkillRequirement(Skill.WOODCUTTING, 61), combatGear, food, runeAxe);
+			new SkillRequirement(Skill.WOODCUTTING, 61, true), combatGear, food, runeAxe);
 		entSteps.setDisplayCondition(notEntYew);
 		entSteps.setLockingStep(entYewTask);
 		allSteps.add(entSteps);
@@ -361,7 +361,7 @@ public class WildernessMedium extends ComplexStateQuestHelper
 		allSteps.add(godWarsSteps);
 
 		PanelDetails bloodveldSteps = new PanelDetails("Kill Bloodveld in God Wars Dungeon",
-			Arrays.asList(moveToGodWars2, wildyGodwars, wildyGWBloodveld), new SkillRequirement(Skill.SLAYER, 50),
+			Arrays.asList(moveToGodWars2, wildyGodwars, wildyGWBloodveld), new SkillRequirement(Skill.SLAYER, 50, true),
 			enterGodwars, combatGear, food, godEquip);
 		bloodveldSteps.setDisplayCondition(notWildyGWBloodveld);
 		bloodveldSteps.setLockingStep(wildyGWBloodveldTask);
@@ -373,25 +373,25 @@ public class WildernessMedium extends ComplexStateQuestHelper
 		allSteps.add(emblemSteps);
 
 		PanelDetails earthOrbSteps = new PanelDetails("Earth Orb", Arrays.asList(moveToEdge, earthOrb),
-			new SkillRequirement(Skill.MAGIC, 60), unpoweredOrb, earthRune.quantity(30), cosmicRune.quantity(3));
+			new SkillRequirement(Skill.MAGIC, 60, true), unpoweredOrb, earthRune.quantity(30), cosmicRune.quantity(3));
 		earthOrbSteps.setDisplayCondition(notEarthOrb);
 		earthOrbSteps.setLockingStep(earthOrbTask);
 		allSteps.add(earthOrbSteps);
 
 		PanelDetails mithSteps = new PanelDetails("Mine Mithril", Collections.singletonList(mineMith),
-			new SkillRequirement(Skill.MINING, 55), pickaxe, knife);
+			new SkillRequirement(Skill.MINING, 55, true), pickaxe, knife);
 		mithSteps.setDisplayCondition(notMineMith);
 		mithSteps.setLockingStep(mineMithTask);
 		allSteps.add(mithSteps);
 
 		PanelDetails wildyAgiSteps = new PanelDetails("Wilderness Agility Course",
-			Collections.singletonList(wildyAgi), new SkillRequirement(Skill.AGILITY, 52), knife);
+			Collections.singletonList(wildyAgi), new SkillRequirement(Skill.AGILITY, 52, true), knife);
 		wildyAgiSteps.setDisplayCondition(notWildyAgi);
 		wildyAgiSteps.setLockingStep(wildyAgiTask);
 		allSteps.add(wildyAgiSteps);
 
 		PanelDetails goldHelmSteps = new PanelDetails("Gold Helmet in Resource Area", Arrays.asList(moveToResource,
-			mineGoldOre, smeltGoldOre, goldHelm), new SkillRequirement(Skill.SMITHING, 50), betweenARock,
+			mineGoldOre, smeltGoldOre, goldHelm), new SkillRequirement(Skill.SMITHING, 50, true), betweenARock,
 			coins.quantity(7500), barsOrPick, hammer, knife);
 		goldHelmSteps.setDisplayCondition(notGoldHelm);
 		goldHelmSteps.setLockingStep(goldHelmTask);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142