### PR TITLE
fix: add missing boost information for Varrock diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
@@ -267,12 +267,12 @@ public class VarrockEasy extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 13));
-		reqs.add(new SkillRequirement(Skill.CRAFTING, 8));
-		reqs.add(new SkillRequirement(Skill.FISHING, 20));
-		reqs.add(new SkillRequirement(Skill.MINING, 15));
-		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 9));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 5));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 13, true));
+		reqs.add(new SkillRequirement(Skill.CRAFTING, 8, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 20, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 15, true));
+		reqs.add(new SkillRequirement(Skill.RUNECRAFT, 9, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 5, true));
 
 		reqs.add(runeMysteries);
 
@@ -330,7 +330,7 @@ public class VarrockEasy extends ComplexStateQuestHelper
 		allSteps.add(auburySteps);
 
 		PanelDetails teaStallSteps = new PanelDetails("Steal from the Tea Stall", Collections.singletonList(teaStall),
-			new SkillRequirement(Skill.THIEVING, 5));
+			new SkillRequirement(Skill.THIEVING, 5, true));
 		teaStallSteps.setDisplayCondition(notTeaStall);
 		teaStallSteps.setLockingStep(teaStallTask);
 		allSteps.add(teaStallSteps);
@@ -346,30 +346,30 @@ public class VarrockEasy extends ComplexStateQuestHelper
 		allSteps.add(dyingTreeSteps);
 
 		PanelDetails earthRuneSteps = new PanelDetails("Craft an Earth Rune", Arrays.asList(moveToEarthRune,
-			earthRune), new SkillRequirement(Skill.RUNECRAFT, 9), essence, earthTali);
+			earthRune), new SkillRequirement(Skill.RUNECRAFT, 9, true), essence, earthTali);
 		earthRuneSteps.setDisplayCondition(notEarthRune);
 		earthRuneSteps.setLockingStep(earthRuneTask);
 		allSteps.add(earthRuneSteps);
 
 		PanelDetails ironSteps = new PanelDetails("Mine Iron South East", Collections.singletonList(iron),
-			new SkillRequirement(Skill.MINING, 15), pickaxe);
+			new SkillRequirement(Skill.MINING, 15, true), pickaxe);
 		ironSteps.setDisplayCondition(notIron);
 		ironSteps.setLockingStep(ironTask);
 		allSteps.add(ironSteps);
 
-		PanelDetails fenceSteps = new PanelDetails("Jump the Fence", Collections.singletonList(fence), new SkillRequirement(Skill.AGILITY, 13));
+		PanelDetails fenceSteps = new PanelDetails("Jump the Fence", Collections.singletonList(fence), new SkillRequirement(Skill.AGILITY, 13, true));
 		fenceSteps.setDisplayCondition(notFence);
 		fenceSteps.setLockingStep(fenceTask);
 		allSteps.add(fenceSteps);
 
 		PanelDetails troutSteps = new PanelDetails("Fish a Trout", Collections.singletonList(trout),
-			new SkillRequirement(Skill.FISHING, 20), flyRod, feathers);
+			new SkillRequirement(Skill.FISHING, 20, true), flyRod, feathers);
 		troutSteps.setDisplayCondition(notTrout);
 		troutSteps.setLockingStep(troutTask);
 		allSteps.add(troutSteps);
 
 		PanelDetails bowlSteps = new PanelDetails("Spin a Bowl in Barbarian Village", Arrays.asList(potteryWheel, bowl),
-			new SkillRequirement(Skill.CRAFTING, 8), softClay);
+			new SkillRequirement(Skill.CRAFTING, 8, true), softClay);
 		bowlSteps.setDisplayCondition(notBowl);
 		bowlSteps.setLockingStep(bowlTask);
 		allSteps.add(bowlSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
@@ -217,10 +217,10 @@ public class VarrockElite extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.COOKING, 95));
-		reqs.add(new SkillRequirement(Skill.FLETCHING, 81));
-		reqs.add(new SkillRequirement(Skill.HERBLORE, 90));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 86));
+		reqs.add(new SkillRequirement(Skill.COOKING, 95, true));
+		reqs.add(new SkillRequirement(Skill.FLETCHING, 81, true));
+		reqs.add(new SkillRequirement(Skill.HERBLORE, 90, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 86, true));
 		reqs.add(new ComplexRequirement(LogicType.OR, "78 Runecraft or 52 with Raiments of the Eye set",
 			new SkillRequirement(Skill.RUNECRAFT, 78, true, "78 Runecraft"),
 			new ItemRequirements("52 with Raiments of the Eye set",
@@ -229,7 +229,7 @@ public class VarrockElite extends ComplexStateQuestHelper
 				new ItemRequirement("Bottom", ItemCollections.EYE_BOTTOM),
 				new ItemRequirement("Boot", ItemID.BOOTS_OF_THE_EYE))
 		));
