### PR TITLE
fix: add missing boost information for Kourend diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendEasy.java
@@ -293,11 +293,11 @@ public class KourendEasy extends ComplexStateQuestHelper
 	{
 		ArrayList<Requirement> req = new ArrayList<>();
 
-		req.add(new SkillRequirement(Skill.CONSTRUCTION, 25));
-		req.add(new SkillRequirement(Skill.FISHING, 20));
-		req.add(new SkillRequirement(Skill.HERBLORE, 12));
-		req.add(new SkillRequirement(Skill.MINING, 15));
-		req.add(new SkillRequirement(Skill.THIEVING, 25));
+		req.add(new SkillRequirement(Skill.CONSTRUCTION, 25, false));
+		req.add(new SkillRequirement(Skill.FISHING, 20, true));
+		req.add(new SkillRequirement(Skill.HERBLORE, 12, true));
+		req.add(new SkillRequirement(Skill.MINING, 15, true));
+		req.add(new SkillRequirement(Skill.THIEVING, 25, true));
 
 		req.add(druidicRitual);
 
@@ -335,13 +335,13 @@ public class KourendEasy extends ComplexStateQuestHelper
 		allSteps.add(mineIronStep);
 
 		PanelDetails fishTroutStep = new PanelDetails("Fish A Trout", Collections.singletonList(fishTrout),
-			new SkillRequirement(Skill.FISHING, 20), flyFishingRod, feathers);
+			new SkillRequirement(Skill.FISHING, 20, true), flyFishingRod, feathers);
 		fishTroutStep.setDisplayCondition(notFishTrout);
 		fishTroutStep.setLockingStep(fishTroutTask);
 		allSteps.add(fishTroutStep);
 
 		PanelDetails makePotionStep = new PanelDetails("Make A Strength Potion", Arrays.asList(enterPub,
-			strengthPotion), new SkillRequirement(Skill.HERBLORE, 12), druidicRitual, tarrominPotU, limpwurtRoot);
+			strengthPotion), new SkillRequirement(Skill.HERBLORE, 12, true), druidicRitual, tarrominPotU, limpwurtRoot);
 		makePotionStep.setDisplayCondition(notStrengthPotion);
 		makePotionStep.setLockingStep(strengthPotionTask);
 		allSteps.add(makePotionStep);
@@ -382,7 +382,7 @@ public class KourendEasy extends ComplexStateQuestHelper
 		allSteps.add(killCrabStep);
 
 		PanelDetails enterPohStep = new PanelDetails("Hosidius House", Arrays.asList(relocateHouse,
-			enterPoh), new SkillRequirement(Skill.CONSTRUCTION, 25), coins.quantity(8750));
+			enterPoh), new SkillRequirement(Skill.CONSTRUCTION, 25, false), coins.quantity(8750));
 		enterPohStep.setDisplayCondition(notEnterPoh);
 		enterPohStep.setLockingStep(enterPohTask);
 		allSteps.add(enterPohStep);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
@@ -347,12 +347,12 @@ public class KourendElite extends ComplexStateQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 
 		req.add(new SkillRequirement(Skill.COOKING, 84, true));
-		req.add(new SkillRequirement(Skill.CRAFTING, 38));
-		req.add(new SkillRequirement(Skill.FARMING, 85));
+		req.add(new SkillRequirement(Skill.CRAFTING, 38, true));
+		req.add(new SkillRequirement(Skill.FARMING, 85, true));
 		req.add(new SkillRequirement(Skill.FISHING, 82, true));
-		req.add(new SkillRequirement(Skill.FLETCHING, 40));
+		req.add(new SkillRequirement(Skill.FLETCHING, 40, true));
 		req.add(new SkillRequirement(Skill.MAGIC, 90, true));
-		req.add(new SkillRequirement(Skill.MINING, 38));
+		req.add(new SkillRequirement(Skill.MINING, 38, true));
 		req.add(new SkillRequirement(Skill.RUNECRAFT, 77, true));
 		req.add(new SkillRequirement(Skill.SLAYER, 95, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 90, true));
