### PR TITLE
fix: add missing boost information for Western Provinces diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternEasy.java
@@ -247,9 +247,9 @@ public class WesternEasy extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new CombatLevelRequirement(40));
-		reqs.add(new SkillRequirement(Skill.FLETCHING, 20));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 9));
-		reqs.add(new SkillRequirement(Skill.MINING, 15));
+		reqs.add(new SkillRequirement(Skill.FLETCHING, 20, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 9, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 15, true));
 
 		reqs.add(bigChompy);
 		reqs.add(runeMysteries);
@@ -292,7 +292,7 @@ public class WesternEasy extends ComplexStateQuestHelper
 		allSteps.add(agiSteps);
 
 		PanelDetails shortbowSteps = new PanelDetails("Fletch Oak Shortbow in Gnome Stronghold",
-			Arrays.asList(moveToStronghold, oakShortbow), new SkillRequirement(Skill.FLETCHING, 20),
+			Arrays.asList(moveToStronghold, oakShortbow), new SkillRequirement(Skill.FLETCHING, 20, true),
 			oakShortU, bowString);
 		shortbowSteps.setDisplayCondition(notOakShortbow);
 		shortbowSteps.setLockingStep(oakShortbowTask);
@@ -321,13 +321,13 @@ public class WesternEasy extends ComplexStateQuestHelper
 		allSteps.add(toadSteps);
 
 		PanelDetails copperSteps = new PanelDetails("Copper Longtail", Collections.singletonList(copperLongtail),
-			new SkillRequirement(Skill.HUNTER, 9), birdSnare);
+			new SkillRequirement(Skill.HUNTER, 9, true), birdSnare);
 		copperSteps.setDisplayCondition(notCopperLongtail);
 		copperSteps.setLockingStep(copperLongtailTask);
 		allSteps.add(copperSteps);
 
 		PanelDetails ironSteps = new PanelDetails("Mine Iron", Collections.singletonList(mineIron),
-			new SkillRequirement(Skill.MINING, 15), pickaxe);
+			new SkillRequirement(Skill.MINING, 15, true), pickaxe);
 		ironSteps.setDisplayCondition(notMineIron);
 		ironSteps.setLockingStep(mineIronTask);
 		allSteps.add(ironSteps);
@@ -345,7 +345,7 @@ public class WesternEasy extends ComplexStateQuestHelper
 		allSteps.add(pestSteps);
 
 		PanelDetails hatSteps = new PanelDetails("Chompy Bird Hat", Collections.singletonList(chompyHat),
-			new SkillRequirement(Skill.RANGED, 30), bigChompy, ogreBellows, ogreBow, ogreArrows);
+			new SkillRequirement(Skill.RANGED, 30, false), bigChompy, ogreBellows, ogreBow, ogreArrows);
 		hatSteps.setDisplayCondition(notChompyHat);
 		hatSteps.setLockingStep(chompyHatTask);
 		allSteps.add(hatSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternElite.java
@@ -127,10 +127,10 @@ public class WesternElite extends ComplexStateQuestHelper
 		notPickpocketElf = new VarplayerRequirement(VarPlayerID.WESTERN_ACHIEVEMENT_DIARY2, false, 14);
 
 		base42CombatSkills = new ComplexRequirement(LogicType.AND, "Base 42s in all combat skills and 22 prayer",
-			new SkillRequirement(Skill.ATTACK, 42), new SkillRequirement(Skill.STRENGTH, 42),
-			new SkillRequirement(Skill.DEFENCE, 42), new SkillRequirement(Skill.HITPOINTS, 42),
-			new SkillRequirement(Skill.RANGED, 42), new SkillRequirement(Skill.MAGIC, 42),
-			new SkillRequirement(Skill.PRAYER, 22));
+			new SkillRequirement(Skill.ATTACK, 42, false), new SkillRequirement(Skill.STRENGTH, 42, false),
+			new SkillRequirement(Skill.DEFENCE, 42, false), new SkillRequirement(Skill.HITPOINTS, 42, false),
+			new SkillRequirement(Skill.RANGED, 42, false), new SkillRequirement(Skill.MAGIC, 42, false),
+			new SkillRequirement(Skill.PRAYER, 22, false));
 
 		magicLongU = new ItemRequirement("Magic longbow (u)", ItemID.UNSTRUNG_MAGIC_LONGBOW).showConditioned(notMagicLong);
 		bowString = new ItemRequirement("Bow string", ItemID.BOW_STRING).showConditioned(notMagicLong);
