### PR TITLE
fix: add missing boost information for Morytania diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaEasy.java
@@ -284,10 +284,20 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new CombatLevelRequirement(20));
-		reqs.add(new SkillRequirement(Skill.COOKING, 12));
-		reqs.add(new SkillRequirement(Skill.CRAFTING, 15));
-		reqs.add(new SkillRequirement(Skill.FARMING, 23));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 15));
+		reqs.add(new SkillRequirement(Skill.COOKING, 12, true));
+		reqs.add(new SkillRequirement(Skill.CRAFTING, 15, true));
+		reqs.add(new SkillRequirement(Skill.FARMING, 23, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 15, true));
+
+		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
+		{
+			// 47 Farming is required to get a Watermelon for the scarecrow step
+			reqs.add(new SkillRequirement(Skill.FARMING, 47, true));
+		}
+		else
+		{
+			reqs.add(new SkillRequirement(Skill.FARMING, 23, true));
+		}
 
 		reqs.add(ghostsAhoy);
 		reqs.add(natureSpirit);
@@ -337,7 +347,7 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		allSteps.add(enterSwampSteps);
 
 		PanelDetails craftSnelmSteps = new PanelDetails("Craft Snelm", Collections.singletonList(craftSnelm),
-			new SkillRequirement(Skill.CRAFTING, 15), snailShell, chisel);
+			new SkillRequirement(Skill.CRAFTING, 15, true), snailShell, chisel);
 		craftSnelmSteps.setDisplayCondition(notCraftSnelm);
 		craftSnelmSteps.setLockingStep(craftSnelmTask);
 		allSteps.add(craftSnelmSteps);
@@ -349,7 +359,7 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		allSteps.add(restorePrayerSteps);
 
 		PanelDetails killBansheeSteps = new PanelDetails("Kill Banshee", Collections.singletonList(killBanshee),
-			new SkillRequirement(Skill.SLAYER, 15), combatGear, food, earProtection);
+			new SkillRequirement(Skill.SLAYER, 15, true), combatGear, food, earProtection);
 		killBansheeSteps.setDisplayCondition(notKillBanshee);
 		killBansheeSteps.setLockingStep(killBansheeTask);
 		allSteps.add(killBansheeSteps);
@@ -373,7 +383,7 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		allSteps.add(mazchnaSteps);
 
 		PanelDetails placeScarecrowSteps = new PanelDetails("Place Scarecrow", Arrays.asList(fillSack, useSackOnSpear,
-			useWatermelonOnSack, placeScarecrow), new SkillRequirement(Skill.FARMING, 23), scarecrowItems, rake);
+			useWatermelonOnSack, placeScarecrow), new SkillRequirement(Skill.FARMING, 23, true), scarecrowItems, rake);
 		placeScarecrowSteps.setDisplayCondition(notPlaceScarecrow);
 		placeScarecrowSteps.setLockingStep(placeScarecrowTask);
 		allSteps.add(placeScarecrowSteps);
@@ -385,7 +395,7 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		allSteps.add(offerBonemealSteps);
 
 		PanelDetails cookSnailSteps = new PanelDetails("Cook Thin Snail", Collections.singletonList(cookSnail),
-			new SkillRequirement(Skill.COOKING, 12), thinSnail);
+			new SkillRequirement(Skill.COOKING, 12, true), thinSnail);
 		cookSnailSteps.setDisplayCondition(notCookSnail);
 		cookSnailSteps.setLockingStep(cookSnailTask);
 		allSteps.add(cookSnailSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaElite.java
@@ -29,6 +29,7 @@ import com.questhelper.collections.ItemCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.ComplexStateQuestHelper;
 import com.questhelper.questinfo.QuestHelperQuest;
+import com.questhelper.requirements.ComplexRequirement;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
@@ -260,15 +261,16 @@ public class MorytaniaElite extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.ATTACK, 70));
+		reqs.add(new ComplexRequirement(LogicType.OR, "70 Attack or Ranged",
+			new SkillRequirement(Skill.ATTACK, 70, false),
+			new SkillRequirement(Skill.RANGED, 70, false)));
 		reqs.add(new SkillRequirement(Skill.CRAFTING, 84, true));
-		reqs.add(new SkillRequirement(Skill.DEFENCE, 70));
+		reqs.add(new SkillRequirement(Skill.DEFENCE, 70, false));
 		reqs.add(new SkillRequirement(Skill.FIREMAKING, 80, true));
 		reqs.add(new SkillRequirement(Skill.FISHING, 96, true));
 		reqs.add(new SkillRequirement(Skill.MAGIC, 83, true));
-		reqs.add(new SkillRequirement(Skill.RANGED, 70));
 		reqs.add(new SkillRequirement(Skill.SLAYER, 85, true));
-		reqs.add(new SkillRequirement(Skill.STRENGTH, 76));
+		reqs.add(new SkillRequirement(Skill.STRENGTH, 76, true));
 
 		reqs.add(inAidOfTheMyreque);
 		reqs.add(shadesOfMorton);
