### PR TITLE
fix: add missing boost information for Lumbridge diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
@@ -292,13 +292,13 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 10));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 15));
-		reqs.add(new SkillRequirement(Skill.FISHING, 15));
-		reqs.add(new SkillRequirement(Skill.MINING, 15));
-		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 5));
-		reqs.add(new SkillRequirement(Skill.SLAYER, 7));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 15));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 10, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 15, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 15, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 15, true));
+		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 5, true));
+		reqs.add(new SkillRequirement(Skill.SLAYER, 7, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 15, true));
 
 		reqs.add(runeMysteries);
 		reqs.add(cooksAssistant);
@@ -336,7 +336,7 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails draynorRooftopsSteps = new PanelDetails("Draynor Rooftops", Collections.singletonList(drayAgi),
-			new SkillRequirement(Skill.AGILITY, 10));
+			new SkillRequirement(Skill.AGILITY, 10, true));
 		draynorRooftopsSteps.setDisplayCondition(notDrayAgi);
 		draynorRooftopsSteps.setLockingStep(drayAgiTask);
 		allSteps.add(draynorRooftopsSteps);
@@ -359,13 +359,13 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		allSteps.add(enterTheHamHideoutSteps);
 
 		PanelDetails killCaveBugSteps = new PanelDetails("Kill Cave Bug", Arrays.asList(addRopeToHole, killCaveBug),
-			new SkillRequirement(Skill.SLAYER, 7), lightSource, rope, spinyHelm);
+			new SkillRequirement(Skill.SLAYER, 7, true), lightSource, rope, spinyHelm);
 		killCaveBugSteps.setDisplayCondition(notKillCaveBug);
 		killCaveBugSteps.setLockingStep(killCaveBugTask);
 		allSteps.add(killCaveBugSteps);
 
 		PanelDetails waterRunesSteps = new PanelDetails("Craft Water Runes", Arrays.asList(moveToWaterAltar, waterRune),
-			new SkillRequirement(Skill.RUNECRAFT, 5), waterAccessOrAbyss, runeEss);
+			new SkillRequirement(Skill.RUNECRAFT, 5, true), waterAccessOrAbyss, runeEss);
 		waterRunesSteps.setDisplayCondition(notWaterRune);
 		waterRunesSteps.setLockingStep(waterRuneTask);
 		allSteps.add(waterRunesSteps);
@@ -387,19 +387,19 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		allSteps.add(pickpocketSteps);
 
 		PanelDetails oakSteps = new PanelDetails("Chop and Burn Oak Logs", Arrays.asList(chopOak, burnOak),
-			new SkillRequirement(Skill.WOODCUTTING, 15), new SkillRequirement(Skill.FIREMAKING, 15), tinderbox, axe);
+			new SkillRequirement(Skill.WOODCUTTING, 15, true), new SkillRequirement(Skill.FIREMAKING, 15, true), tinderbox, axe);
 		oakSteps.setDisplayCondition(notOak);
 		oakSteps.setLockingStep(oakTask);
 		allSteps.add(oakSteps);
 
 		PanelDetails mineIronSteps = new PanelDetails("Mine Iron in Al-Kharid", Collections.singletonList(mineIron),
-			new SkillRequirement(Skill.MINING, 15), pickaxe);
+			new SkillRequirement(Skill.MINING, 15, true), pickaxe);
 		mineIronSteps.setDisplayCondition(notIron);
 		mineIronSteps.setLockingStep(ironTask);
 		allSteps.add(mineIronSteps);
 
 		PanelDetails anchoviesSteps = new PanelDetails("Fish Anchovies in Al-Kharid",
-			Collections.singletonList(fishAnchovies), new SkillRequirement(Skill.FISHING, 15), smallFishingNet);
+			Collections.singletonList(fishAnchovies), new SkillRequirement(Skill.FISHING, 15, true), smallFishingNet);
 		anchoviesSteps.setDisplayCondition(notFishAnchovies);
 		anchoviesSteps.setLockingStep(fishAnchoviesTask);
 		allSteps.add(anchoviesSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -242,8 +242,8 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 70));
-		reqs.add(new SkillRequirement(Skill.RANGED, 70));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 70, true));
+		reqs.add(new SkillRequirement(Skill.RANGED, 70, true));
 		reqs.add(new ComplexRequirement(LogicType.OR, "76 Runecraft or 57 with Raiments of the Eye set",
 			new SkillRequirement(Skill.RUNECRAFT, 76, true, "76 Runecraft"),
 			new ItemRequirements("57 with Raiments of the Eye set",
@@ -253,9 +253,9 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 				new ItemRequirement("Boot", ItemID.BOOTS_OF_THE_EYE)).alsoCheckBank(questBank)
 		));
 		reqs.add(new SkillRequirement(Skill.SMITHING, 88, true));
