### PR TITLE
feat: Reimplemented remaining items section in quest bank

### DIFF
--- a/src/main/java/com/questhelper/bank/banktab/BankTabItem.java
+++ b/src/main/java/com/questhelper/bank/banktab/BankTabItem.java
@@ -68,7 +68,7 @@ public class BankTabItem
 		this.text = item.getName();
 		this.itemIDs = Collections.singletonList(item.getId());
 		this.details = item.getTooltip();
-		this.displayID = -1;
+		this.displayID = item.getId();
 		this.itemRequirement = item;
 	}
 }

--- a/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestBankTab.java
@@ -475,10 +475,6 @@ public class QuestBankTab
 			return;
 		}
 
-		Set<Integer> allIds = Arrays.stream(bankContainer.getItems())
-				.map(Item::getId)
-				.collect(Collectors.toCollection(LinkedHashSet::new));
-
 		Set<Integer> usedIds = newLayout.stream()
 				.flatMap(tab -> Stream.concat(
 						tab.getItems().stream().flatMap(item -> item.getItemIDs().stream()),
@@ -486,7 +482,10 @@ public class QuestBankTab
 				))
 				.collect(Collectors.toSet());
 
-		allIds.removeAll(usedIds);
+		Set<Integer> allIds = Arrays.stream(bankContainer.getItems())
+				.map(Item::getId)
+				.filter(id -> !usedIds.contains(id))
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 
 		BankTabItems leftoverTab = new BankTabItems("Non-quest items");
 		for (Integer id : allIds)

--- a/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
+++ b/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
@@ -117,6 +117,7 @@ public class QuestPerspective
 		List<LocalPoint> localPoints = new ArrayList<>();
 		for (WorldPoint worldPoint : instanceWorldPoint)
 		{
+			if (worldPoint == null) continue;
 			LocalPoint lp = LocalPoint.fromWorld(client.getTopLevelWorldView(), worldPoint);
 			if (lp != null)
 			{


### PR DESCRIPTION
This means in the quest bank, in addition to all the bank items in sections needed being listed, there will be an additional section for all the remaining items. This is mainly useful for the Check all items helper, as it lets you see the items you don't need for any remaining content. For other quests and helpers it's still useful for when you want to grab an additional item which isn't listed as part of the helper sections.