### PR TITLE
fix: add missing boost information for Desert diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertEasy.java
@@ -264,8 +264,8 @@ public class DesertEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.HUNTER, 5));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 21));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 5, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 21, false));
 
 		reqs.add(icthlarinsLittleHelper);
 
@@ -335,7 +335,7 @@ public class DesertEasy extends ComplexStateQuestHelper
 		allSteps.add(kalphiteCactiSteps);
 
 		PanelDetails goldenWarblerSteps = new PanelDetails("Golden Warbler", Collections.singletonList(goldWarbler),
-			new SkillRequirement(Skill.HUNTER, 5), birdSnare);
+			new SkillRequirement(Skill.HUNTER, 5, true), birdSnare);
 		goldenWarblerSteps.setDisplayCondition(notGoldWarbler);
 		goldenWarblerSteps.setLockingStep(goldWarblerTask);
 		allSteps.add(goldenWarblerSteps);
@@ -364,7 +364,7 @@ public class DesertEasy extends ComplexStateQuestHelper
 		allSteps.add(vultureSteps);
 
 		PanelDetails openSarcSteps = new PanelDetails("First Sarcophagus", Arrays.asList(moveToPyramidPlunder,
-			startPyramidPlunder, openSarc), new SkillRequirement(Skill.THIEVING, 21), icthlarinsLittleHelper);
+			startPyramidPlunder, openSarc), new SkillRequirement(Skill.THIEVING, 21, false), icthlarinsLittleHelper);
 		openSarcSteps.setDisplayCondition(notOpenSarc);
 		openSarcSteps.setLockingStep(openSarcTask);
 		allSteps.add(openSarcSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertElite.java
@@ -265,12 +265,12 @@ public class DesertElite extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 78));
-		reqs.add(new SkillRequirement(Skill.COOKING, 85));
-		reqs.add(new SkillRequirement(Skill.FLETCHING, 95));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 94));
-		reqs.add(new SkillRequirement(Skill.PRAYER, 85));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 91));
+		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 78, true));
+		reqs.add(new SkillRequirement(Skill.COOKING, 85, true));
+		reqs.add(new SkillRequirement(Skill.FLETCHING, 95, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 94, true));
+		reqs.add(new SkillRequirement(Skill.PRAYER, 85, false));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 91, false));
 
 
 		reqs.add(desertTreasure);