@@ -389,16 +389,16 @@ public class KourendElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails battlestaffStep = new PanelDetails("Battlestaff From Scratch", Arrays.asList(plantCelastrusTree,
-			fletchBattlestaff), new SkillRequirement(Skill.FARMING, 85),
-			new SkillRequirement(Skill.FLETCHING, 40), spade, celastrusSapling, knife, axe);
+			fletchBattlestaff), new SkillRequirement(Skill.FARMING, 85, true),
+			new SkillRequirement(Skill.FLETCHING, 40, true), spade, celastrusSapling, knife, axe);
 		battlestaffStep.setDisplayCondition(notFletchBattlestaff);
 		battlestaffStep.setLockingStep(fletchBattlestaffTask);
 		allSteps.add(battlestaffStep);
 
 		PanelDetails craftBloodRuneStep = new PanelDetails("Craft Blood Rune",
 			Arrays.asList(bloodMineDenseEssence, bloodVenerateEssenceBlock, chiselEssenceBlock, craftBloodRune),
-			new SkillRequirement(Skill.RUNECRAFT, 77, true), new SkillRequirement(Skill.MINING, 38),
-			new SkillRequirement(Skill.CRAFTING, 38), chisel, pickaxe);
+			new SkillRequirement(Skill.RUNECRAFT, 77, true), new SkillRequirement(Skill.MINING, 38, true),
+			new SkillRequirement(Skill.CRAFTING, 38, true), chisel, pickaxe);
 		craftBloodRuneStep.setDisplayCondition(notCraftBloodRune);
 		craftBloodRuneStep.setLockingStep(craftBloodRuneTask);
 		allSteps.add(craftBloodRuneStep);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendHard.java
@@ -334,8 +334,8 @@ public class KourendHard extends ComplexStateQuestHelper
 		req.add(new SkillRequirement(Skill.MINING, 65, true));
 		req.add(new SkillRequirement(Skill.SLAYER, 62, true));
 		req.add(new SkillRequirement(Skill.SMITHING, 70, true));
-		req.add(new SkillRequirement(Skill.THIEVING, 49));
-		req.add(new SkillRequirement(Skill.WOODCUTTING, 60));
+		req.add(new SkillRequirement(Skill.THIEVING, 49, false));
+		req.add(new SkillRequirement(Skill.WOODCUTTING, 60, true));
 
 		req.add(dreamMentor);
 		req.add(theForsakenTower);
@@ -368,20 +368,20 @@ public class KourendHard extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails deliverArtifactStep = new PanelDetails("Deliver an artifact", Arrays.asList(talkToCaptainKhaled,
-			deliverArtifact), new SkillRequirement(Skill.THIEVING, 49), lockpick);
+			deliverArtifact), new SkillRequirement(Skill.THIEVING, 49, false), lockpick);
 		deliverArtifactStep.setDisplayCondition(notDeliverArtifact);
 		deliverArtifactStep.setLockingStep(deliverArtifactTask);
 		allSteps.add(deliverArtifactStep);
 
 		PanelDetails plantLogavanoStep = new PanelDetails("Plant some logavano seeds", Arrays.asList(searchSeedTable,
-			enterTitheFarm, plantLogavanoSeed), new SkillRequirement(Skill.FARMING, 74), seedDibber, spade,
+			enterTitheFarm, plantLogavanoSeed), new SkillRequirement(Skill.FARMING, 74, true), seedDibber, spade,
 			wateringCan, logavanoSeeds);
 		plantLogavanoStep.setDisplayCondition(notPlantLogavano);
 		plantLogavanoStep.setLockingStep(plantLogavanoTask);
 		allSteps.add(plantLogavanoStep);
 
 		PanelDetails woodcuttingGuildStep = new PanelDetails("Enter the woodcutting guild",
-			Collections.singletonList(enterWoodcuttingGuild), new SkillRequirement(Skill.WOODCUTTING, 60));
+			Collections.singletonList(enterWoodcuttingGuild), new SkillRequirement(Skill.WOODCUTTING, 60, true));
 		woodcuttingGuildStep.setDisplayCondition(notWoodcuttingGuild);
 		woodcuttingGuildStep.setLockingStep(woodcuttingGuildTask);
 		allSteps.add(woodcuttingGuildStep);