-		reqs.add(new SkillRequirement(Skill.STRENGTH, 70));
+		reqs.add(new SkillRequirement(Skill.STRENGTH, 70, true));
 		reqs.add(new SkillRequirement(Skill.THIEVING, 78, true));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 75));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 75, true));
 
 		reqs.add(allQuests);
 
@@ -309,21 +309,21 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		allSteps.add(richChestSteps);
 
 		PanelDetails movarioSteps = new PanelDetails("Movario", Arrays.asList(moveToUndergroundMovario, moveToDorgMovario,
-			dorgStairsMovario, moveToDorgAgi, movario), new SkillRequirement(Skill.THIEVING, 42),
-			new SkillRequirement(Skill.AGILITY, 70), new SkillRequirement(Skill.RANGED, 70),
-			new SkillRequirement(Skill.STRENGTH, 70), deathToDorg, templeOfIkov, mithgrap, crossbow, lightsource);
+			dorgStairsMovario, moveToDorgAgi, movario), new SkillRequirement(Skill.THIEVING, 42, true),
+			new SkillRequirement(Skill.AGILITY, 70, true), new SkillRequirement(Skill.RANGED, 70, true),
+			new SkillRequirement(Skill.STRENGTH, 70, true), deathToDorg, templeOfIkov, mithgrap, crossbow, lightsource);
 		movarioSteps.setDisplayCondition(notMovario);
 		movarioSteps.setLockingStep(movarioTask);
 		allSteps.add(movarioSteps);
 
 		PanelDetails waterRunesSteps = new PanelDetails("140 Water Runes", Arrays.asList(moveToWater, waterRunes),
-			new SkillRequirement(Skill.RUNECRAFT, 76), essence.quantity(28), waterAccessOrAbyss);
+			new SkillRequirement(Skill.RUNECRAFT, 76, true), essence.quantity(28), waterAccessOrAbyss);
 		waterRunesSteps.setDisplayCondition(notWaterRunes);
 		waterRunesSteps.setLockingStep(waterRunesTask);
 		allSteps.add(waterRunesSteps);
 
 		PanelDetails chopMagicsSteps = new PanelDetails("Chop Magics", Collections.singletonList(chopMagic),
-			new SkillRequirement(Skill.WOODCUTTING, 75), axe);
+			new SkillRequirement(Skill.WOODCUTTING, 75, true), axe);
 		chopMagicsSteps.setDisplayCondition(notChopMagic);
 		chopMagicsSteps.setLockingStep(chopMagicTask);
 		allSteps.add(chopMagicsSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -338,14 +338,14 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 46));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 46, true));
 		reqs.add(new SkillRequirement(Skill.CRAFTING, 70, true));
-		reqs.add(new SkillRequirement(Skill.FARMING, 63));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 65));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 60));
-		reqs.add(new SkillRequirement(Skill.PRAYER, 52));
+		reqs.add(new SkillRequirement(Skill.FARMING, 63, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 65, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 60, true));
+		reqs.add(new SkillRequirement(Skill.PRAYER, 52, false));
 		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 59, true));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 57));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 57, true));
 
 		reqs.add(tearOfGuth);
 		reqs.add(anotherSliceOfHAM);
