### PR TITLE
fix: add missing boost information for Falador diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorEasy.java
@@ -304,7 +304,7 @@ public class FaladorEasy extends ComplexStateQuestHelper
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new SkillRequirement(Skill.AGILITY, 5, true));
-		req.add(new SkillRequirement(Skill.CONSTRUCTION, 16));
+		req.add(new SkillRequirement(Skill.CONSTRUCTION, 16, true));
 		req.add(new SkillRequirement(Skill.MINING, 10, true));
 		req.add(new SkillRequirement(Skill.SMITHING, 13, true));
 
@@ -394,7 +394,7 @@ public class FaladorEasy extends ComplexStateQuestHelper
 		allSteps.add(mindTiaraSteps);
 
 		PanelDetails familyCrestSteps = new PanelDetails("Family Crest", Arrays.asList(climbLadderWhiteKnightCastle,
-			discoverFamilyCrest), new SkillRequirement(Skill.CONSTRUCTION, 16));
+			discoverFamilyCrest), new SkillRequirement(Skill.CONSTRUCTION, 16, true));
 		familyCrestSteps.setDisplayCondition(notFamilyCrest);
 		familyCrestSteps.setLockingStep(familyCrestTask);
 		allSteps.add(familyCrestSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
@@ -328,10 +328,10 @@ public class FaladorHard extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.AGILITY, 50));
-		req.add(new SkillRequirement(Skill.DEFENCE, 50));
+		req.add(new SkillRequirement(Skill.AGILITY, 50, true));
+		req.add(new SkillRequirement(Skill.DEFENCE, 50, false));
 		req.add(new SkillRequirement(Skill.MINING, 60, true));
-		req.add(new SkillRequirement(Skill.PRAYER, 70));
+		req.add(new SkillRequirement(Skill.PRAYER, 70, false));
 		req.add(new ComplexRequirement(LogicType.OR, "56 Runecraft or 42 with Raiments of the Eye set",
 			new SkillRequirement(Skill.RUNECRAFT, 56, true, "56 Runecraft"),
 			new ItemRequirements("42 with Raiments of the Eye set",
@@ -375,7 +375,7 @@ public class FaladorHard extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails changeCrestSteps = new PanelDetails("To Saradomin!", Arrays.asList(climbLadderWhiteKnightCastle,
-			changeFamilyCrest), new SkillRequirement(Skill.PRAYER, 70), coins10000);
+			changeFamilyCrest), new SkillRequirement(Skill.PRAYER, 70, false), coins10000);
 		changeCrestSteps.setDisplayCondition(notChangedFamilyCrest);
 		changeCrestSteps.setLockingStep(changedFamilyCrestTask);
 		allSteps.add(changeCrestSteps);
@@ -387,13 +387,13 @@ public class FaladorHard extends ComplexStateQuestHelper
 		allSteps.add(moleSteps);
 
 		PanelDetails fallyRoofSteps = new PanelDetails("Make sure to stretch!",
-			Collections.singletonList(completeAgiCourse), new SkillRequirement(Skill.AGILITY, 50));
+			Collections.singletonList(completeAgiCourse), new SkillRequirement(Skill.AGILITY, 50, true));
 		fallyRoofSteps.setDisplayCondition(notCompleteAgiCourse);
 		fallyRoofSteps.setLockingStep(completeAgiCourseTask);
 		allSteps.add(fallyRoofSteps);
 
 		PanelDetails dwarvenHelmSteps = new PanelDetails("A snug fit", Arrays.asList(enterDwarvenMinesHelmet,
-			equipDwarvenHelmet), new SkillRequirement(Skill.DEFENCE, 50), dwarvenHelmet, grimTales);
+			equipDwarvenHelmet), new SkillRequirement(Skill.DEFENCE, 50, false), dwarvenHelmet, grimTales);
 		dwarvenHelmSteps.setDisplayCondition(notDwarvenHelmetDwarvenMines);
 		dwarvenHelmSteps.setLockingStep(dwarvenHelmetDwarvenMinesTask);
 		allSteps.add(dwarvenHelmSteps);