@@ -275,20 +275,20 @@ public class WesternElite extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails prissySteps = new PanelDetails("Prissy Scilla's Protection",
-			Collections.singletonList(prissyScilla), new SkillRequirement(Skill.FARMING, 75), magicSapling,
+			Collections.singletonList(prissyScilla), new SkillRequirement(Skill.FARMING, 75, true), magicSapling,
 			coconuts25, rake, spade);
 		prissySteps.setDisplayCondition(notPrissyScilla);
 		prissySteps.setLockingStep(prissyScillaTask);
 		allSteps.add(prissySteps);
 
 		PanelDetails agiSteps = new PanelDetails("Advanced Elven Shortcut", Collections.singletonList(advancedAgi),
-			undergroundPass, new SkillRequirement(Skill.AGILITY, 85));
+			undergroundPass, new SkillRequirement(Skill.AGILITY, 85, true));
 		agiSteps.setDisplayCondition(notAdvancedAgi);
 		agiSteps.setLockingStep(advancedAgiTask);
 		allSteps.add(agiSteps);
 
 		PanelDetails magicSteps = new PanelDetails("Magic Longbow In Tirannwn", Arrays.asList(moveToTirannwn,
-			magicLong), new SkillRequirement(Skill.FLETCHING, 85), regicide, magicLongU, bowString);
+			magicLong), new SkillRequirement(Skill.FLETCHING, 85, true), regicide, magicLongU, bowString);
 		magicSteps.setDisplayCondition(notMagicLong);
 		magicSteps.setLockingStep(magicLongTask);
 		allSteps.add(magicSteps);
@@ -301,7 +301,7 @@ public class WesternElite extends ComplexStateQuestHelper
 		allSteps.add(thermySteps);
 
 		PanelDetails elfSteps = new PanelDetails("Pickpocket An Elf", Collections.singletonList(pickpocketElf),
-			new SkillRequirement(Skill.THIEVING, 85), mourningsEndPartI);
+			new SkillRequirement(Skill.THIEVING, 85, true), mourningsEndPartI);
 		elfSteps.setDisplayCondition(notPickpocketElf);
 		elfSteps.setLockingStep(pickpocketElfTask);
 		allSteps.add(elfSteps);
@@ -313,7 +313,7 @@ public class WesternElite extends ComplexStateQuestHelper
 		allSteps.add(voidSteps);
 
 		PanelDetails hatSteps = new PanelDetails("Chompy Bird Hat", Collections.singletonList(chompyHat),
-			new SkillRequirement(Skill.RANGED, 30), bigChompy, ogreBellows, ogreBow, ogreArrows);
+			new SkillRequirement(Skill.RANGED, 30, false), bigChompy, ogreBellows, ogreBow, ogreArrows);
 		hatSteps.setDisplayCondition(notChompyHat);
 		hatSteps.setLockingStep(chompyHatTask);
 		allSteps.add(hatSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternHard.java
@@ -336,18 +336,18 @@ public class WesternHard extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new CombatLevelRequirement(100));
-		reqs.add(new SkillRequirement(Skill.AGILITY, 48));
-		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 65));
-		reqs.add(new SkillRequirement(Skill.COOKING, 62));
-		reqs.add(new SkillRequirement(Skill.FARMING, 68));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 50));
-		reqs.add(new SkillRequirement(Skill.FISHING, 62));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 69));
-		reqs.add(new SkillRequirement(Skill.RANGED, 70));
-		reqs.add(new SkillRequirement(Skill.MAGIC, 64));
-		reqs.add(new SkillRequirement(Skill.MINING, 70));
-		reqs.add(new SkillRequirement(Skill.THIEVING, 75));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 50));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 48, true));
+		reqs.add(new SkillRequirement(Skill.CONSTRUCTION, 65, true));
+		reqs.add(new SkillRequirement(Skill.COOKING, 62, true));
+		reqs.add(new SkillRequirement(Skill.FARMING, 68, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 50, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 62, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 69, true));
+		reqs.add(new SkillRequirement(Skill.RANGED, 70, false));
+		reqs.add(new SkillRequirement(Skill.MAGIC, 64, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 70, true));
+		reqs.add(new SkillRequirement(Skill.THIEVING, 75, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 50, true));
 
 		reqs.add(mourningsEndPartI);
 		reqs.add(awowogeiRFD);