-		reqs.add(new SkillRequirement(Skill.SMITHING, 89));
+		reqs.add(new SkillRequirement(Skill.SMITHING, 89, true));
 
 		reqs.add(dreamMentor);
 		reqs.add(touristTrap);
@@ -263,33 +263,33 @@ public class VarrockElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails superCombatSteps = new PanelDetails("Make Super Combat", Arrays.asList(moveToBank, superCombat),
-			new SkillRequirement(Skill.HERBLORE, 90), sAtk4, sStr4, sDef4, torstol);
+			new SkillRequirement(Skill.HERBLORE, 90, true), sAtk4, sStr4, sDef4, torstol);
 		superCombatSteps.setDisplayCondition(notSuperCombat);
 		superCombatSteps.setLockingStep(superCombatTask);
 		allSteps.add(superCombatSteps);
 
 		PanelDetails summerPieSteps = new PanelDetails("Summer Pie", Arrays.asList(moveToCookingGuild, summerPie),
-			new SkillRequirement(Skill.COOKING, 95), cookingGuild, rawPie);
+			new SkillRequirement(Skill.COOKING, 95, true), cookingGuild, rawPie);
 		summerPieSteps.setDisplayCondition(notSummerPie);
 		summerPieSteps.setLockingStep(summerPieTask);
 		allSteps.add(summerPieSteps);
 
 		PanelDetails runeDartsSteps = new PanelDetails("Smith and Fletch 10 Rune Darts", Arrays.asList(moveToAnvil,
-			dartTip, runeDart), new SkillRequirement(Skill.FLETCHING, 81), new SkillRequirement(Skill.SMITHING, 89),
+			dartTip, runeDart), new SkillRequirement(Skill.FLETCHING, 81, true), new SkillRequirement(Skill.SMITHING, 89, true),
 			touristTrap, runeBar, feather, hammer);
 		runeDartsSteps.setDisplayCondition(notRuneDart);
 		runeDartsSteps.setLockingStep(runeDartTask);
 		allSteps.add(runeDartsSteps);
 
 		PanelDetails plankMakeSteps = new PanelDetails("Plank Make", Arrays.asList(moveToLumb, plankMake),
-			new SkillRequirement(Skill.MAGIC, 86), lunarBook, dreamMentor, natureRune.quantity(20),
+			new SkillRequirement(Skill.MAGIC, 86, true), lunarBook, dreamMentor, natureRune.quantity(20),
 			astralRune.quantity(40), earthRune.quantity(300), coins.quantity(21000), mahoganyLog.quantity(20));
 		plankMakeSteps.setDisplayCondition(notPlankMake);
 		plankMakeSteps.setLockingStep(plankMakeTask);
 		allSteps.add(plankMakeSteps);
 
 		PanelDetails earth100Steps = new PanelDetails("Craft 100 Earth runes", Arrays.asList(moveToEarthRune,
-			earthRune100), new SkillRequirement(Skill.RUNECRAFT, 78), essence.quantity(25), earthTali);
+			earthRune100), new SkillRequirement(Skill.RUNECRAFT, 78, true), essence.quantity(25), earthTali);
 		earth100Steps.setDisplayCondition(not100Earth);
 		earth100Steps.setLockingStep(earthRuneTask);
 		allSteps.add(earth100Steps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
@@ -392,21 +392,18 @@ public class VarrockHard extends ComplexStateQuestHelper
 	public List<Requirement> getGeneralRequirements()
 	{
 		List<Requirement> reqs = new ArrayList<>();
-		reqs.add(new SkillRequirement(Skill.AGILITY, 51));
-		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 51, true));
+		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 50, false));
 		reqs.add(new SkillRequirement(Skill.FARMING, 68, true));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 60, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 66, false));
 		if (questHelperPlugin.getPlayerStateManager().getAccountType().isAnyIronman())
 		{
 			reqs.add(new SkillRequirement(Skill.HUNTER, 69, true));
 		}