@@ -312,22 +314,22 @@ public class MorytaniaElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails grabSharkSteps = new PanelDetails("Grab Shark", Collections.singletonList(bareHandShark),
-			new SkillRequirement(Skill.FISHING, 96, true), new SkillRequirement(Skill.STRENGTH, 76),
+			new SkillRequirement(Skill.FISHING, 96, true), new SkillRequirement(Skill.STRENGTH, 76, true),
 			inAidOfTheMyreque, bareHandBarb);
 		grabSharkSteps.setDisplayCondition(notBareHandShark);
 		grabSharkSteps.setLockingStep(bareHandSharkTask);
 		allSteps.add(grabSharkSteps);
 
 		PanelDetails cremateSteps = new PanelDetails("Cremate Shade Remains", Collections.singletonList(cremateShade),
-			new SkillRequirement(Skill.FIREMAKING, 80), shadesOfMorton, magicRedwoodPyreLogs, shadeRemains, tinderbox);
+			new SkillRequirement(Skill.FIREMAKING, 80, true), shadesOfMorton, magicRedwoodPyreLogs, shadeRemains, tinderbox);
 		cremateSteps.setDisplayCondition(notCremateShade);
 		cremateSteps.setLockingStep(cremateShadeTask);
 		allSteps.add(cremateSteps);
 
 		PanelDetails barrowsSteps = new PanelDetails("Barrows Looting", Arrays.asList(moveToBarrows,
 			barrowsChest), new SkillRequirement(Skill.DEFENCE, 70, false, "70 Defense and one of the following:"),
-			new SkillRequirement(Skill.ATTACK, 70), new SkillRequirement(Skill.MAGIC, 70),
-			new SkillRequirement(Skill.RANGED, 70), new SkillRequirement(Skill.STRENGTH, 70), barrowsSet);
+			new SkillRequirement(Skill.ATTACK, 70, false), new SkillRequirement(Skill.MAGIC, 70, false),
+			new SkillRequirement(Skill.RANGED, 70, false), new SkillRequirement(Skill.STRENGTH, 70, false), barrowsSet);
 		barrowsSteps.setDisplayCondition(notBarrowsChest);
 		barrowsSteps.setLockingStep(barrowsChestTask);
 		allSteps.add(barrowsSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaHard.java
@@ -332,15 +332,15 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new SkillRequirement(Skill.AGILITY, 71, true));
-		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50));
+		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50, true));
 		reqs.add(new SkillRequirement(Skill.DEFENCE, 70, false));
 		reqs.add(new SkillRequirement(Skill.FARMING, 53, true));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 50));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 50, true));
 		reqs.add(new SkillRequirement(Skill.MAGIC, 66, true));
 		reqs.add(new SkillRequirement(Skill.MINING, 55, true));
 		reqs.add(new SkillRequirement(Skill.PRAYER, 70, false));
 		reqs.add(new SkillRequirement(Skill.SLAYER, 58, true));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 50));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 50, true));
 
 		reqs.add(cabinFever);
 		reqs.add(desertTreasure);
@@ -408,8 +408,8 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 		allSteps.add(mithSteps);
 
 		PanelDetails pietySteps = new PanelDetails("Nature Grotto Piety", Arrays.asList(moveToGrotto, pietyAltar),
-			natureSpirit, kingsRansom, knightWaves, new SkillRequirement(Skill.PRAYER, 70),
-			new SkillRequirement(Skill.DEFENCE, 70));
+			natureSpirit, kingsRansom, knightWaves, new SkillRequirement(Skill.PRAYER, 70, false),
+			new SkillRequirement(Skill.DEFENCE, 70, false));
 		pietySteps.setDisplayCondition(notPietyAltar);
 		pietySteps.setLockingStep(pietyAltarTask);
 		allSteps.add(pietySteps);
@@ -420,7 +420,7 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 		allSteps.add(hardSteps);
 
 		PanelDetails salveSteps = new PanelDetails("Shortcut Over the Salve", Collections.singletonList(bridgeSalve),
-			new SkillRequirement(Skill.AGILITY, 65));
+			new SkillRequirement(Skill.AGILITY, 65, true));
 		salveSteps.setDisplayCondition(notBridgeSalve);
 		salveSteps.setLockingStep(bridgeSalveTask);
 		allSteps.add(salveSteps);
@@ -439,15 +439,15 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 		allSteps.add(caveHorrorSteps);
 
 		PanelDetails mahoSteps = new PanelDetails("Chop and Burn Mahogany", Arrays.asList(moveToCaptMaho, moveToMosMaho,
-			moveToCaveMaho, moveToIsland, chopMaho, burnMaho), new SkillRequirement(Skill.FIREMAKING, 50),
-			new SkillRequirement(Skill.WOODCUTTING, 50),
+			moveToCaveMaho, moveToIsland, chopMaho, burnMaho), new SkillRequirement(Skill.FIREMAKING, 50, true),
+			new SkillRequirement(Skill.WOODCUTTING, 50, true),
 			axe, tinderbox, witchwoodIcon.equipped(), lightSource);
 		mahoSteps.setDisplayCondition(notBurnMaho);
 		mahoSteps.setLockingStep(burnMahoTask);
 		allSteps.add(mahoSteps);
 
 		PanelDetails kharyllSteps = new PanelDetails("Kharyrll Portal", Collections.singletonList(kharyrll),
-			new SkillRequirement(Skill.MAGIC, 66), new SkillRequirement(Skill.CONSTRUCTION, 50),
+			new SkillRequirement(Skill.MAGIC, 66, true), new SkillRequirement(Skill.CONSTRUCTION, 50, true),
 			desertTreasure, coins.quantity(100000), limestoneBrick.quantity(2), hammer, saw, teakPlank.quantity(3),
 			lawRune.quantity(200), bloodRune.quantity(100));
 		kharyllSteps.setDisplayCondition(notKharyrll);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaMedium.java