@@ -391,45 +391,45 @@ public class WesternHard extends ComplexStateQuestHelper
 		List<PanelDetails> allSteps = new ArrayList<>();
 
 		PanelDetails palmSteps = new PanelDetails("Lletya Palm tree", Collections.singletonList(lletyaPalm),
-			new SkillRequirement(Skill.FARMING, 68), mourningsEndPartI, palmSapling, rake, spade);
+			new SkillRequirement(Skill.FARMING, 68, true), mourningsEndPartI, palmSapling, rake, spade);
 		palmSteps.setDisplayCondition(notLletyaPalm);
 		palmSteps.setLockingStep(lletyaPalmTask);
 		allSteps.add(palmSteps);
 
 		PanelDetails fishSteps = new PanelDetails("Catch And Cook Monkfish", Arrays.asList(fishMonkfish, monkfishPisc),
-			new SkillRequirement(Skill.COOKING, 62), new SkillRequirement(Skill.FISHING, 62),
+			new SkillRequirement(Skill.COOKING, 62, true), new SkillRequirement(Skill.FISHING, 62, true),
 			swanSong, smallFishingNet);
 		fishSteps.setDisplayCondition(notMonkfishPisc);
 		fishSteps.setLockingStep(monkfishPiscTask);
 		allSteps.add(fishSteps);
 
 		PanelDetails kebbitSteps = new PanelDetails("Dashing Kebbit", Arrays.asList(getBird, dashingKebbit),
-			new SkillRequirement(Skill.HUNTER, 69), coins);
+			new SkillRequirement(Skill.HUNTER, 69, true), coins);
 		kebbitSteps.setDisplayCondition(notDashingKebbit);
 		kebbitSteps.setLockingStep(dashingKebbitTask);
 		allSteps.add(kebbitSteps);
 
 		PanelDetails gnomeSteps = new PanelDetails("Pickpocket A Gnome", Collections.singletonList(pickpocketGnome),
-			new SkillRequirement(Skill.THIEVING, 75), treeGnomeVillage);
+			new SkillRequirement(Skill.THIEVING, 75, true), treeGnomeVillage);
 		gnomeSteps.setDisplayCondition(notPickpocketGnome);
 		gnomeSteps.setLockingStep(pickpocketGnomeTask);
 		allSteps.add(gnomeSteps);
 
 		PanelDetails tpSteps = new PanelDetails("Teleport To Ape Atoll", Collections.singletonList(tpApe),
-			new SkillRequirement(Skill.MAGIC, 64), awowogeiRFD, normalBook, lawRunes2, fireRunes2, waterRunes2, banana);
+			new SkillRequirement(Skill.MAGIC, 64, true), awowogeiRFD, normalBook, lawRunes2, fireRunes2, waterRunes2, banana);
 		tpSteps.setDisplayCondition(notTPApe);
 		tpSteps.setLockingStep(tpApeTask);
 		allSteps.add(tpSteps);
 
 		PanelDetails mahoSteps = new PanelDetails("Mahogany On Ape Atoll", Arrays.asList(moveToApeMahogany,
-			mahoganyChopped, mahoganyBurned), new SkillRequirement(Skill.FIREMAKING, 50),
-			new SkillRequirement(Skill.WOODCUTTING, 50), monkeyMadnessI, axe, tinderbox);
+			mahoganyChopped, mahoganyBurned), new SkillRequirement(Skill.FIREMAKING, 50, true),
+			new SkillRequirement(Skill.WOODCUTTING, 50, true), monkeyMadnessI, axe, tinderbox);
 		mahoSteps.setDisplayCondition(notMahoganyBurned);
 		mahoSteps.setLockingStep(mahoganyBurnedTask);
 		allSteps.add(mahoSteps);
 
 		PanelDetails agiSteps = new PanelDetails("Ape Atoll Agility Course", Arrays.asList(moveToApeAgi, apeAtollAgi),
-			new SkillRequirement(Skill.AGILITY, 48), monkeyMadnessI, ninjaGreegree);
+			new SkillRequirement(Skill.AGILITY, 48, true), monkeyMadnessI, ninjaGreegree);
 		agiSteps.setDisplayCondition(notApeAtollAgi);
 		agiSteps.setLockingStep(apeAtollAgiTask);
 		allSteps.add(agiSteps);