@@ -287,38 +287,38 @@ public class DesertElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails wildPieSteps = new PanelDetails("Bake Wild Pie", Collections.singletonList(wildPie),
-			new SkillRequirement(Skill.COOKING, 85), rawPie);
+			new SkillRequirement(Skill.COOKING, 85, true), rawPie);
 		wildPieSteps.setDisplayCondition(notWildPie);
 		wildPieSteps.setLockingStep(wildPieTask);
 		allSteps.add(wildPieSteps);
 
 		PanelDetails iceBarrageSteps = new PanelDetails("Ice Barrage", Collections.singletonList(iceBarrage),
-			new SkillRequirement(Skill.MAGIC, 94), desertTreasure, ancientBook, waterRune.quantity(6),
+			new SkillRequirement(Skill.MAGIC, 94, true), desertTreasure, ancientBook, waterRune.quantity(6),
 			bloodRune.quantity(2), deathRune.quantity(4));
 		iceBarrageSteps.setDisplayCondition(notIceBarrage);
 		iceBarrageSteps.setLockingStep(iceBarrageTask);
 		allSteps.add(iceBarrageSteps);
 
 		PanelDetails grandGoldChestSteps = new PanelDetails("Grand Gold Chest", Arrays.asList(moveToPyramidPlunder,
-			startPyramidPlunder, grandGoldChest), new SkillRequirement(Skill.THIEVING, 91), icthlarinsLittleHelper);
+			startPyramidPlunder, grandGoldChest), new SkillRequirement(Skill.THIEVING, 91, false), icthlarinsLittleHelper);
 		grandGoldChestSteps.setDisplayCondition(notGrandGoldChest);
 		grandGoldChestSteps.setLockingStep(grandGoldChestTask);
 		allSteps.add(grandGoldChestSteps);
 
 		PanelDetails restorePrayerSteps = new PanelDetails("Restore 85 Prayer",
-			Collections.singletonList(restorePrayer), new SkillRequirement(Skill.PRAYER, 85), icthlarinsLittleHelper);
+			Collections.singletonList(restorePrayer), new SkillRequirement(Skill.PRAYER, 85, false), icthlarinsLittleHelper);
 		restorePrayerSteps.setDisplayCondition(notRestorePrayer);
 		restorePrayerSteps.setLockingStep(restorePrayerTask);
 		allSteps.add(restorePrayerSteps);
 
 		PanelDetails dragonDartsSteps = new PanelDetails("Dragon Darts", Arrays.asList(moveToBed, dragonDarts),
-			new SkillRequirement(Skill.FLETCHING, 95), touristTrap, dragonDartTip, feather);
+			new SkillRequirement(Skill.FLETCHING, 95, true), touristTrap, dragonDartTip, feather);
 		dragonDartsSteps.setDisplayCondition(notDragonDarts);
 		dragonDartsSteps.setLockingStep(dragonDartsTask);
 		allSteps.add(dragonDartsSteps);
 
 		PanelDetails kqHeadSteps = new PanelDetails("Kalphite Queen Head", Collections.singletonList(talkKQHead),
-			new SkillRequirement(Skill.CONSTRUCTION, 78), priestInPeril, kqHead, coins.quantity(50000),
+			new SkillRequirement(Skill.CONSTRUCTION, 78, true), priestInPeril, kqHead, coins.quantity(50000),
 			mahoganyPlank.quantity(2), goldLeaves.quantity(2), saw, hammer);
 		kqHeadSteps.setDisplayCondition(notTalkKQHead);
 		kqHeadSteps.setLockingStep(talkKQHeadTask);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertHard.java
@@ -272,15 +272,15 @@ public class DesertHard extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 70));
-		reqs.add(new SkillRequirement(Skill.ATTACK, 50));
-		reqs.add(new SkillRequirement(Skill.DEFENCE, 10));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 68));
-		reqs.add(new SkillRequirement(Skill.MINING, 45));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 68));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 65));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 65));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 70, true));
+		reqs.add(new SkillRequirement(Skill.ATTACK, 50, false));
+		reqs.add(new SkillRequirement(Skill.DEFENCE, 10, false));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 68, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 45, true));
+		reqs.add(new SkillRequirement(Skill.SMITHING, 68, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 65, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 65, true));
 
 		reqs.add(contact);
 		reqs.add(dreamMentor);
