### PR TITLE
fix: add missing boost information for Ardougne diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneEasy.java
@@ -184,7 +184,7 @@ public class ArdougneEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.THIEVING, 5));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 5, true));
 
 		reqs.add(runeMysteries);
 		reqs.add(biohazard);
@@ -240,7 +240,7 @@ public class ArdougneEasy extends ComplexStateQuestHelper
 		allSteps.add(essSteps);
 
 		PanelDetails cakeSteps = new PanelDetails("Steal Cake", Collections.singletonList(stealCake),
-			new SkillRequirement(Skill.THIEVING, 5));
+			new SkillRequirement(Skill.THIEVING, 5, true));
 		cakeSteps.setDisplayCondition(notStealCake);
 		cakeSteps.setLockingStep(stealCakeTask);
 		allSteps.add(cakeSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneElite.java
@@ -305,11 +305,11 @@ public class ArdougneElite extends ComplexStateQuestHelper
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new SkillRequirement(Skill.AGILITY, 90, true));
 		reqs.add(new SkillRequirement(Skill.COOKING, 91, true));
-		reqs.add(new SkillRequirement(Skill.CRAFTING, 10));
-		reqs.add(new SkillRequirement(Skill.FARMING, 85));
-		reqs.add(new SkillRequirement(Skill.FISHING, 81));
-		reqs.add(new SkillRequirement(Skill.FLETCHING, 69));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 94));
+		reqs.add(new SkillRequirement(Skill.CRAFTING, 10, true));
+		reqs.add(new SkillRequirement(Skill.FARMING, 85, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 81, false));
+		reqs.add(new SkillRequirement(Skill.FLETCHING, 69, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 94, true));
 		reqs.add(new SkillRequirement(Skill.SMITHING, 91, true));
 		reqs.add(new SkillRequirement(Skill.THIEVING, 82, true));
 
@@ -355,13 +355,13 @@ public class ArdougneElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails torstolSteps = new PanelDetails("Ardougne Torstol", Collections.singletonList(pickTorstol),
-			new SkillRequirement(Skill.FARMING, 85), torstolSeed, compost, rake, seedDib, spade);
+			new SkillRequirement(Skill.FARMING, 85, true), torstolSeed, compost, rake, seedDib, spade);
 		torstolSteps.setDisplayCondition(notPickTorstol);
 		torstolSteps.setLockingStep(pickTorstolTask);
 		allSteps.add(torstolSteps);
 
 		PanelDetails iceSteps = new PanelDetails("Ice Barrage in Castle Wars", Collections.singletonList(iceBarrage),
-			new SkillRequirement(Skill.MAGIC, 94), desertTreasure, ancientBook, waterRune.quantity(6),
+			new SkillRequirement(Skill.MAGIC, 94, true), desertTreasure, ancientBook, waterRune.quantity(6),
 			bloodRune.quantity(2), deathRune.quantity(4));
 		iceSteps.setDisplayCondition(notIceBarrage);
 		iceSteps.setLockingStep(iceBarrageTask);
@@ -380,7 +380,7 @@ public class ArdougneElite extends ComplexStateQuestHelper
 		allSteps.add(salveSteps);
 
 		PanelDetails raySteps = new PanelDetails("Fishing Trawler Manta Ray", Collections.singletonList(trawlerRay),
-			new SkillRequirement(Skill.COOKING, 91, true), new SkillRequirement(Skill.FISHING, 81));
+			new SkillRequirement(Skill.COOKING, 91, true), new SkillRequirement(Skill.FISHING, 81, false));
 		raySteps.setDisplayCondition(notTrawlerRay);
 		raySteps.setLockingStep(trawlerRayTask);
 		allSteps.add(raySteps);