@@ -441,7 +441,7 @@ public class WesternHard extends ComplexStateQuestHelper
 		allSteps.add(zulSteps);
 
 		PanelDetails addySteps = new PanelDetails("Mine Adamantite in Tirannwn", Collections.singletonList(mineAddyOre),
-			new SkillRequirement(Skill.MINING, 70), regicide, pickaxe);
+			new SkillRequirement(Skill.MINING, 70, true), regicide, pickaxe);
 		addySteps.setDisplayCondition(notMineAddyOre);
 		addySteps.setLockingStep(mineAddyOreTask);
 		allSteps.add(addySteps);
@@ -458,13 +458,13 @@ public class WesternHard extends ComplexStateQuestHelper
 		allSteps.add(pestSteps);
 
 		PanelDetails isaSteps = new PanelDetails("Isafdar Painting In POH", Collections.singletonList(isafdarPainting),
-			new SkillRequirement(Skill.CONSTRUCTION, 65), rovingElves, mahoganyPlank, painting, saw, hammer);
+			new SkillRequirement(Skill.CONSTRUCTION, 65, true), rovingElves, mahoganyPlank, painting, saw, hammer);
 		isaSteps.setDisplayCondition(notIsafdarPainting);
 		isaSteps.setLockingStep(isafdarPaintingTask);
 		allSteps.add(isaSteps);
 
 		PanelDetails hatSteps = new PanelDetails("Chompy Bird Hat", Collections.singletonList(chompyHat),
-			new SkillRequirement(Skill.RANGED, 30), bigChompy, ogreBellows, ogreBow, ogreArrows);
+			new SkillRequirement(Skill.RANGED, 30, false), bigChompy, ogreBellows, ogreBow, ogreArrows);
 		hatSteps.setDisplayCondition(notChompyHat);
 		hatSteps.setLockingStep(chompyHatTask);
 		allSteps.add(hatSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternMedium.java
@@ -338,13 +338,13 @@ public class WesternMedium extends ComplexStateQuestHelper
 	{
 		List<Requirement> reqs = new ArrayList<>();
 		reqs.add(new CombatLevelRequirement(70));
-		reqs.add(new SkillRequirement(Skill.AGILITY, 37));
-		reqs.add(new SkillRequirement(Skill.COOKING, 42));
-		reqs.add(new SkillRequirement(Skill.FIREMAKING, 35));
-		reqs.add(new SkillRequirement(Skill.FISHING, 46));
-		reqs.add(new SkillRequirement(Skill.HUNTER, 31));
-		reqs.add(new SkillRequirement(Skill.MINING, 40));
-		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 35));
+		reqs.add(new SkillRequirement(Skill.AGILITY, 37, true));
+		reqs.add(new SkillRequirement(Skill.COOKING, 42, true));
+		reqs.add(new SkillRequirement(Skill.FIREMAKING, 35, true));
+		reqs.add(new SkillRequirement(Skill.FISHING, 46, true));
+		reqs.add(new SkillRequirement(Skill.HUNTER, 31, true));
+		reqs.add(new SkillRequirement(Skill.MINING, 40, true));
+		reqs.add(new SkillRequirement(Skill.WOODCUTTING, 35, true));
 
 		reqs.add(bigChompy);
 		reqs.add(eaglesPeak);