@@ -331,27 +331,27 @@ public class DesertHard extends ComplexStateQuestHelper
 		allSteps.add(kalphiteQueenSteps);
 
 		PanelDetails pollRooftopSteps = new PanelDetails("Pollnivneach Rooftops",
-			Collections.singletonList(pollRooftop), new SkillRequirement(Skill.AGILITY, 70));
+			Collections.singletonList(pollRooftop), new SkillRequirement(Skill.AGILITY, 70, true));
 		pollRooftopSteps.setDisplayCondition(notPollRooftop);
 		pollRooftopSteps.setLockingStep(pollRooftopTask);
 		allSteps.add(pollRooftopSteps);
 
 		PanelDetails menaphiteThugSteps = new PanelDetails("Menaphite Thug", Collections.singletonList(menaThug),
-			new SkillRequirement(Skill.THIEVING, 65), theFeud, blackjack);
+			new SkillRequirement(Skill.THIEVING, 65, true), theFeud, blackjack);
 		menaphiteThugSteps.setDisplayCondition(notMenaThug);
 		menaphiteThugSteps.setLockingStep(menaThugTask);
 		allSteps.add(menaphiteThugSteps);
 
 		PanelDetails refillWaterskinsSteps = new PanelDetails("Refill Waterskins",
-			Collections.singletonList(refillWaterskin), new SkillRequirement(Skill.MAGIC, 68), dreamMentor,
+			Collections.singletonList(refillWaterskin), new SkillRequirement(Skill.MAGIC, 68, true), dreamMentor,
 			lunarBook, fireRune.quantity(1), waterRune.quantity(3), astralRune.quantity(1), emptyWaterskin);
 		refillWaterskinsSteps.setDisplayCondition(notRefillWaterskin);
 		refillWaterskinsSteps.setLockingStep(refillWaterskinTask);
 		allSteps.add(refillWaterskinsSteps);
 
 		PanelDetails dustDevilSteps = new PanelDetails("Dust Devil", Arrays.asList(moveToSmoke, killDust),
-			new SkillRequirement(Skill.CRAFTING, 55), new SkillRequirement(Skill.DEFENCE, 10),
-			new SkillRequirement(Skill.SLAYER, 65), desertTreasure, combatGear, food, slayerHelm);
+			new SkillRequirement(Skill.CRAFTING, 55, true), new SkillRequirement(Skill.DEFENCE, 10, false),
+			new SkillRequirement(Skill.SLAYER, 65, true), desertTreasure, combatGear, food, slayerHelm);
 		dustDevilSteps.setDisplayCondition(notKillDust);
 		dustDevilSteps.setLockingStep(killDustTask);
 		allSteps.add(dustDevilSteps);
@@ -363,26 +363,26 @@ public class DesertHard extends ComplexStateQuestHelper
 		allSteps.add(ancientMagicksSteps);
 
 		PanelDetails mineGraniteSteps = new PanelDetails("Mine Granite", Collections.singletonList(granite),
-			new SkillRequirement(Skill.MINING, 45), pickaxe);
+			new SkillRequirement(Skill.MINING, 45, true), pickaxe);
 		mineGraniteSteps.setDisplayCondition(notGranite);
 		mineGraniteSteps.setLockingStep(graniteTask);
 		allSteps.add(mineGraniteSteps);
 
 		PanelDetails burnYewSteps = new PanelDetails("Burn Yew on Nardah Mayor's Balcony", Arrays.asList(moveToMayor,
-			burnYew), new SkillRequirement(Skill.FIREMAKING, 60), yewLog, tinderbox);
+			burnYew), new SkillRequirement(Skill.FIREMAKING, 60, true), yewLog, tinderbox);
 		burnYewSteps.setDisplayCondition(notBurnYew);
 		burnYewSteps.setLockingStep(burnYewTask);
 		allSteps.add(burnYewSteps);
 
 		PanelDetails mithrilPlatebodySteps = new PanelDetails("Mithril Platebody",
-			Collections.singletonList(mithPlatebody), new SkillRequirement(Skill.SMITHING, 68), mithBar.quantity(5),
+			Collections.singletonList(mithPlatebody), new SkillRequirement(Skill.SMITHING, 68, true), mithBar.quantity(5),
 			hammer);
 		mithrilPlatebodySteps.setDisplayCondition(notMithPlatebody);
 		mithrilPlatebodySteps.setLockingStep(mithPlatebodyTask);
 		allSteps.add(mithrilPlatebodySteps);
 
 		PanelDetails locusRiderSteps = new PanelDetails("Kill Locust Rider with Keris", Arrays.asList(moveToSoph,
-			killLocustRider), new SkillRequirement(Skill.ATTACK, 50), contact, keris, combatGear, lightsource, food);
+			killLocustRider), new SkillRequirement(Skill.ATTACK, 50, false), contact, keris, combatGear, lightsource, food);
 		locusRiderSteps.setDisplayCondition(notKillLocustRider);
 		locusRiderSteps.setLockingStep(killLocustRiderTask);
 		allSteps.add(locusRiderSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/desert/DesertMedium.java
@@ -284,13 +284,13 @@ public class DesertMedium extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 30));
-		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 20));
-		reqs.add(new SkillRequirement(Skill.HERBLORE, 36));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 47));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 22));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 25));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 35));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 30, true));
+		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 20, false));
+		reqs.add(new SkillRequirement(Skill.HERBLORE, 36, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 47, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 22, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 25, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 35, true));
 
 		reqs.add(theGolem);
 		reqs.add(eaglesPeak);