@@ -392,14 +392,14 @@ public class ArdougneElite extends ComplexStateQuestHelper
 		allSteps.add(roofSteps);
 
 		PanelDetails heroSteps = new PanelDetails("Pickpocket Hero", Collections.singletonList(pickHero),
-			new SkillRequirement(Skill.THIEVING, 80));
+			new SkillRequirement(Skill.THIEVING, 80, true));
 		heroSteps.setDisplayCondition(notPickHero);
 		heroSteps.setLockingStep(pickHeroTask);
 		allSteps.add(heroSteps);
 
 		PanelDetails crossSteps = new PanelDetails("Rune Crossbow in Yanille / Witchaven", Arrays.asList(spinString,
-			smithLimbs, fletchStock, makeUnstrungCross, runeCrossbow), new SkillRequirement(Skill.CRAFTING, 10),
-			new SkillRequirement(Skill.SMITHING, 91, true), new SkillRequirement(Skill.FLETCHING, 69),
+			smithLimbs, fletchStock, makeUnstrungCross, runeCrossbow), new SkillRequirement(Skill.CRAFTING, 10, true),
+			new SkillRequirement(Skill.SMITHING, 91, true), new SkillRequirement(Skill.FLETCHING, 69, true),
 			yewLog, runeBar, hammer, knife, sinewOrRoot);
 		crossSteps.setDisplayCondition(notRuneCrossbow);
 		crossSteps.setLockingStep(runeCrossbowTask);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
@@ -330,8 +330,8 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50, false));
 		reqs.add(new SkillRequirement(Skill.FARMING, 70, true));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 59));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 66));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 59, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 66, true));
 		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 65, true));
 		reqs.add(new SkillRequirement(Skill.SMITHING, 68, true));
 		reqs.add(new SkillRequirement(Skill.THIEVING, 72, true));
@@ -382,7 +382,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		allSteps.add(ivySteps);
 
 		PanelDetails watchtowerSteps = new PanelDetails("Teleport to Watchtower",
-			Collections.singletonList(tPWatchtower), new SkillRequirement(Skill.MAGIC, 58), watchtower,
+			Collections.singletonList(tPWatchtower), new SkillRequirement(Skill.MAGIC, 58, true), watchtower,
 			earthRune.quantity(2), lawRune.quantity(2));
 		watchtowerSteps.setDisplayCondition(notTPWatchtower);
 		watchtowerSteps.setLockingStep(tpWatchtowerTask);
@@ -400,7 +400,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		allSteps.add(yanSteps);
 
 		PanelDetails mgSteps = new PanelDetails("Magic Guild", Collections.singletonList(magicGuild),
-			new SkillRequirement(Skill.MAGIC, 66));
+			new SkillRequirement(Skill.MAGIC, 66, true));
 		mgSteps.setDisplayCondition(notMagicGuild);
 		mgSteps.setLockingStep(magicGuildTask);
 		allSteps.add(mgSteps);
@@ -412,7 +412,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		allSteps.add(plateSteps);
 
 		PanelDetails sallySteps = new PanelDetails("Red Salamander", Collections.singletonList(redSally),
-			new SkillRequirement(Skill.HUNTER, 59), rope, smallFishingNet);
+			new SkillRequirement(Skill.HUNTER, 59, true), rope, smallFishingNet);
 		sallySteps.setDisplayCondition(notRedSally);
 		sallySteps.setLockingStep(redSallyTask);
 		allSteps.add(sallySteps);
@@ -430,13 +430,13 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		allSteps.add(monkeySteps);
 
 		PanelDetails chestSteps = new PanelDetails("Stealing from Ardougne Royalty", Arrays.asList(moveToCastle,
-			stealChest), new SkillRequirement(Skill.THIEVING, 72), lockpick);
+			stealChest), new SkillRequirement(Skill.THIEVING, 72, true), lockpick);
 		chestSteps.setDisplayCondition(notStealChest);
 		chestSteps.setLockingStep(stealChestTask);
 		allSteps.add(chestSteps);
 
 		PanelDetails dragSteps = new PanelDetails("Smith Dragon Square in West Ardougne",
-			Collections.singletonList(dragSquare), new SkillRequirement(Skill.SMITHING, 60), shieldLeft, shieldRight,
+			Collections.singletonList(dragSquare), new SkillRequirement(Skill.SMITHING, 60, true), shieldLeft, shieldRight,
 			hammer);
 		dragSteps.setDisplayCondition(notDragSquare);
 		dragSteps.setLockingStep(dragSquareTask);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
