### PR TITLE
fix: add missing boost information for Fremennik diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikEasy.java
@@ -298,13 +298,13 @@ public class FremennikEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.CRAFTING, 23));
-		req.add(new SkillRequirement(Skill.FIREMAKING, 15));
-		req.add(new SkillRequirement(Skill.HUNTER, 11));
-		req.add(new SkillRequirement(Skill.MINING, 20));
-		req.add(new SkillRequirement(Skill.SMITHING, 20));
-		req.add(new SkillRequirement(Skill.THIEVING, 5));
-		req.add(new SkillRequirement(Skill.WOODCUTTING, 15));
+		req.add(new SkillRequirement(Skill.CRAFTING, 23, true));
+		req.add(new SkillRequirement(Skill.FIREMAKING, 15, true));
+		req.add(new SkillRequirement(Skill.HUNTER, 11, true));
+		req.add(new SkillRequirement(Skill.MINING, 20, true));
+		req.add(new SkillRequirement(Skill.SMITHING, 20, true));
+		req.add(new SkillRequirement(Skill.THIEVING, 5, true));
+		req.add(new SkillRequirement(Skill.WOODCUTTING, 15, true));
 
 		req.add(fremennikTrials);
 		req.add(giantDwarf);
@@ -348,7 +348,7 @@ public class FremennikEasy extends ComplexStateQuestHelper
 		allSteps.add(rockCrabSteps);
 
 		PanelDetails oakSteps = new PanelDetails("Chop and burn", Arrays.asList(chopOak, burnOak),
-			new SkillRequirement(Skill.FIREMAKING, 15), new SkillRequirement(Skill.WOODCUTTING, 15),
+			new SkillRequirement(Skill.FIREMAKING, 15, true), new SkillRequirement(Skill.WOODCUTTING, 15, true),
 			axe, tinderbox);
 		oakSteps.setDisplayCondition(notChopAndBurnOak);
 		oakSteps.setLockingStep(chopAndBurnOakTask);
@@ -366,8 +366,8 @@ public class FremennikEasy extends ComplexStateQuestHelper
 		allSteps.add(changeBootsSteps);
 
 		PanelDetails tiaraSteps = new PanelDetails("Craft Tiara", Arrays.asList(mineSilver, smeltSilver, craftTiara),
-			new SkillRequirement(Skill.CRAFTING, 23), new SkillRequirement(Skill.MINING, 20),
-			new SkillRequirement(Skill.SMITHING, 20), fremennikTrials, pickaxe, tiaraMould);
+			new SkillRequirement(Skill.CRAFTING, 23, true), new SkillRequirement(Skill.MINING, 20, true),
+			new SkillRequirement(Skill.SMITHING, 20, true), fremennikTrials, pickaxe, tiaraMould);
 		tiaraSteps.setDisplayCondition(notCraftTiara);
 		tiaraSteps.setLockingStep(craftTiaraTask);
 		allSteps.add(tiaraSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikHard.java
@@ -281,7 +281,7 @@ public class FremennikHard extends ComplexStateQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new SkillRequirement(Skill.HERBLORE, 66, true));
 		req.add(new SkillRequirement(Skill.HUNTER, 55, true));
-		req.add(new SkillRequirement(Skill.MAGIC, 72));
+		req.add(new SkillRequirement(Skill.MAGIC, 72, true));
 		req.add(new SkillRequirement(Skill.MINING, 70, true));
 		req.add(new SkillRequirement(Skill.SMITHING, 60, false));
 		req.add(new SkillRequirement(Skill.THIEVING, 75, true));
@@ -369,13 +369,13 @@ public class FremennikHard extends ComplexStateQuestHelper
 		allSteps.add(freeBlastFurnaceSteps);
 
 		PanelDetails teleportToTrollheimSteps = new PanelDetails("Teleport to Trollheim", Collections.singletonList(tpTroll),
-			eadgarsRuse, new SkillRequirement(Skill.MAGIC, 61), normalBook, fireRune.quantity(2), lawRune.quantity(2));
+			eadgarsRuse, new SkillRequirement(Skill.MAGIC, 61, true), normalBook, fireRune.quantity(2), lawRune.quantity(2));
 		teleportToTrollheimSteps.setDisplayCondition(notTPTroll);
 		teleportToTrollheimSteps.setLockingStep(tpTrollTask);
 		allSteps.add(teleportToTrollheimSteps);
 
 		PanelDetails teleportToWaterbirthSteps = new PanelDetails("Teleport to Waterbirth", Collections.singletonList(tpWaterbirth),
-			lunarDiplomacy, new SkillRequirement(Skill.MAGIC, 72), lunarBook, waterRune.quantity(1), astralRune.quantity(2), lawRune2.quantity(1));
+			lunarDiplomacy, new SkillRequirement(Skill.MAGIC, 72, true), lunarBook, waterRune.quantity(1), astralRune.quantity(2), lawRune2.quantity(1));
 		teleportToWaterbirthSteps.setDisplayCondition(notTPWaterbirth);
 		teleportToWaterbirthSteps.setLockingStep(tpWaterbirthTask);
 		allSteps.add(teleportToWaterbirthSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikMedium.java
@@ -418,7 +418,7 @@ public class FremennikMedium extends ComplexStateQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new SkillRequirement(Skill.CONSTRUCTION, 37, true));
 		req.add(new SkillRequirement(Skill.HUNTER, 35, true));
-		req.add(new SkillRequirement(Skill.MINING, 40));
+		req.add(new SkillRequirement(Skill.MINING, 40, true));
 		req.add(new SkillRequirement(Skill.SLAYER, 47, true));
 		req.add(new SkillRequirement(Skill.THIEVING, 42, true));
 		req.add(new SkillRequirement(Skill.PRAYER, 43, false,
@@ -480,14 +480,14 @@ public class FremennikMedium extends ComplexStateQuestHelper
 		allSteps.add(snowyKnightSteps);
 
 		PanelDetails mineGoldSteps = new PanelDetails("Mine Gold", Arrays.asList(moveToCave, moveToRiver, moveToCannon,
-			moveToArzinian, mineGold), betweenARock, new SkillRequirement(Skill.MINING, 40), pickaxe, goldHelm,
+			moveToArzinian, mineGold), betweenARock, new SkillRequirement(Skill.MINING, 40, true), pickaxe, goldHelm,
 			coins.quantity(2));
 		mineGoldSteps.setDisplayCondition(notMineGold);
 		mineGoldSteps.setLockingStep(mineGoldTask);
 		allSteps.add(mineGoldSteps);
 
 		PanelDetails mineCoalSteps = new PanelDetails("Mine Coal", Collections.singletonList(mineCoal),
-			fremennikTrials, new SkillRequirement(Skill.MINING, 30), pickaxe);
+			fremennikTrials, new SkillRequirement(Skill.MINING, 30, true), pickaxe);
 		mineCoalSteps.setDisplayCondition(notMineCoal);
 		mineCoalSteps.setLockingStep(mineCoalTask);
 		allSteps.add(mineCoalSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142