@@ -429,7 +429,7 @@ public class FaladorHard extends ComplexStateQuestHelper
 		allSteps.add(mindRunesSteps);
 
 		PanelDetails praySteps = new PanelDetails("Praise the Lord!", Arrays.asList(getProsySet, prayAtAltarSarim),
-			new SkillRequirement(Skill.DEFENCE, 30), slugMenace, prosyHelm, prosyChest, prosyLegs);
+			new SkillRequirement(Skill.DEFENCE, 30, false), slugMenace, prosyHelm, prosyChest, prosyLegs);
 		praySteps.setDisplayCondition(notPraySarimAltarProsy);
 		praySteps.setLockingStep(praySarimAltarProsyTask);
 		allSteps.add(praySteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
@@ -399,7 +399,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 
 		generalRequirements.add(new SkillRequirement(Skill.AGILITY, 42, true));
 		generalRequirements.add(new SkillRequirement(Skill.CRAFTING, 40, true));
-		generalRequirements.add(new SkillRequirement(Skill.DEFENCE, 20));
+		generalRequirements.add(new SkillRequirement(Skill.DEFENCE, 20, false));
 		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			// 47 Farming is required to get a Watermelon for the "Brain not included" step
@@ -416,10 +416,10 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		generalRequirements.add(new SkillRequirement(Skill.FIREMAKING, 49, true));
 		generalRequirements.add(new SkillRequirement(Skill.MAGIC, 37, true));
 		generalRequirements.add(new SkillRequirement(Skill.MINING, 40, true));
-		generalRequirements.add(new SkillRequirement(Skill.PRAYER, 10));
-		generalRequirements.add(new SkillRequirement(Skill.RANGED, 19));
-		generalRequirements.add(new SkillRequirement(Skill.SLAYER, 32));
-		generalRequirements.add(new SkillRequirement(Skill.STRENGTH, 37));
+		generalRequirements.add(new SkillRequirement(Skill.PRAYER, 10, false));
+		generalRequirements.add(new SkillRequirement(Skill.RANGED, 19, true));
+		generalRequirements.add(new SkillRequirement(Skill.SLAYER, 32, true));
+		generalRequirements.add(new SkillRequirement(Skill.STRENGTH, 37, true));
 		generalRequirements.add(new SkillRequirement(Skill.THIEVING, 40, true));
 		generalRequirements.add(new SkillRequirement(Skill.WOODCUTTING, 30, true));
 
@@ -498,7 +498,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		allSteps.add(lanternSteps);
 
 		PanelDetails mogreSteps = new PanelDetails("Mogres have layers", Arrays.asList(spawnMogre, killMogre),
-			skippyAndMogres, new SkillRequirement(Skill.SLAYER, 32), combatGear, fishingExplosive);
+			skippyAndMogres, new SkillRequirement(Skill.SLAYER, 32, true), combatGear, fishingExplosive);
 		mogreSteps.setDisplayCondition(notKilledMogre);
 		mogreSteps.setLockingStep(killedMogreTask);
 		allSteps.add(mogreSteps);
@@ -524,15 +524,15 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		allSteps.add(scarecrowSteps);
 
 		PanelDetails grappleSteps = new PanelDetails("To the window.. To the wall!",
-			Arrays.asList(grappleNorthWallStart, grappleNorthWallEnd), new SkillRequirement(Skill.AGILITY, 11),
-			new SkillRequirement(Skill.STRENGTH, 37), new SkillRequirement(Skill.RANGED, 19),
+			Arrays.asList(grappleNorthWallStart, grappleNorthWallEnd), new SkillRequirement(Skill.AGILITY, 11, true),
+			new SkillRequirement(Skill.STRENGTH, 37, true), new SkillRequirement(Skill.RANGED, 19, true),
 			mithGrapple, anyCrossbow);
 		grappleSteps.setDisplayCondition(notGrappleNorthWall);
 		grappleSteps.setLockingStep(grappleNorthWallTask);
 		allSteps.add(grappleSteps);
 
 		PanelDetails dwarfShortcutSteps = new PanelDetails("To Middle Earth", Arrays.asList(enterDwarvenMines,
-			dwarfShortcut), new SkillRequirement(Skill.AGILITY, 42));
+			dwarfShortcut), new SkillRequirement(Skill.AGILITY, 42, true));
 		dwarfShortcutSteps.setDisplayCondition(notDwarfShortcut);
 		dwarfShortcutSteps.setLockingStep(dwarfShortcutTask);
 		allSteps.add(dwarfShortcutSteps);
@@ -545,7 +545,7 @@ public class FaladorMedium extends ComplexStateQuestHelper
 		allSteps.add(teleFallySteps);
 
 		PanelDetails pickGuardSteps = new PanelDetails("Cor blimey mate!", Collections.singletonList(pickpocketGuard),
-			new SkillRequirement(Skill.THIEVING, 40));
+			new SkillRequirement(Skill.THIEVING, 40, true));
 		pickGuardSteps.setDisplayCondition(notPickpocketGuard);
 		pickGuardSteps.setLockingStep(pickpocketGuardTask);
 		allSteps.add(pickGuardSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142