@@ -399,13 +399,13 @@ public class KourendHard extends ComplexStateQuestHelper
 		allSteps.add(mineLovakiteStep);
 
 		PanelDetails smeltBarStep = new PanelDetails("Smelt some adamantite", Arrays.asList(enterForsakenTower,
-			smeltAddyBar), new SkillRequirement(Skill.SMITHING, 70), theForsakenTower, adamantiteOre, coal.quantity(6));
+			smeltAddyBar), new SkillRequirement(Skill.SMITHING, 70, true), theForsakenTower, adamantiteOre, coal.quantity(6));
 		smeltBarStep.setDisplayCondition(notSmeltAddyBar);
 		smeltBarStep.setLockingStep(smeltAddyBarTask);
 		allSteps.add(smeltBarStep);
 
 		PanelDetails killWyrmStep = new PanelDetails("Slay a wyrm", Arrays.asList(enterMountKaruulmDungeon,
-			enterWyrmArea, killWyrm), new SkillRequirement(Skill.SLAYER, 62), combatGear, food, bootsOfStone);
+			enterWyrmArea, killWyrm), new SkillRequirement(Skill.SLAYER, 62, true), combatGear, food, bootsOfStone);
 		killWyrmStep.setDisplayCondition(notKillWyrm);
 		killWyrmStep.setLockingStep(killWyrmTask);
 		allSteps.add(killWyrmStep);
@@ -418,7 +418,7 @@ public class KourendHard extends ComplexStateQuestHelper
 		allSteps.add(killShamanStep);
 
 		PanelDetails examineMonsterStep = new PanelDetails("Cast Monster Examine",
-			Collections.singletonList(castMonsterExamine), new SkillRequirement(Skill.MAGIC, 66), dreamMentor,
+			Collections.singletonList(castMonsterExamine), new SkillRequirement(Skill.MAGIC, 66, true), dreamMentor,
 			lunarBook, mindRune, astralRune, cosmicRune);
 		examineMonsterStep.setDisplayCondition(notExamineMonster);
 		examineMonsterStep.setLockingStep(examineMonsterTask);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
@@ -356,12 +356,12 @@ public class KourendMedium extends ComplexStateQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 
 		req.add(new SkillRequirement(Skill.AGILITY, 49, true));
-		req.add(new SkillRequirement(Skill.CRAFTING, 30));
-		req.add(new SkillRequirement(Skill.FARMING, 45));
-		req.add(new SkillRequirement(Skill.FIREMAKING, 50));
-		req.add(new SkillRequirement(Skill.FISHING, 43));
+		req.add(new SkillRequirement(Skill.CRAFTING, 30, true));
+		req.add(new SkillRequirement(Skill.FARMING, 45, true));
+		req.add(new SkillRequirement(Skill.FIREMAKING, 50, false));
+		req.add(new SkillRequirement(Skill.FISHING, 43, false));
 		req.add(new SkillRequirement(Skill.HUNTER, 53, true));
-		req.add(new SkillRequirement(Skill.MINING, 42));
+		req.add(new SkillRequirement(Skill.MINING, 42, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 50, true));
 
 		req.add(fairytaleII);