@@ -330,19 +330,19 @@ public class DesertMedium extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails combatPotionSteps = new PanelDetails("Combat Potion", Arrays.asList(moveToDesert, combatPot),
-			new SkillRequirement(Skill.HERBLORE, 36), harraPot, goatHornDust);
+			new SkillRequirement(Skill.HERBLORE, 36, true), harraPot, goatHornDust);
 		combatPotionSteps.setDisplayCondition(notCombatPot);
 		combatPotionSteps.setLockingStep(combatPotTask);
 		allSteps.add(combatPotionSteps);
 
 		PanelDetails phoenixFeatherSteps = new PanelDetails("Phoenix Feather",
-			Collections.singletonList(phoenixFeather), new SkillRequirement(Skill.THIEVING, 25));
+			Collections.singletonList(phoenixFeather), new SkillRequirement(Skill.THIEVING, 25, true));
 		phoenixFeatherSteps.setDisplayCondition(notPhoenixFeather);
 		phoenixFeatherSteps.setLockingStep(phoenixFeatherTask);
 		allSteps.add(phoenixFeatherSteps);
 
 		PanelDetails orangeSalamanderSteps = new PanelDetails("Orange Salamander",
-			Collections.singletonList(orangeSally), new SkillRequirement(Skill.HUNTER, 47), rope, smallFishingNet);
+			Collections.singletonList(orangeSally), new SkillRequirement(Skill.HUNTER, 47, true), rope, smallFishingNet);
 		orangeSalamanderSteps.setDisplayCondition(notOrangeSally);
 		orangeSalamanderSteps.setLockingStep(orangeSallyTask);
 		allSteps.add(orangeSalamanderSteps);
@@ -354,7 +354,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 		allSteps.add(magicCarpetSteps);
 
 		PanelDetails chopTeakAtUzerSteps = new PanelDetails("Chop Teak at Uzer", Collections.singletonList(chopTeak),
-			new SkillRequirement(Skill.WOODCUTTING, 35), axe);
+			new SkillRequirement(Skill.WOODCUTTING, 35, true), axe);
 		chopTeakAtUzerSteps.setDisplayCondition(notChopTeak);
 		chopTeakAtUzerSteps.setLockingStep(chopTeakTask);
 		allSteps.add(chopTeakAtUzerSteps);
@@ -378,7 +378,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 		allSteps.add(visitTheGenieSteps);
 
 		PanelDetails agilityPyramidSteps = new PanelDetails("Agility Pyramid", Arrays.asList(moveToPyramid,
-			talkToSimon, agiPyramid), new SkillRequirement(Skill.AGILITY, 30));
+			talkToSimon, agiPyramid), new SkillRequirement(Skill.AGILITY, 30, true));
 		agilityPyramidSteps.setDisplayCondition(notAgiPyramid);
 		agilityPyramidSteps.setLockingStep(agiPyramidTask);
 		allSteps.add(agilityPyramidSteps);
@@ -396,7 +396,7 @@ public class DesertMedium extends ComplexStateQuestHelper
 		allSteps.add(eagleSteps);
 
 		PanelDetails teleportToPollnivneachSteps = new PanelDetails("Pollnivneach House",
-			Collections.singletonList(tpPollnivneach), new SkillRequirement(Skill.CONSTRUCTION, 20), teleToHouse,
+			Collections.singletonList(tpPollnivneach), new SkillRequirement(Skill.CONSTRUCTION, 20, false), teleToHouse,
 			scrollOfRedir);
 		teleportToPollnivneachSteps.setDisplayCondition(notTPPollnivneach);
 		teleportToPollnivneachSteps.setLockingStep(tpPollnivneachTask);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142