@@ -387,35 +387,35 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		allSteps.add(belladonnaSteps);
 
 		PanelDetails smiteAltarSteps = new PanelDetails("Smite Altar", Collections.singletonList(smiteAltar),
-			new SkillRequirement(Skill.PRAYER, 52));
+			new SkillRequirement(Skill.PRAYER, 52, false));
 		smiteAltarSteps.setDisplayCondition(notSmiteAltar);
 		smiteAltarSteps.setLockingStep(smiteAltarTask);
 		allSteps.add(smiteAltarSteps);
 
 		PanelDetails peachesPalaceSteps = new PanelDetails("Bones to Peaches Palace",
 			Arrays.asList(unlockBonesToPeaches, moveToPalace, bonesToPeachesPalace),
-			new SkillRequirement(Skill.MAGIC, 60), bonesToPeaches, bones, earthRune.quantity(4),
+			new SkillRequirement(Skill.MAGIC, 60, true), bonesToPeaches, bones, earthRune.quantity(4),
 			waterRune, natureRune);
 		peachesPalaceSteps.setDisplayCondition(notBonesToPeachesPalace);
 		peachesPalaceSteps.setLockingStep(bonesToPeachesPalaceTask);
 		allSteps.add(peachesPalaceSteps);
 
 		PanelDetails wakaToEdgevilleSteps = new PanelDetails("Waka to Edgeville",
-			Collections.singletonList(wakaToEdge), new SkillRequirement(Skill.WOODCUTTING, 57), axe);
+			Collections.singletonList(wakaToEdge), new SkillRequirement(Skill.WOODCUTTING, 57, true), axe);
 		wakaToEdgevilleSteps.setDisplayCondition(notWakaToEdge);
 		wakaToEdgevilleSteps.setLockingStep(wakaToEdgeTask);
 		allSteps.add(wakaToEdgevilleSteps);
 
 		PanelDetails powerAmuletSteps = new PanelDetails("Power Amulet", Arrays.asList(moveToLumby, smeltAmmy,
 			stringAmmy, powerAmmy), new SkillRequirement(Skill.CRAFTING, 70, true),
-			new SkillRequirement(Skill.MAGIC, 57), goldBar, cutDiamond, amuletMould, ballOfWool,
+			new SkillRequirement(Skill.MAGIC, 57, true), goldBar, cutDiamond, amuletMould, ballOfWool,
 			cosmicRune.quantity(1), earthRune.quantity(10));
 		powerAmuletSteps.setDisplayCondition(notPowerAmmy);
 		powerAmuletSteps.setLockingStep(powerAmmyTask);
 		allSteps.add(powerAmuletSteps);
 
 		PanelDetails miningHelmetSteps = new PanelDetails("Mining Helmet", Arrays.asList(moveToBasementForHelm,
-			lightMiningHelm), new SkillRequirement(Skill.FIREMAKING, 65), miningHelm, tinderbox);
+			lightMiningHelm), new SkillRequirement(Skill.FIREMAKING, 65, true), miningHelm, tinderbox);
 		miningHelmetSteps.setDisplayCondition(notLightMiningHelm);
 		miningHelmetSteps.setLockingStep(lightMiningHelmTask);
 		allSteps.add(miningHelmetSteps);
@@ -439,7 +439,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		allSteps.add(dorgeshTrainSteps);
 
 		PanelDetails juttingWallSteps = new PanelDetails("Jutting Wall", Arrays.asList(moveToZanarisForWall, juttingWall),
-			new SkillRequirement(Skill.AGILITY, 46), lostCity, fairyAccess);
+			new SkillRequirement(Skill.AGILITY, 46, true), lostCity, fairyAccess);
 		juttingWallSteps.setDisplayCondition(notJuttingWall);
 		juttingWallSteps.setLockingStep(juttingWallTask);
 		allSteps.add(juttingWallSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
@@ -277,16 +277,16 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new CombatLevelRequirement(70));
-		reqs.add(new SkillRequirement(Skill.AGILITY, 20));
-		reqs.add(new SkillRequirement(Skill.CRAFTING, 38));
-		reqs.add(new SkillRequirement(Skill.FISHING, 30));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 42));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 31));
-		reqs.add(new SkillRequirement(Skill.RANGED, 50));
-		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 23));
-		reqs.add(new SkillRequirement(Skill.STRENGTH, 19));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 38));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 30));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 20, true));
+		reqs.add(new SkillRequirement(Skill.CRAFTING, 38, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 30, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 42, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 31, true));
+		reqs.add(new SkillRequirement(Skill.RANGED, 50, false));
+		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 23, true));
+		reqs.add(new SkillRequirement(Skill.STRENGTH, 19, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 38, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 30, true));
 
 		reqs.add(fairyTaleII);
 		reqs.add(animalMagnetism);
@@ -324,7 +324,7 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		allSteps.add(chaeldarSteps);
 
 		PanelDetails puroImpSteps = new PanelDetails("Catch Essence or Eclectic Imp", Arrays.asList(moveToZanarisPuro,
-			moveToPuro, puroImp), new SkillRequirement(Skill.HUNTER, 42), lostCity, fairyAccess, butterflyNet, implingJar);
+			moveToPuro, puroImp), new SkillRequirement(Skill.HUNTER, 42, true), lostCity, fairyAccess, butterflyNet, implingJar);
 		puroImpSteps.setDisplayCondition(notPuroImp);
 		puroImpSteps.setLockingStep(puroImpTask);
 		allSteps.add(puroImpSteps);
