### PR TITLE
fix: add missing boost information for Kandarin diaries

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinElite.java
@@ -258,14 +258,14 @@ public class KandarinElite extends ComplexStateQuestHelper
 
 		ArrayList<Requirement> req = new ArrayList<>();
 		req.add(new SkillRequirement(Skill.AGILITY, 60, true));
-		req.add(new SkillRequirement(Skill.COOKING, 80));
-		req.add(new SkillRequirement(Skill.CRAFTING, 85));
-		req.add(new SkillRequirement(Skill.FARMING, 79));
-		req.add(new SkillRequirement(Skill.FIREMAKING, 85));
-		req.add(new SkillRequirement(Skill.FISHING, 76));
-		req.add(new SkillRequirement(Skill.HERBLORE, 86));
-		req.add(new SkillRequirement(Skill.MAGIC, 87));
-		req.add(new SkillRequirement(Skill.SMITHING, 90));
+		req.add(new SkillRequirement(Skill.COOKING, 80, true));
+		req.add(new SkillRequirement(Skill.CRAFTING, 85, true));
+		req.add(new SkillRequirement(Skill.FARMING, 79, true));
+		req.add(new SkillRequirement(Skill.FIREMAKING, 85, true));
+		req.add(new SkillRequirement(Skill.FISHING, 76, true));
+		req.add(new SkillRequirement(Skill.HERBLORE, 86, true));
+		req.add(new SkillRequirement(Skill.MAGIC, 87, true));
+		req.add(new SkillRequirement(Skill.SMITHING, 90, true));
 
 		req.add(barbHerb);
 		req.add(barbFire);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
@@ -322,16 +322,16 @@ public class KandarinHard extends ComplexStateQuestHelper
 		ArrayList<Requirement> req = new ArrayList<>();
 
 		req.add(new SkillRequirement(Skill.AGILITY, 60, true));
-		req.add(new SkillRequirement(Skill.CONSTRUCTION, 50));
-		req.add(new SkillRequirement(Skill.DEFENCE, 70));
+		req.add(new SkillRequirement(Skill.CONSTRUCTION, 50, false));
+		req.add(new SkillRequirement(Skill.DEFENCE, 70, false));
 		req.add(new SkillRequirement(Skill.FIREMAKING, 65, true));
 		req.add(new SkillRequirement(Skill.FISHING, 70, true));
 		req.add(new SkillRequirement(Skill.FLETCHING, 70, true));
-		req.add(new SkillRequirement(Skill.PRAYER, 70));
-		req.add(new SkillRequirement(Skill.MAGIC, 56));
+		req.add(new SkillRequirement(Skill.PRAYER, 70, false));
+		req.add(new SkillRequirement(Skill.MAGIC, 56, true));
 		req.add(new SkillRequirement(Skill.SMITHING, 75, true));
-		req.add(new SkillRequirement(Skill.STRENGTH, 50));
-		req.add(new SkillRequirement(Skill.THIEVING, 53));
+		req.add(new SkillRequirement(Skill.STRENGTH, 50, false));
+		req.add(new SkillRequirement(Skill.THIEVING, 53, true));
 		req.add(new SkillRequirement(Skill.WOODCUTTING, 60, true));
 
 		req.add(taiBwoWannai);
@@ -398,7 +398,7 @@ public class KandarinHard extends ComplexStateQuestHelper
 
 		PanelDetails pietySteps = new PanelDetails("Piety in the Courthouse", Collections.singletonList(pietyCourt),
 			new QuestRequirement(QuestHelperQuest.KINGS_RANSOM, QuestState.FINISHED),
-			knightWaves, new SkillRequirement(Skill.PRAYER, 70), new SkillRequirement(Skill.DEFENCE, 70));
+			knightWaves, new SkillRequirement(Skill.PRAYER, 70, false), new SkillRequirement(Skill.DEFENCE, 70, false));
 		pietySteps.setDisplayCondition(notPietyCourt);
 		pietySteps.setLockingStep(pietyCourtTask);
 		allSteps.add(pietySteps);
@@ -410,7 +410,7 @@ public class KandarinHard extends ComplexStateQuestHelper
 		allSteps.add(burnMapleSteps);
 
 		PanelDetails fancyStoneSteps = new PanelDetails("Fancy Stone Decoration", Collections.singletonList(fancyStone),
-			new SkillRequirement(Skill.CONSTRUCTION, 50), coins.quantity(25000));
+			new SkillRequirement(Skill.CONSTRUCTION, 50, false), coins.quantity(25000));
 		fancyStoneSteps.setDisplayCondition(notFancyStone);
 		fancyStoneSteps.setLockingStep(fancyStoneTask);
 		allSteps.add(fancyStoneSteps);