@@ -405,26 +405,26 @@ public class KourendMedium extends ComplexStateQuestHelper
 		allSteps.add(fairyRingStep);
 
 		PanelDetails chopMahoganyStep = new PanelDetails("Chop Mahogany Tree",
-			Collections.singletonList(chopMahoganyTree), new SkillRequirement(Skill.WOODCUTTING, 50), axe);
+			Collections.singletonList(chopMahoganyTree), new SkillRequirement(Skill.WOODCUTTING, 50, true), axe);
 		chopMahoganyStep.setDisplayCondition(notChopMahoganyTree);
 		chopMahoganyStep.setLockingStep(chopMahoganyTreeTask);
 		allSteps.add(chopMahoganyStep);
 
 		PanelDetails enterFarmingGuildStep = new PanelDetails("Enter The Farming Guild",
-			Collections.singletonList(enterFarmingGuild), new SkillRequirement(Skill.FARMING, 45));
+			Collections.singletonList(enterFarmingGuild), new SkillRequirement(Skill.FARMING, 45, true));
 		enterFarmingGuildStep.setDisplayCondition(notEnterFarmingGuild);
 		enterFarmingGuildStep.setLockingStep(enterFarmingGuildTask);
 		allSteps.add(enterFarmingGuildStep);
 
 		PanelDetails catchBluegillStep = new PanelDetails("Catch A Bluegill", Arrays.asList(travelToMolchIsland,
-			pickupWorms, talkToAlry, catchBluegill), new SkillRequirement(Skill.FISHING, 43),
-			new SkillRequirement(Skill.HUNTER, 35), kingWorm);
+			pickupWorms, talkToAlry, catchBluegill), new SkillRequirement(Skill.FISHING, 43, false),
+			new SkillRequirement(Skill.HUNTER, 35, false), kingWorm);
 		catchBluegillStep.setDisplayCondition(notCatchBluegill);
 		catchBluegillStep.setLockingStep(catchBluegillTask);
 		allSteps.add(catchBluegillStep);
 
 		PanelDetails mineSulphurStep = new PanelDetails("Mine volcanic sulphur", Collections.singletonList(mineSulphur),
-			new SkillRequirement(Skill.MINING, 42), pickaxe, faceMask);
+			new SkillRequirement(Skill.MINING, 42, true), pickaxe, faceMask);
 		mineSulphurStep.setDisplayCondition(notMineSulphur);
 		mineSulphurStep.setLockingStep(mineSulphurTask);
 		allSteps.add(mineSulphurStep);
@@ -436,13 +436,13 @@ public class KourendMedium extends ComplexStateQuestHelper
 		allSteps.add(killLizardmanStep);
 
 		PanelDetails catchChinStep = new PanelDetails("Catch A Chinchompa", Collections.singletonList(catchChinchompa),
-			new SkillRequirement(Skill.HUNTER, 53), boxTrap, eaglesPeak);
+			new SkillRequirement(Skill.HUNTER, 53, true), boxTrap, eaglesPeak);
 		catchChinStep.setDisplayCondition(notCatchChinchompa);
 		catchChinStep.setLockingStep(catchChinchompaTask);
 		allSteps.add(catchChinStep);
 
 		PanelDetails repairCraneStep = new PanelDetails("Repair Crane", Collections.singletonList(repairCrane),
-			new SkillRequirement(Skill.CRAFTING, 30), hammer, nails, planks);
+			new SkillRequirement(Skill.CRAFTING, 30, true), hammer, nails, planks);
 		repairCraneStep.setDisplayCondition(notRepairCrane);
 		repairCraneStep.setLockingStep(repairCraneTask);
 		allSteps.add(repairCraneStep);
@@ -453,13 +453,13 @@ public class KourendMedium extends ComplexStateQuestHelper
 		allSteps.add(switchSpellbookStep);
 
 		PanelDetails leapBoulderStep = new PanelDetails("Leap the boulder", Collections.singletonList(useBoulderShortcut),
-			new SkillRequirement(Skill.AGILITY, 49));
+			new SkillRequirement(Skill.AGILITY, 49, true));
 		leapBoulderStep.setDisplayCondition(notUseBoulderShortcut);
 		leapBoulderStep.setLockingStep(useBoulderShortcutTask);
 		allSteps.add(leapBoulderStep);
 
 		PanelDetails subdueWintertodtStep = new PanelDetails("Subdue the Wintertodt",
-			Collections.singletonList(subdueWintertodt), new SkillRequirement(Skill.FIREMAKING, 50), axe,
+			Collections.singletonList(subdueWintertodt), new SkillRequirement(Skill.FIREMAKING, 50, false), axe,
 			tinderbox, food, warmClothing, knife, hammer);
 		subdueWintertodtStep.setDisplayCondition(notSubdueWintertodt);
 		subdueWintertodtStep.setLockingStep(subdueWintertodtTask);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142