@@ -339,13 +339,13 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 40));
-		reqs.add(new SkillRequirement(Skill.COOKING, 40));
-		reqs.add(new SkillRequirement(Skill.HERBLORE, 22));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 29));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 42));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 35));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 45));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 40, true));
+		reqs.add(new SkillRequirement(Skill.COOKING, 40, false));
+		reqs.add(new SkillRequirement(Skill.HERBLORE, 22, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 29, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 42, true));
+		reqs.add(new SkillRequirement(Skill.SMITHING, 35, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 45, true));
 
 		reqs.add(dwarfCannon);
 		reqs.add(ghostsAhoy);
@@ -400,13 +400,13 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 		allSteps.add(terrorDogSteps);
 
 		PanelDetails canifisSteps = new PanelDetails("Canifis Rooftop Course", Collections.singletonList(canifisAgi),
-			new SkillRequirement(Skill.AGILITY, 40));
+			new SkillRequirement(Skill.AGILITY, 40, true));
 		canifisSteps.setDisplayCondition(notCanifisAgi);
 		canifisSteps.setLockingStep(canifisAgiTask);
 		allSteps.add(canifisSteps);
 
 		PanelDetails swampLizardSteps = new PanelDetails("Swamp Lizard", Collections.singletonList(swampLizard),
-			new SkillRequirement(Skill.HUNTER, 29), rope, smallFishingNet);
+			new SkillRequirement(Skill.HUNTER, 29, true), rope, smallFishingNet);
 		swampLizardSteps.setDisplayCondition(notSwampLizard);
 		swampLizardSteps.setLockingStep(swampLizardTask);
 		allSteps.add(swampLizardSteps);
@@ -418,19 +418,19 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 		allSteps.add(ectophialSteps);
 
 		PanelDetails cannonballsSteps = new PanelDetails("Cannonballs", Collections.singletonList(cannonBall),
-			new SkillRequirement(Skill.SMITHING, 35), dwarfCannon, ammoMould, steelBar);
+			new SkillRequirement(Skill.SMITHING, 35, true), dwarfCannon, ammoMould, steelBar);
 		cannonballsSteps.setDisplayCondition(notCannonBall);
 		cannonballsSteps.setLockingStep(cannonBallTask);
 		allSteps.add(cannonballsSteps);
 
 		PanelDetails guthSteps = new PanelDetails("Guthix Balance", Collections.singletonList(guthBalance),
-			new SkillRequirement(Skill.HERBLORE, 22), inAidOfMyreque, restorePot, garlic, silverDust);
+			new SkillRequirement(Skill.HERBLORE, 22, true), inAidOfMyreque, restorePot, garlic, silverDust);
 		guthSteps.setDisplayCondition(notGuthBalance);
 		guthSteps.setLockingStep(guthBalanceTask);
 		allSteps.add(guthSteps);
 
 		PanelDetails hollowSteps = new PanelDetails("Hollow Tree", Collections.singletonList(hollowTree),
-			new SkillRequirement(Skill.WOODCUTTING, 45), axe);
+			new SkillRequirement(Skill.WOODCUTTING, 45, true), axe);
 		hollowSteps.setDisplayCondition(notHollowTree);
 		hollowSteps.setLockingStep(hollowTreeTask);
 		allSteps.add(hollowSteps);
@@ -443,13 +443,13 @@ public class MorytaniaMedium extends ComplexStateQuestHelper
 
 		PanelDetails feverSteps = new PanelDetails("Fever Spider", Arrays.asList(moveToBrainDeath,
 			moveToDownstairs, feverSpider),
-			new SkillRequirement(Skill.SLAYER, 42), rumDeal, slayerGloves);
+			new SkillRequirement(Skill.SLAYER, 42, true), rumDeal, slayerGloves);
 		feverSteps.setDisplayCondition(notFeverSpider);
 		feverSteps.setLockingStep(feverSpiderTask);
 		allSteps.add(feverSteps);
 
 		PanelDetails troubleSteps = new PanelDetails("Trouble Brewing", Arrays.asList(moveToCapt, moveToMos, troubleBrewing),
-			new SkillRequirement(Skill.COOKING, 40), cabinFever);
+			new SkillRequirement(Skill.COOKING, 40, false), cabinFever);
 		troubleSteps.setDisplayCondition(notTroubleBrewing);
 		troubleSteps.setLockingStep(troubleBrewingTask);
 		allSteps.add(troubleSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142