-		else
-		{
-			reqs.add(new SkillRequirement(Skill.HUNTER, 66));
-		}
-		reqs.add(new SkillRequirement(Skill.MAGIC, 54));
-		reqs.add(new SkillRequirement(Skill.PRAYER, 52));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 60));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 54, true));
+		reqs.add(new SkillRequirement(Skill.PRAYER, 52, false));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 60, true));
 		reqs.add(atleast153Kudos);
 		reqs.add(ancientBook);
 		reqs.add(desertTreasure);
@@ -445,14 +442,14 @@ public class VarrockHard extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails yewRootsSteps = new PanelDetails("Yew Roots", Arrays.asList(growYew, chopYew, digUpYewRoots),
-			new SkillRequirement(Skill.FARMING, 68, true), new SkillRequirement(Skill.WOODCUTTING, 60), axe, spade,
+			new SkillRequirement(Skill.FARMING, 68, true), new SkillRequirement(Skill.WOODCUTTING, 60, true), axe, spade,
 			rake, yewSap);
 		yewRootsSteps.setDisplayCondition(notYewRoots);
 		yewRootsSteps.setLockingStep(yewRootsTask);
 		allSteps.add(yewRootsSteps);
 
 		PanelDetails spottierCapeSteps = new PanelDetails("Trade for A Spottier Cape", Arrays.asList(getCape, spottyCape),
-			new SkillRequirement(Skill.HUNTER, 66), dashingKeb.quantity(2), coins.quantity(800));
+			new SkillRequirement(Skill.HUNTER, 66, false), dashingKeb.quantity(2), coins.quantity(800));
 		spottierCapeSteps.setDisplayCondition(notSpottyCape);
 		spottierCapeSteps.setLockingStep(spottyCapeTask);
 		allSteps.add(spottierCapeSteps);
@@ -464,39 +461,39 @@ public class VarrockHard extends ComplexStateQuestHelper
 		allSteps.add(kudosSteps);
 
 		PanelDetails yewChurchSteps = new PanelDetails("Cut and Burn Yew Logs Atop the Church", Arrays.asList(cutYew,
-			goUp1, burnLogs), new SkillRequirement(Skill.FIREMAKING, 60),
-			new SkillRequirement(Skill.WOODCUTTING, 60), axe, tinderBox);
+			goUp1, burnLogs), new SkillRequirement(Skill.FIREMAKING, 60, true),
+			new SkillRequirement(Skill.WOODCUTTING, 60, true), axe, tinderBox);
 		yewChurchSteps.setDisplayCondition(notYewChurch);
 		yewChurchSteps.setLockingStep(yewChurchTask);
 		allSteps.add(yewChurchSteps);
 
 		PanelDetails fancyStoneSteps = new PanelDetails("Fancy Stone", Collections.singletonList(fancyStone),
-			new SkillRequirement(Skill.CONSTRUCTION, 50), coins.quantity(25000));
+			new SkillRequirement(Skill.CONSTRUCTION, 50, false), coins.quantity(25000));
 		fancyStoneSteps.setDisplayCondition(notFancyStone);
 		fancyStoneSteps.setLockingStep(fancyStoneTask);
 		allSteps.add(fancyStoneSteps);
 
 		PanelDetails smitedSteps = new PanelDetails("Altar Smited", Arrays.asList(moveToUpstairs,
-			prayAtAltar), new SkillRequirement(Skill.PRAYER, 52));
+			prayAtAltar), new SkillRequirement(Skill.PRAYER, 52, false));
 		smitedSteps.setDisplayCondition(notSmiteAltar);
 		smitedSteps.setLockingStep(smiteAltarTask);
 		allSteps.add(smitedSteps);
 
 		PanelDetails edgevilleWakkaSteps = new PanelDetails("Edgeville Wakka", Collections.singletonList(wakkaEdge),
-			new SkillRequirement(Skill.WOODCUTTING, 57), axe);
+			new SkillRequirement(Skill.WOODCUTTING, 57, true), axe);
 		edgevilleWakkaSteps.setDisplayCondition(notWakkaEdge);
 		edgevilleWakkaSteps.setLockingStep(wakkaEdgeTask);
 		allSteps.add(edgevilleWakkaSteps);
 
 		PanelDetails paddewwaSteps = new PanelDetails("Teleport to Paddewwa", Collections.singletonList(paddewwaTP),
-			new SkillRequirement(Skill.MAGIC, 54), desertTreasure, ancientBook, lawRune.quantity(2),
+			new SkillRequirement(Skill.MAGIC, 54, true), desertTreasure, ancientBook, lawRune.quantity(2),
 			airRune.quantity(1), fireRune.quantity(1));
 		paddewwaSteps.setDisplayCondition(notPaddewwaTP);
 		paddewwaSteps.setLockingStep(paddewwaTPTask);
 		allSteps.add(paddewwaSteps);
 
 		PanelDetails obstaclePipeSteps = new PanelDetails("Obstacle Pipe", Arrays.asList(moveToEdge, obsPipe),
-			new SkillRequirement(Skill.AGILITY, 51));
+			new SkillRequirement(Skill.AGILITY, 51, true));
 		obstaclePipeSteps.setDisplayCondition(notPipe);
 		obstaclePipeSteps.setLockingStep(pipeTask);
 		allSteps.add(obstaclePipeSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockMedium.java
@@ -306,10 +306,10 @@ public class VarrockMedium extends ComplexStateQuestHelper
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new CombatLevelRequirement(40));
 		reqs.add(qp);