@@ -422,8 +422,8 @@ public class KandarinHard extends ComplexStateQuestHelper
 		allSteps.add(killHoundSteps);
 
 		PanelDetails fishSturgeonSteps = new PanelDetails("Fish a Leaping Sturgeon", Collections.singletonList(catchSturgeon),
-			new SkillRequirement(Skill.FISHING, 70, true), new SkillRequirement(Skill.AGILITY, 45),
-			new SkillRequirement(Skill.STRENGTH, 45), barbFishing, barbRod, feather.quantity(20));
+			new SkillRequirement(Skill.FISHING, 70, true), new SkillRequirement(Skill.AGILITY, 45, true),
+			new SkillRequirement(Skill.STRENGTH, 45, true), barbFishing, barbRod, feather.quantity(20));
 		fishSturgeonSteps.setDisplayCondition(notCatchSturgeon);
 		fishSturgeonSteps.setLockingStep(catchSturgeonTask);
 		allSteps.add(fishSturgeonSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinMedium.java
@@ -343,17 +343,17 @@ public class KandarinMedium extends ComplexStateQuestHelper
 		setupGeneralRequirements();
 
 		ArrayList<Requirement> req = new ArrayList<>();
-		req.add(new SkillRequirement(Skill.AGILITY, 36));
-		req.add(new SkillRequirement(Skill.COOKING, 43));
-		req.add(new SkillRequirement(Skill.FARMING, 26));
-		req.add(new SkillRequirement(Skill.FISHING, 46));
-		req.add(new SkillRequirement(Skill.FLETCHING, 50));
-		req.add(new SkillRequirement(Skill.HERBLORE, 48));
-		req.add(new SkillRequirement(Skill.MAGIC, 45));
-		req.add(new SkillRequirement(Skill.MINING, 30));
-		req.add(new SkillRequirement(Skill.RANGED, 40));
-		req.add(new SkillRequirement(Skill.STRENGTH, 22));
-		req.add(new SkillRequirement(Skill.THIEVING, 47));
+		req.add(new SkillRequirement(Skill.AGILITY, 36, true));
+		req.add(new SkillRequirement(Skill.COOKING, 43, true));
+		req.add(new SkillRequirement(Skill.FARMING, 26, true));
+		req.add(new SkillRequirement(Skill.FISHING, 46, true));
+		req.add(new SkillRequirement(Skill.FLETCHING, 50, true));
+		req.add(new SkillRequirement(Skill.HERBLORE, 48, true));
+		req.add(new SkillRequirement(Skill.MAGIC, 45, true));
+		req.add(new SkillRequirement(Skill.MINING, 30, true));
+		req.add(new SkillRequirement(Skill.RANGED, 40, true));
+		req.add(new SkillRequirement(Skill.STRENGTH, 22, true));
+		req.add(new SkillRequirement(Skill.THIEVING, 47, true));
 
 		req.add(alfredBar);
 		req.add(eleWorkII);
@@ -399,8 +399,8 @@ public class KandarinMedium extends ComplexStateQuestHelper
 		allSteps.add(pickLimpSteps);
 
 		PanelDetails grappleStep = new PanelDetails("Grapple from Water Obelisk", Arrays.asList(moveToTavDungeon, moveToOb, grapOb),
-			new SkillRequirement(Skill.AGILITY, 36), new SkillRequirement(Skill.STRENGTH, 22),
-			new SkillRequirement(Skill.RANGED, 39), mithGrap, crossbow, dustyKey);
+			new SkillRequirement(Skill.AGILITY, 36, true), new SkillRequirement(Skill.STRENGTH, 22, true),
+			new SkillRequirement(Skill.RANGED, 39, true), mithGrap, crossbow, dustyKey);
 		grappleStep.setDisplayCondition(notGrapOb);
 		grappleStep.setLockingStep(grapObTask);
 		allSteps.add(grappleStep);
@@ -432,14 +432,14 @@ public class KandarinMedium extends ComplexStateQuestHelper
 		allSteps.add(makeMindHelmStep);
 
 		PanelDetails enterRangeSteps = new PanelDetails("Enter the Ranging Guild", Collections.singletonList(enterRange),
-			new SkillRequirement(Skill.RANGED, 40));
+			new SkillRequirement(Skill.RANGED, 40, true));
 		enterRangeSteps.setDisplayCondition(notEnterRange);
 		enterRangeSteps.setLockingStep(enterRangeTask);
 		allSteps.add(enterRangeSteps);
 
 		PanelDetails stealHemSteps = new PanelDetails("Steal from Hemenster Chest",
 			Collections.singletonList(stealHemen),
-			new SkillRequirement(Skill.THIEVING, 47),
+			new SkillRequirement(Skill.THIEVING, 47, true),
 			lockpick);
 		stealHemSteps.setDisplayCondition(notStealHemen);
 		stealHemSteps.setLockingStep(stealHemenTask);
@@ -459,7 +459,7 @@ public class KandarinMedium extends ComplexStateQuestHelper
 
 		PanelDetails barbAgiSteps = new PanelDetails("Barbarian Agility Course Lap", Collections.singletonList(barbAgi),
 			alfredBar,
-			new SkillRequirement(Skill.AGILITY, 35));
+			new SkillRequirement(Skill.AGILITY, 35, true));
 		barbAgiSteps.setDisplayCondition(notBarbAgi);
 		barbAgiSteps.setLockingStep(barbAgiTask);
 		allSteps.add(barbAgiSteps);


### PR DESCRIPTION
This pull request adds in boost information for every individual step of the achievement diary and includes boost information for the general requirements as well.

Relates to: #2142