@@ -336,19 +336,19 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		allSteps.add(wizardsTowerSteps);
 
 		PanelDetails chopWillowSteps = new PanelDetails("Chop Willow", Collections.singletonList(chopWillow),
-			new SkillRequirement(Skill.WOODCUTTING, 30), axe);
+			new SkillRequirement(Skill.WOODCUTTING, 30, true), axe);
 		chopWillowSteps.setDisplayCondition(notChopWillow);
 		chopWillowSteps.setLockingStep(chopWillowTask);
 		allSteps.add(chopWillowSteps);
 
 		PanelDetails pickpocketMasterGardenerSteps = new PanelDetails("Pickpocket Master Gardener",
-			Collections.singletonList(pickGardener), new SkillRequirement(Skill.THIEVING, 38));
+			Collections.singletonList(pickGardener), new SkillRequirement(Skill.THIEVING, 38, true));
 		pickpocketMasterGardenerSteps.setDisplayCondition(notPickGardener);
 		pickpocketMasterGardenerSteps.setLockingStep(pickGardenerTask);
 		allSteps.add(pickpocketMasterGardenerSteps);
 
 		PanelDetails upgradeSteps = new PanelDetails("Ava's Accumulator", Collections.singletonList(upgradeDevice),
-			new SkillRequirement(Skill.RANGED, 50), animalMagnetism, avasAccumulator, steelArrows.quantity(75));
+			new SkillRequirement(Skill.RANGED, 50, false), animalMagnetism, avasAccumulator, steelArrows.quantity(75));
 		upgradeSteps.setDisplayCondition(notUpgradeDevice);
 		upgradeSteps.setLockingStep(upgradeDeviceTask);
 		allSteps.add(upgradeSteps);
@@ -360,33 +360,33 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		allSteps.add(tpLumbSteps);
 
 		PanelDetails catchSalmonSteps = new PanelDetails("Catch Salmon", Collections.singletonList(catchSalmon),
-			new SkillRequirement(Skill.FISHING, 30), feathers, flyFishingRod);
+			new SkillRequirement(Skill.FISHING, 30, true), feathers, flyFishingRod);
 		catchSalmonSteps.setDisplayCondition(notCatchSalmon);
 		catchSalmonSteps.setLockingStep(catchSalmonTask);
 		allSteps.add(catchSalmonSteps);
 
 		PanelDetails craftACoifSteps = new PanelDetails("Craft a coif in the cow pen", Arrays.asList(moveToCowPen, craftCoif),
-			new SkillRequirement(Skill.CRAFTING, 38), leather, needle, thread);
+			new SkillRequirement(Skill.CRAFTING, 38, true), leather, needle, thread);
 		craftACoifSteps.setDisplayCondition(notCraftCoif);
 		craftACoifSteps.setLockingStep(craftCoifTask);
 		allSteps.add(craftACoifSteps);
 
 		PanelDetails alKharidRooftopCourseSteps = new PanelDetails("Al Kharid Rooftop Course",
-			Collections.singletonList(alKharidRooftop), new SkillRequirement(Skill.AGILITY, 20));
+			Collections.singletonList(alKharidRooftop), new SkillRequirement(Skill.AGILITY, 20, true));
 		alKharidRooftopCourseSteps.setDisplayCondition(notAlKharidRooftop);
 		alKharidRooftopCourseSteps.setLockingStep(alKharidRooftopTask);
 		allSteps.add(alKharidRooftopCourseSteps);
 
 		PanelDetails grappleRiverLumSteps = new PanelDetails("Grapple River Lum",
-			Collections.singletonList(grappleLum), new SkillRequirement(Skill.AGILITY, 8),
-			new SkillRequirement(Skill.STRENGTH, 19), new SkillRequirement(Skill.RANGED, 37),
+			Collections.singletonList(grappleLum), new SkillRequirement(Skill.AGILITY, 8, true),
+			new SkillRequirement(Skill.STRENGTH, 19, true), new SkillRequirement(Skill.RANGED, 37, true),
 			crossbow, mithGrap);
 		grappleRiverLumSteps.setDisplayCondition(notGrappleLum);
 		grappleRiverLumSteps.setLockingStep(grappleLumTask);
 		allSteps.add(grappleRiverLumSteps);
 
 		PanelDetails lavaRunesSteps = new PanelDetails("Craft Lava Runes", Arrays.asList(moveToLavaAltar, craftLava),
-			new SkillRequirement(Skill.RUNECRAFT, 23), fireAccess, earthTali, earthRune, essence);
+			new SkillRequirement(Skill.RUNECRAFT, 23, true), fireAccess, earthTali, earthRune, essence);
 		lavaRunesSteps.setDisplayCondition(notCraftLava);
 		lavaRunesSteps.setLockingStep(craftLavaTask);
 		allSteps.add(lavaRunesSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142