-		reqs.add(new SkillRequirement(Skill.AGILITY, 30));
-		reqs.add(new SkillRequirement(Skill.FARMING, 30));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 40));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 25));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 30, true));
+		reqs.add(new SkillRequirement(Skill.FARMING, 30, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 40, true));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 25, true));
 		reqs.add(normalBook);
 
 		reqs.add(gardenOfTranq);
@@ -399,32 +399,32 @@ public class VarrockMedium extends ComplexStateQuestHelper
 		allSteps.add(maho20Steps);
 
 		PanelDetails balloonSteps = new PanelDetails("Leave Varrock in a Balloon", Arrays.asList(moveToEntrana, talkToAug,
-			balloon), new SkillRequirement(Skill.FIREMAKING, 40), enlightenedJourney, willowLog1, log);
+			balloon), new SkillRequirement(Skill.FIREMAKING, 40, true), enlightenedJourney, willowLog1, log);
 		balloonSteps.setDisplayCondition(new Conditions(notBalloon, notVarrBalloon2));
 		balloonSteps.setLockingStep(balloonTask);
 		allSteps.add(balloonSteps);
 
 		PanelDetails balloon2Steps = new PanelDetails("Leave Varrock in a Balloon", Arrays.asList(moveToEntrana, talkToAug,
-			balloon), new SkillRequirement(Skill.FIREMAKING, 40), enlightenedJourney, willowLog11, log);
+			balloon), new SkillRequirement(Skill.FIREMAKING, 40, true), enlightenedJourney, willowLog11, log);
 		balloon2Steps.setDisplayCondition(new Conditions(notBalloon, notVarrBalloon));
 		balloon2Steps.setLockingStep(balloonTask);
 		allSteps.add(balloon2Steps);
 
 		PanelDetails tpVarrSteps = new PanelDetails("Teleport to Varrock", Collections.singletonList(tpVarrock),
-			new SkillRequirement(Skill.MAGIC, 25), airRune.quantity(3), lawRune.quantity(1), fireRune.quantity(1),
+			new SkillRequirement(Skill.MAGIC, 25, true), airRune.quantity(3), lawRune.quantity(1), fireRune.quantity(1),
 			normalBook);
 		tpVarrSteps.setDisplayCondition(notTPVarrock);
 		tpVarrSteps.setLockingStep(tpVarrockTask);
 		allSteps.add(tpVarrSteps);
 
 		PanelDetails whiteFruitSteps = new PanelDetails("Pick a White Fruit", Collections.singletonList(whiteFruit),
-			new SkillRequirement(Skill.FARMING, 25), gardenOfTranq);
+			new SkillRequirement(Skill.FARMING, 25, false), gardenOfTranq);
 		whiteFruitSteps.setDisplayCondition(notWhiteFruit);
 		whiteFruitSteps.setLockingStep(whiteFruitTask);
 		allSteps.add(whiteFruitSteps);
 
 		PanelDetails varrAgiSteps = new PanelDetails("Rooftop Course Lap", Collections.singletonList(varrAgi),
-			new SkillRequirement(Skill.AGILITY, 30));
+			new SkillRequirement(Skill.AGILITY, 30, true));
 		varrAgiSteps.setDisplayCondition(notVarrAgi);
 		varrAgiSteps.setLockingStep(varrAgiTask);
 		allSteps.add(varrAgiSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142