@@ -326,13 +326,13 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 39));
-		reqs.add(new SkillRequirement(Skill.FARMING, 31));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 50));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 51));
-		reqs.add(new SkillRequirement(Skill.STRENGTH, 38));
-		reqs.add(new SkillRequirement(Skill.RANGED, 21));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 38));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 39, true));
+		reqs.add(new SkillRequirement(Skill.FARMING, 31, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 50, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 51, true));
+		reqs.add(new SkillRequirement(Skill.STRENGTH, 38, true));
+		reqs.add(new SkillRequirement(Skill.RANGED, 21, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 38, true));
 
 		reqs.add(fairyTaleII);
 		reqs.add(enlightenedJourney);
@@ -379,19 +379,19 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails strawSteps = new PanelDetails("Ardougne Strawberries", Collections.singletonList(ardyStraw),
-			new SkillRequirement(Skill.FARMING, 31), rake, strawSeeds.quantity(3), seedDib, spade);
+			new SkillRequirement(Skill.FARMING, 31, true), rake, strawSeeds.quantity(3), seedDib, spade);
 		strawSteps.setDisplayCondition(notArdyStraw);
 		strawSteps.setLockingStep(ardyStrawTask);
 		allSteps.add(strawSteps);
 
 		PanelDetails cwSteps = new PanelDetails("Castle Wars Balloon", Arrays.asList(moveToEntrana, talkToAug,
-			balloonCW), new SkillRequirement(Skill.FIREMAKING, 50), enlightenedJourney, yewLog11);
+			balloonCW), new SkillRequirement(Skill.FIREMAKING, 50, true), enlightenedJourney, yewLog11);
 		cwSteps.setDisplayCondition(new Conditions(notBalloonCW, notCWBallon2));
 		cwSteps.setLockingStep(balloonCWTask);
 		allSteps.add(cwSteps);
 
 		PanelDetails cw2Steps = new PanelDetails("Castle Wars Balloon", Collections.singletonList(balloonCW),
-			new SkillRequirement(Skill.FIREMAKING, 50), enlightenedJourney, yewLog1);
+			new SkillRequirement(Skill.FIREMAKING, 50, true), enlightenedJourney, yewLog1);
 		cw2Steps.setDisplayCondition(new Conditions(notBalloonCW, notCWBallon));
 		cw2Steps.setLockingStep(balloonCWTask);
 		allSteps.add(cw2Steps);
@@ -403,8 +403,8 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		allSteps.add(nightSteps);
 
 		PanelDetails grapSteps = new PanelDetails("Yanille Wall Grapple", Arrays.asList(grapYan, grapYan2),
-			new SkillRequirement(Skill.AGILITY, 39), new SkillRequirement(Skill.STRENGTH, 38),
-			new SkillRequirement(Skill.RANGED, 21), mithGrap, crossbow);
+			new SkillRequirement(Skill.AGILITY, 39, true), new SkillRequirement(Skill.STRENGTH, 38, true),
+			new SkillRequirement(Skill.RANGED, 21, true), mithGrap, crossbow);
 		grapSteps.setDisplayCondition(notGrapYan);
 		grapSteps.setLockingStep(grapYanTask);
 		allSteps.add(grapSteps);
@@ -415,7 +415,7 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		allSteps.add(sandSteps);
 
 		PanelDetails tpSteps = new PanelDetails("Teleport to Ardougne", Collections.singletonList(tPArdy),
-			new SkillRequirement(Skill.MAGIC, 51), plagueCity, normalBook, lawRune.quantity(2), waterRune.quantity(2));
+			new SkillRequirement(Skill.MAGIC, 51, true), plagueCity, normalBook, lawRune.quantity(2), waterRune.quantity(2));
 		tpSteps.setDisplayCondition(notTPArdy);
 		tpSteps.setLockingStep(tpArdyTask);
 		allSteps.add(tpSteps);
@@ -433,7 +433,7 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 		allSteps.add(fishSteps);
 
 		PanelDetails farmerSteps = new PanelDetails("Pickpocket Master Farmer",
-			Collections.singletonList(pickMasterFarmer), new SkillRequirement(Skill.THIEVING, 38));
+			Collections.singletonList(pickMasterFarmer), new SkillRequirement(Skill.THIEVING, 38, true));
 		farmerSteps.setDisplayCondition(notPickMasterFarmer);
 		farmerSteps.setLockingStep(pickMasterFarmerTask);
 		allSteps.add(farmerSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142