@@ -386,20 +386,20 @@ public class WesternMedium extends ComplexStateQuestHelper
 		allSteps.add(spiritSteps);
 
 		PanelDetails chocoSteps = new PanelDetails("Chocolate Bomb", Arrays.asList(moveToStrongFirstChoco,
-			chocolateBomb), new SkillRequirement(Skill.COOKING, 42), gnomebowl, gianneDough, chocolateBar, equaLeaf,
+			chocolateBomb), new SkillRequirement(Skill.COOKING, 42, true), gnomebowl, gianneDough, chocolateBar, equaLeaf,
 			potOfCream, chocolateDust);
 		chocoSteps.setDisplayCondition(notChocolateBomb);
 		chocoSteps.setLockingStep(chocolateBombTask);
 		allSteps.add(chocoSteps);
 
 		PanelDetails restSteps = new PanelDetails("Gnome Restaurant Delivery",
-			Arrays.asList(moveToStrongFirstDelivery, gnomeDelivery), new SkillRequirement(Skill.COOKING, 42));
+			Arrays.asList(moveToStrongFirstDelivery, gnomeDelivery), new SkillRequirement(Skill.COOKING, 42, true));
 		restSteps.setDisplayCondition(notGnomeDelivery);
 		restSteps.setLockingStep(gnomeDeliveryTask);
 		allSteps.add(restSteps);
 
 		PanelDetails goldSteps = new PanelDetails("Gold Under The Grand Tree",
-			Arrays.asList(moveToStrongBase, mineGold), new SkillRequirement(Skill.MINING, 40), pickaxe);
+			Arrays.asList(moveToStrongBase, mineGold), new SkillRequirement(Skill.MINING, 40, true), pickaxe);
 		goldSteps.setDisplayCondition(notMineGold);
 		goldSteps.setLockingStep(mineGoldTask);
 		allSteps.add(goldSteps);
@@ -411,7 +411,7 @@ public class WesternMedium extends ComplexStateQuestHelper
 		allSteps.add(sawSteps);
 
 		PanelDetails agiSteps = new PanelDetails("Agility Shortcut To Otto", Collections.singletonList(agiShortcut),
-			new SkillRequirement(Skill.AGILITY, 37), treeGnomeVillage, grandTree);
+			new SkillRequirement(Skill.AGILITY, 37, true), treeGnomeVillage, grandTree);
 		agiSteps.setDisplayCondition(notAgiShortcut);
 		agiSteps.setLockingStep(agiShortcutTask);
 		allSteps.add(agiSteps);
@@ -422,7 +422,7 @@ public class WesternMedium extends ComplexStateQuestHelper
 		allSteps.add(eagleSteps);
 
 		PanelDetails laruSteps = new PanelDetails("Spined Larupia", Collections.singletonList(spinedLarupia),
-			new SkillRequirement(Skill.HUNTER, 31), teasingStick, knife, logs);
+			new SkillRequirement(Skill.HUNTER, 31, true), teasingStick, knife, logs);
 		laruSteps.setDisplayCondition(notSpinedLarupia);
 		laruSteps.setLockingStep(spinedLarupiaTask);
 		allSteps.add(laruSteps);
@@ -434,13 +434,13 @@ public class WesternMedium extends ComplexStateQuestHelper
 		allSteps.add(gliderSteps);
 
 		PanelDetails bassSteps = new PanelDetails("Bass On Ape Atoll", Arrays.asList(moveToApeBass, apeBass),
-			new SkillRequirement(Skill.FISHING, 46), monkeyMadnessI, bigFishingNet);
+			new SkillRequirement(Skill.FISHING, 46, true), monkeyMadnessI, bigFishingNet);
 		bassSteps.setDisplayCondition(notApeBass);
 		bassSteps.setLockingStep(apeBassTask);
 		allSteps.add(bassSteps);
 
 		PanelDetails teakSteps = new PanelDetails("Teaks On Ape Atoll", Arrays.asList(moveToApeTeak, apeTeakChop,
-			apeTeakBurn), new SkillRequirement(Skill.FIREMAKING, 35), new SkillRequirement(Skill.WOODCUTTING, 35),
+			apeTeakBurn), new SkillRequirement(Skill.FIREMAKING, 35, true), new SkillRequirement(Skill.WOODCUTTING, 35, true),
 			monkeyMadnessI, axe, tinderbox);
 		teakSteps.setDisplayCondition(notApeTeak);
 		teakSteps.setLockingStep(apeTeakTask);
@@ -453,7 +453,7 @@ public class WesternMedium extends ComplexStateQuestHelper
 		allSteps.add(pestSteps);
 
 		PanelDetails hatSteps = new PanelDetails("Chompy Bird Hat", Collections.singletonList(chompyHat),
-			new SkillRequirement(Skill.RANGED, 30), bigChompy, ogreBellows, ogreBow, ogreArrows);
+			new SkillRequirement(Skill.RANGED, 30, false), bigChompy, ogreBellows, ogreBow, ogreArrows);
 		hatSteps.setDisplayCondition(notChompyHat);
 		hatSteps.setLockingStep(chompyHatTask);
 		allSteps.add(hatSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142