### PR TITLE
Refactor: Cleans up the access to runecrafting altars

### DIFF
--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1464,7 +1464,7 @@ public enum ItemCollections
 		ItemID.JEWL_BRACELET_OF_COMBAT
 	)),
 
-	DEATHALTAR(ImmutableList.of(
+	DEATH_ALTAR(ImmutableList.of(
 		ItemID.TIARA_DEATH,
 		ItemID.DEATH_TALISMAN
 	)),

--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1429,7 +1429,9 @@ public enum ItemCollections
 
 	DEATH_ALTAR(ImmutableList.of(
 		ItemID.TIARA_DEATH,
-		ItemID.DEATH_TALISMAN
+		ItemID.DEATH_TALISMAN,
+		ItemID.CATALYTIC_TALISMAN,
+		ItemID.TIARA_CATALYTIC
 	)),
 
 	PLUNDER_ARTEFACTS(ImmutableList.of(

--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1426,6 +1426,15 @@ public enum ItemCollections
 		ItemID.TIARA_CHAOS,
 		ItemID.CHAOS_TALISMAN
 	)),
+	NATURE_ALTAR_WEARABLE(ImmutableList.of(
+		ItemID.TIARA_CATALYTIC,
+		ItemID.TIARA_NATURE
+	)),
+	NATURE_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(NATURE_ALTAR_WEARABLE.getItems()).add(
+			ItemID.CATALYTIC_TALISMAN,
+			ItemID.NATURE_TALISMAN
+		).build()),
 
 	DEATH_ALTAR(ImmutableList.of(
 		ItemID.TIARA_DEATH,

--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1365,50 +1365,60 @@ public enum ItemCollections
 		.add(ItemID.WALLBEAST_SPIKE_HELMET)
 		.build()),
 
-	AIR_ALTAR(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
-		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.TIARA_AIR,
-		ItemID.AIR_TALISMAN
-	)),
-
 	AIR_ALTAR_WEARABLE(ImmutableList.of(
 		ItemID.TIARA_ELEMENTAL,
 		ItemID.TIARA_AIR
 	)),
-
-	WATER_ALTAR(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
+	AIR_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(AIR_ALTAR_WEARABLE.getItems()).add(
 		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.TIARA_WATER,
+		ItemID.AIR_TALISMAN
+	).build()),
+
+	WATER_ALTAR_WEARABLE(ImmutableList.of(
+		ItemID.TIARA_ELEMENTAL,
+		ItemID.TIARA_WATER
+	)),
+	WATER_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(WATER_ALTAR_WEARABLE.getItems()).add(
+		ItemID.ELEMENTAL_TALISMAN,
 		ItemID.WATER_TALISMAN
-	)),
+	).build()),
 
-	EARTH_ALTAR(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
-		ItemID.ELEMENTAL_TALISMAN,
+	EARTH_ALTAR_WEARABLE(ImmutableList.of(
 		ItemID.TIARA_EARTH,
-		ItemID.EARTH_TALISMAN
+		ItemID.TIARA_ELEMENTAL
 	)),
-
-	FIRE_ALTAR(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
+	EARTH_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(EARTH_ALTAR_WEARABLE.getItems()).add(
 		ItemID.ELEMENTAL_TALISMAN,
+		ItemID.EARTH_TALISMAN
+	).build()),
+
+	FIRE_ALTAR_WEARABLE(ImmutableList.of(
 		ItemID.TIARA_FIRE,
-		ItemID.FIRE_TALISMAN
+		ItemID.TIARA_ELEMENTAL
 	)),
+	FIRE_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(AIR_ALTAR_WEARABLE.getItems()).add(
+		ItemID.ELEMENTAL_TALISMAN,
+		ItemID.FIRE_TALISMAN
+	).build()),
 
 	MIND_ALTAR_WEARABLE(ImmutableList.of(
 		ItemID.TIARA_CATALYTIC,
-		ItemID.TIARA_COSMIC
+		ItemID.TIARA_MIND
 	)),
 
-	COSMIC_ALTAR(ImmutableList.of(
+	COSMIC_ALTAR_WEARABLE(ImmutableList.of(
 		ItemID.TIARA_CATALYTIC,
-		ItemID.CATALYTIC_TALISMAN,
-		ItemID.TIARA_COSMIC,
-		ItemID.COSMIC_TALISMAN
+		ItemID.TIARA_COSMIC
 	)),
+	COSMIC_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(COSMIC_ALTAR_WEARABLE.getItems()).add(
+		ItemID.CATALYTIC_TALISMAN,
+		ItemID.COSMIC_TALISMAN
+	).build()),
 
 	CHAOS_ALTAR(ImmutableList.of(
 		ItemID.TIARA_CATALYTIC,

--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1365,88 +1365,103 @@ public enum ItemCollections
 		.add(ItemID.WALLBEAST_SPIKE_HELMET)
 		.build()),
 
-	AIR_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
-		ItemID.TIARA_AIR
+	ALTAR_WEARABLE_COMMON(ImmutableList.of(
+		ItemID.SKILLCAPE_RUNECRAFTING,
+		ItemID.SKILLCAPE_RUNECRAFTING_TRIMMED
+		//Max Cape (+Variants) do not allow access to Altars
 	)),
+
+	AIR_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_ELEMENTAL,
+			ItemID.TIARA_AIR
+		).build()),
 	AIR_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(AIR_ALTAR_WEARABLE.getItems()).add(
-		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.AIR_TALISMAN
-	).build()),
+			ItemID.ELEMENTAL_TALISMAN,
+			ItemID.AIR_TALISMAN
+		).build()),
 
-	WATER_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
-		ItemID.TIARA_WATER
-	)),
+	WATER_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_ELEMENTAL,
+			ItemID.TIARA_WATER
+		).build()),
 	WATER_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(WATER_ALTAR_WEARABLE.getItems()).add(
-		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.WATER_TALISMAN
-	).build()),
+			ItemID.ELEMENTAL_TALISMAN,
+			ItemID.WATER_TALISMAN
+		).build()),
 
-	EARTH_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_EARTH,
-		ItemID.TIARA_ELEMENTAL
-	)),
+	EARTH_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_EARTH,
+			ItemID.TIARA_ELEMENTAL
+		).build()),
 	EARTH_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(EARTH_ALTAR_WEARABLE.getItems()).add(
-		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.EARTH_TALISMAN
-	).build()),
+			ItemID.ELEMENTAL_TALISMAN,
+			ItemID.EARTH_TALISMAN
+		).build()),
 
-	FIRE_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_FIRE,
-		ItemID.TIARA_ELEMENTAL
-	)),
+	FIRE_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_FIRE,
+			ItemID.TIARA_ELEMENTAL
+		).build()),
 	FIRE_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(AIR_ALTAR_WEARABLE.getItems()).add(
-		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.FIRE_TALISMAN
-	).build()),
+			ItemID.ELEMENTAL_TALISMAN,
+			ItemID.FIRE_TALISMAN
+		).build()),
 
-	MIND_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_CATALYTIC,
-		ItemID.TIARA_MIND
-	)),
+	MIND_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_CATALYTIC,
+			ItemID.TIARA_MIND
+		).build()),
 	MIND_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(MIND_ALTAR_WEARABLE.getItems()).add(
 			ItemID.CATALYTIC_TALISMAN,
 			ItemID.MIND_TALISMAN
-	).build()),
+		).build()),
 
-	COSMIC_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_CATALYTIC,
-		ItemID.TIARA_COSMIC
-	)),
+	COSMIC_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_CATALYTIC,
+			ItemID.TIARA_COSMIC
+		).build()),
 	COSMIC_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(COSMIC_ALTAR_WEARABLE.getItems()).add(
-		ItemID.CATALYTIC_TALISMAN,
-		ItemID.COSMIC_TALISMAN
-	).build()),
+			ItemID.CATALYTIC_TALISMAN,
+			ItemID.COSMIC_TALISMAN
+		).build()),
 
-	CHAOS_ALTAR(ImmutableList.of(
-		ItemID.TIARA_CATALYTIC,
-		ItemID.CATALYTIC_TALISMAN,
-		ItemID.TIARA_CHAOS,
-		ItemID.CHAOS_TALISMAN
-	)),
-	NATURE_ALTAR_WEARABLE(ImmutableList.of(
-		ItemID.TIARA_CATALYTIC,
-		ItemID.TIARA_NATURE
-	)),
+	CHAOS_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_CATALYTIC,
+			ItemID.CATALYTIC_TALISMAN,
+			ItemID.TIARA_CHAOS,
+			ItemID.CHAOS_TALISMAN
+		).build()),
+	NATURE_ALTAR_WEARABLE(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_CATALYTIC,
+			ItemID.TIARA_NATURE
+		).build()),
 	NATURE_ALTAR(new ImmutableList.Builder<Integer>()
 		.addAll(NATURE_ALTAR_WEARABLE.getItems()).add(
 			ItemID.CATALYTIC_TALISMAN,
 			ItemID.NATURE_TALISMAN
 		).build()),
 
-	DEATH_ALTAR(ImmutableList.of(
-		ItemID.TIARA_DEATH,
-		ItemID.DEATH_TALISMAN,
-		ItemID.CATALYTIC_TALISMAN,
-		ItemID.TIARA_CATALYTIC
-	)),
+	DEATH_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(ALTAR_WEARABLE_COMMON.getItems()).add(
+			ItemID.TIARA_DEATH,
+			ItemID.DEATH_TALISMAN,
+			ItemID.CATALYTIC_TALISMAN,
+			ItemID.TIARA_CATALYTIC
+		).build()),
 
 	PLUNDER_ARTEFACTS(ImmutableList.of(
 		ItemID.NTK_IVORY_COMB,
@@ -2229,7 +2244,7 @@ public enum ItemCollections
 		ItemID.CA_OFFHAND_MEDIUM,
 		ItemID.CA_OFFHAND_EASY
 	)),
-	
+
 	PROSPECTOR_HELMET(ImmutableList.of(
 		ItemID.MOTHERLODE_REWARD_HAT,
 		ItemID.FOSSIL_MOTHERLODE_REWARD_HAT,

--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1218,13 +1218,6 @@ public enum ItemCollections
 		ItemID.DRAMEN_STAFF
 	)),
 
-	EARTH_ALTAR(ImmutableList.of(
-		ItemID.TIARA_ELEMENTAL,
-		ItemID.ELEMENTAL_TALISMAN,
-		ItemID.TIARA_EARTH,
-		ItemID.EARTH_TALISMAN
-	)),
-
 	ESSENCE_LOW(ImmutableList.of(
 		ItemID.BLANKRUNE_DAEYALT,
 		ItemID.BLANKRUNE_HIGH,
@@ -1367,17 +1360,22 @@ public enum ItemCollections
 		ItemID.SKILLCAPE_QP
 	)),
 
-	COSMIC_ALTAR(ImmutableList.of(
-		ItemID.TIARA_CATALYTIC,
-		ItemID.CATALYTIC_TALISMAN,
-		ItemID.TIARA_COSMIC,
-		ItemID.COSMIC_TALISMAN
-	)),
-
 	WALL_BEAST(new ImmutableList.Builder<Integer>()
 		.addAll(SharedCollections.slayer_helmets)
 		.add(ItemID.WALLBEAST_SPIKE_HELMET)
 		.build()),
+
+	AIR_ALTAR(ImmutableList.of(
+		ItemID.TIARA_ELEMENTAL,
+		ItemID.ELEMENTAL_TALISMAN,
+		ItemID.TIARA_AIR,
+		ItemID.AIR_TALISMAN
+	)),
+
+	AIR_ALTAR_WEARABLE(ImmutableList.of(
+		ItemID.TIARA_ELEMENTAL,
+		ItemID.TIARA_AIR
+	)),
 
 	WATER_ALTAR(ImmutableList.of(
 		ItemID.TIARA_ELEMENTAL,
@@ -1386,11 +1384,42 @@ public enum ItemCollections
 		ItemID.WATER_TALISMAN
 	)),
 
+	EARTH_ALTAR(ImmutableList.of(
+		ItemID.TIARA_ELEMENTAL,
+		ItemID.ELEMENTAL_TALISMAN,
+		ItemID.TIARA_EARTH,
+		ItemID.EARTH_TALISMAN
+	)),
+
 	FIRE_ALTAR(ImmutableList.of(
 		ItemID.TIARA_ELEMENTAL,
 		ItemID.ELEMENTAL_TALISMAN,
 		ItemID.TIARA_FIRE,
 		ItemID.FIRE_TALISMAN
+	)),
+
+	MIND_ALTAR_WEARABLE(ImmutableList.of(
+		ItemID.TIARA_CATALYTIC,
+		ItemID.TIARA_COSMIC
+	)),
+
+	COSMIC_ALTAR(ImmutableList.of(
+		ItemID.TIARA_CATALYTIC,
+		ItemID.CATALYTIC_TALISMAN,
+		ItemID.TIARA_COSMIC,
+		ItemID.COSMIC_TALISMAN
+	)),
+
+	CHAOS_ALTAR(ImmutableList.of(
+		ItemID.TIARA_CATALYTIC,
+		ItemID.CATALYTIC_TALISMAN,
+		ItemID.TIARA_CHAOS,
+		ItemID.CHAOS_TALISMAN
+	)),
+
+	DEATH_ALTAR(ImmutableList.of(
+		ItemID.TIARA_DEATH,
+		ItemID.DEATH_TALISMAN
 	)),
 
 	PLUNDER_ARTEFACTS(ImmutableList.of(
@@ -1462,11 +1491,6 @@ public enum ItemCollections
 		ItemID.JEWL_BRACELET_OF_COMBAT_1,
 		ItemID.JEWL_NECKLACE_OF_SKILLS,
 		ItemID.JEWL_BRACELET_OF_COMBAT
-	)),
-
-	DEATH_ALTAR(ImmutableList.of(
-		ItemID.TIARA_DEATH,
-		ItemID.DEATH_TALISMAN
 	)),
 
 	IMBUABLE_SALVE_AMULET(ImmutableList.of(
@@ -1546,13 +1570,6 @@ public enum ItemCollections
 		ItemID.WILDERNESS_CAPE_48,
 		ItemID.WILDERNESS_CAPE_49,
 		ItemID.WILDERNESS_CAPE_50
-	)),
-
-	CHAOS_ALTAR(ImmutableList.of(
-		ItemID.TIARA_CATALYTIC,
-		ItemID.CATALYTIC_TALISMAN,
-		ItemID.TIARA_CHAOS,
-		ItemID.CHAOS_TALISMAN
 	)),
 
 	RUNE_AXE_BETTER(ImmutableList.of(

--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1409,6 +1409,11 @@ public enum ItemCollections
 		ItemID.TIARA_CATALYTIC,
 		ItemID.TIARA_MIND
 	)),
+	MIND_ALTAR(new ImmutableList.Builder<Integer>()
+		.addAll(MIND_ALTAR_WEARABLE.getItems()).add(
+			ItemID.CATALYTIC_TALISMAN,
+			ItemID.MIND_TALISMAN
+	).build()),
 
 	COSMIC_ALTAR_WEARABLE(ImmutableList.of(
 		ItemID.TIARA_CATALYTIC,

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
@@ -178,9 +178,9 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		lockpick = new ItemRequirement("Lockpick", ItemID.LOCKPICK).showConditioned(notStealChest).isNotConsumed();
 		shieldLeft = new ItemRequirement("Shield left half", ItemID.DRAGONSHIELD_A).showConditioned(notDragSquare);
 		shieldRight = new ItemRequirement("Shield right half", ItemID.DRAGONSHIELD_B).showConditioned(notDragSquare);
-		deathAccess = new ItemRequirement("Access to Death altar, or travel through abyss",
+		deathAccess = new ItemRequirement("Access to the Death Altar",
 			ItemCollections.DEATH_ALTAR).showConditioned(notDeathRune).isNotConsumed();
-		deathAccess.setTooltip("Death talisman or tiara");
+		deathAccess.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss");
 		crystalTrink = new ItemRequirement("Crystal Trinket", ItemID.MOURNING_CRYSTAL_TRINKET).showConditioned(notDeathRune).isNotConsumed();
 		highEss = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.ESSENCE_HIGH)
 			.showConditioned(notDeathRune);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
@@ -179,7 +179,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		shieldLeft = new ItemRequirement("Shield left half", ItemID.DRAGONSHIELD_A).showConditioned(notDragSquare);
 		shieldRight = new ItemRequirement("Shield right half", ItemID.DRAGONSHIELD_B).showConditioned(notDragSquare);
 		deathAccess = new ItemRequirement("Access to Death altar, or travel through abyss",
-			ItemCollections.DEATHALTAR).showConditioned(notDeathRune).isNotConsumed();
+			ItemCollections.DEATH_ALTAR).showConditioned(notDeathRune).isNotConsumed();
 		deathAccess.setTooltip("Death talisman or tiara");
 		crystalTrink = new ItemRequirement("Crystal Trinket", ItemID.MOURNING_CRYSTAL_TRINKET).showConditioned(notDeathRune).isNotConsumed();
 		highEss = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.ESSENCE_HIGH)

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
@@ -180,7 +180,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 		shieldRight = new ItemRequirement("Shield right half", ItemID.DRAGONSHIELD_B).showConditioned(notDragSquare);
 		deathAccess = new ItemRequirement("Access to the Death Altar",
 			ItemCollections.DEATH_ALTAR).showConditioned(notDeathRune).isNotConsumed();
-		deathAccess.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss");
+		deathAccess.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or via Abyss");
 		crystalTrink = new ItemRequirement("Crystal Trinket", ItemID.MOURNING_CRYSTAL_TRINKET).showConditioned(notDeathRune).isNotConsumed();
 		highEss = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.ESSENCE_HIGH)
 			.showConditioned(notDeathRune);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorElite.java
@@ -136,7 +136,8 @@ public class FaladorElite extends ComplexStateQuestHelper
 		notMadeSaraBrew = new VarplayerRequirement(VarPlayerID.FALADOR_ACHIEVEMENT_DIARY2, false, 10);
 
 		pureEss28 = new ItemRequirement("Pure Essence", ItemID.BLANKRUNE_HIGH, 28).showConditioned(notCraftedAirRunes);
-		airTiara = new ItemRequirement("Air Tiara", ItemID.TIARA_AIR, 1, true).showConditioned(notCraftedAirRunes).isNotConsumed();
+		airTiara = new ItemRequirement("Access to the Air Altar", ItemCollections.AIR_ALTAR_WEARABLE, 1, true).showConditioned(notCraftedAirRunes).isNotConsumed();
+		airTiara.setTooltip("Air tiara, Elemental Tiara, or via Abyss");
 		coins1920 = new ItemRequirement("Coins", ItemCollections.COINS, 1920).showConditioned(notPurchasedWhite2hSword);
 		spade = new ItemRequirement("Spade", ItemID.SPADE).showConditioned(notGotMagicRoots).isNotConsumed();
 		axe = new ItemRequirement("Any Axe", ItemCollections.AXES).showConditioned(notGotMagicRoots).isNotConsumed();
@@ -304,8 +305,10 @@ public class FaladorElite extends ComplexStateQuestHelper
 		magicRootsSteps.setLockingStep(gotMagicRootsTask);
 		allSteps.add(magicRootsSteps);
 
+		SkillRequirement rcRequirement = new SkillRequirement(Skill.RUNECRAFT, 88, true);
+		rcRequirement.setTooltip("55 with Raiments of the Eye set");
 		PanelDetails airRunesSteps = new PanelDetails("One with the wind..", Arrays.asList(enterAirAltar,
-			craftAirRunes), new SkillRequirement(Skill.RUNECRAFT, 88, true), airTiara, pureEss28);
+			craftAirRunes), rcRequirement, airTiara, pureEss28);
 		airRunesSteps.setDisplayCondition(notCraftedAirRunes);
 		airRunesSteps.setLockingStep(craftedAirRunesTask);
 		allSteps.add(airRunesSteps);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorElite.java
@@ -137,7 +137,7 @@ public class FaladorElite extends ComplexStateQuestHelper
 
 		pureEss28 = new ItemRequirement("Pure Essence", ItemID.BLANKRUNE_HIGH, 28).showConditioned(notCraftedAirRunes);
 		airTiara = new ItemRequirement("Access to the Air Altar", ItemCollections.AIR_ALTAR_WEARABLE, 1, true).showConditioned(notCraftedAirRunes).isNotConsumed();
-		airTiara.setTooltip("Air tiara, Elemental Tiara, or via Abyss");
+		airTiara.setTooltip("Air tiara, Elemental Tiara, RC-skill cape or via Abyss");
 		coins1920 = new ItemRequirement("Coins", ItemCollections.COINS, 1920).showConditioned(notPurchasedWhite2hSword);
 		spade = new ItemRequirement("Spade", ItemID.SPADE).showConditioned(notGotMagicRoots).isNotConsumed();
 		axe = new ItemRequirement("Any Axe", ItemCollections.AXES).showConditioned(notGotMagicRoots).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
@@ -164,7 +164,8 @@ public class FaladorHard extends ComplexStateQuestHelper
 		notDwarvenHelmetDwarvenMines = new VarplayerRequirement(VarPlayerID.FALADOR_ACHIEVEMENT_DIARY2, false, 4);
 
 		pureEss28 = new ItemRequirement("Pure Essence", ItemID.BLANKRUNE_HIGH, 28).showConditioned(notCraftedMindRunes);
-		mindTiara = new ItemRequirement("Mind Tiara", ItemID.TIARA_MIND, 1, true).showConditioned(notCraftedMindRunes);
+		mindTiara = new ItemRequirement("Access to the Mind Altar", ItemCollections.MIND_ALTAR_WEARABLE, 1, true).showConditioned(notCraftedMindRunes);
+		mindTiara.setTooltip("Mind Tiara, Elemental Tiara, or via Abyss");
 		coins10000 = new ItemRequirement("Coins", ItemCollections.COINS, 10000).showConditioned(notChangedFamilyCrest);
 		combatGear = new ItemRequirement("Combat Gear", -1, -1).isNotConsumed();
 		food = new ItemRequirement("Good healing food.", ItemCollections.GOOD_EATING_FOOD, -1);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
@@ -165,7 +165,7 @@ public class FaladorHard extends ComplexStateQuestHelper
 
 		pureEss28 = new ItemRequirement("Pure Essence", ItemID.BLANKRUNE_HIGH, 28).showConditioned(notCraftedMindRunes);
 		mindTiara = new ItemRequirement("Access to the Mind Altar", ItemCollections.MIND_ALTAR_WEARABLE, 1, true).showConditioned(notCraftedMindRunes);
-		mindTiara.setTooltip("Mind Tiara, Elemental Tiara, or via Abyss");
+		mindTiara.setTooltip("Mind Tiara, Catalytic Tiara, or via Abyss");
 		coins10000 = new ItemRequirement("Coins", ItemCollections.COINS, 10000).showConditioned(notChangedFamilyCrest);
 		combatGear = new ItemRequirement("Combat Gear", -1, -1).isNotConsumed();
 		food = new ItemRequirement("Good healing food.", ItemCollections.GOOD_EATING_FOOD, -1);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
@@ -165,7 +165,7 @@ public class FaladorHard extends ComplexStateQuestHelper
 
 		pureEss28 = new ItemRequirement("Pure Essence", ItemID.BLANKRUNE_HIGH, 28).showConditioned(notCraftedMindRunes);
 		mindTiara = new ItemRequirement("Access to the Mind Altar", ItemCollections.MIND_ALTAR_WEARABLE, 1, true).showConditioned(notCraftedMindRunes);
-		mindTiara.setTooltip("Mind Tiara, Catalytic Tiara, or via Abyss");
+		mindTiara.setTooltip("Mind Tiara, Catalytic Tiara, RC-skill cape or via Abyss");
 		coins10000 = new ItemRequirement("Coins", ItemCollections.COINS, 10000).showConditioned(notChangedFamilyCrest);
 		combatGear = new ItemRequirement("Combat Gear", -1, -1).isNotConsumed();
 		food = new ItemRequirement("Good healing food.", ItemCollections.GOOD_EATING_FOOD, -1);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaElite.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.helpers.achievementdiaries.karamja;
 
+import com.questhelper.collections.ItemCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.ComplexStateQuestHelper;
 import com.questhelper.requirements.Requirement;
@@ -106,8 +107,8 @@ public class KaramjaElite extends ComplexStateQuestHelper
 		notMadePotion = new VarplayerRequirement(VarPlayerID.ATJUN_TASKS_4, false, 4);
 		notCheckedCalquat = new VarplayerRequirement(VarPlayerID.ATJUN_TASKS_4, false, 5);
 
-		natureTiaraOrAbyss = new ItemRequirement("Nature tiara, or access to nature altar through the Abyss",
-			ItemID.TIARA_NATURE).showConditioned(notCraftedRunes).isNotConsumed();
+		natureTiaraOrAbyss = new ItemRequirement("Access to the Nature Altar", ItemCollections.NATURE_ALTAR_WEARABLE).showConditioned(notCraftedRunes).isNotConsumed();
+		natureTiaraOrAbyss.setTooltip("Nature Tiara, Catalytic Tiara or via Abyss");
 		pureEssence = new ItemRequirement("Pure essence", ItemID.BLANKRUNE_HIGH).showConditioned(notCraftedRunes);
 		fireCapeOrInfernal = new ItemRequirement("Fire cape or infernal cape", ItemID.TZHAAR_CAPE_FIRE)
 			.showConditioned(notEquippedCape).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaElite.java
@@ -108,7 +108,7 @@ public class KaramjaElite extends ComplexStateQuestHelper
 		notCheckedCalquat = new VarplayerRequirement(VarPlayerID.ATJUN_TASKS_4, false, 5);
 
 		natureTiaraOrAbyss = new ItemRequirement("Access to the Nature Altar", ItemCollections.NATURE_ALTAR_WEARABLE).showConditioned(notCraftedRunes).isNotConsumed();
-		natureTiaraOrAbyss.setTooltip("Nature Tiara, Catalytic Tiara or via Abyss");
+		natureTiaraOrAbyss.setTooltip("Nature Tiara, Catalytic Tiara, RC-skill cape or via Abyss");
 		pureEssence = new ItemRequirement("Pure essence", ItemID.BLANKRUNE_HIGH).showConditioned(notCraftedRunes);
 		fireCapeOrInfernal = new ItemRequirement("Fire cape or infernal cape", ItemID.TZHAAR_CAPE_FIRE)
 			.showConditioned(notEquippedCape).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaHard.java
@@ -168,7 +168,7 @@ public class KaramjaHard extends ComplexStateQuestHelper
 		pureEssence = new ItemRequirement("Pure essence", ItemID.BLANKRUNE_HIGH).showConditioned(notCraftedNature);
 		natureTalismanOrAbyss = new ItemRequirement("Access to the Nature Altar", ItemCollections.NATURE_ALTAR)
 			.showConditioned(notCraftedNature).isNotConsumed();
-		natureTalismanOrAbyss.setTooltip("Nature Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss");
+		natureTalismanOrAbyss.setTooltip("Nature Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or via Abyss");
 		rawKarambwan = new ItemRequirement("Raw karambwan", ItemID.TBWT_RAW_KARAMBWAN).showConditioned(notCookedKarambwan);
 		axe = new ItemRequirement("Any axe", ItemCollections.AXES).showConditioned(new Conditions(LogicType.OR,
 			notCollectedLeaves, notKilledDeathwing, notKilledDragon)).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/karamja/KaramjaHard.java
@@ -166,10 +166,9 @@ public class KaramjaHard extends ComplexStateQuestHelper
 		oomlieWrap.setTooltip("You can make one by using a palm leaf on a raw oomlie and cooking it. Both are " +
 			"obtained from the Kharazi Jungle");
 		pureEssence = new ItemRequirement("Pure essence", ItemID.BLANKRUNE_HIGH).showConditioned(notCraftedNature);
-		natureTalismanOrAbyss = new ItemRequirement("Access to the Nature Altar", ItemID.NATURE_TALISMAN)
+		natureTalismanOrAbyss = new ItemRequirement("Access to the Nature Altar", ItemCollections.NATURE_ALTAR)
 			.showConditioned(notCraftedNature).isNotConsumed();
-		natureTalismanOrAbyss.addAlternates(ItemID.TIARA_NATURE);
-		natureTalismanOrAbyss.setTooltip("Nature talisman or tiara");
+		natureTalismanOrAbyss.setTooltip("Nature Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss");
 		rawKarambwan = new ItemRequirement("Raw karambwan", ItemID.TBWT_RAW_KARAMBWAN).showConditioned(notCookedKarambwan);
 		axe = new ItemRequirement("Any axe", ItemCollections.AXES).showConditioned(new Conditions(LogicType.OR,
 			notCollectedLeaves, notKilledDeathwing, notKilledDragon)).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
@@ -162,9 +162,9 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		rope = new ItemRequirement("Rope", ItemID.ROPE).showConditioned(notKillCaveBug);
 		spinyHelm = new ItemRequirement("Spiny helmet or slayer helmet (Recommended for low combat levels / Ironmen)",
 			ItemCollections.WALL_BEAST).showConditioned(notKillCaveBug).isNotConsumed();
-		waterAccessOrAbyss = new ItemRequirement("Access to water altar, or travel through abyss.",
+		waterAccessOrAbyss = new ItemRequirement("Access to Water Altar",
 			ItemCollections.WATER_ALTAR).showConditioned(notWaterRune).isNotConsumed();
-		waterAccessOrAbyss.setTooltip("Water talisman or tiara");
+		waterAccessOrAbyss.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
 		runeEss = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(notWaterRune);
 		dough = new ItemRequirement("Bread dough", ItemID.BREAD_DOUGH).showConditioned(notBread);
 		oakLogs = new ItemRequirement("Oak logs", ItemID.OAK_LOGS).showConditioned(notOak);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
@@ -162,9 +162,9 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		rope = new ItemRequirement("Rope", ItemID.ROPE).showConditioned(notKillCaveBug);
 		spinyHelm = new ItemRequirement("Spiny helmet or slayer helmet (Recommended for low combat levels / Ironmen)",
 			ItemCollections.WALL_BEAST).showConditioned(notKillCaveBug).isNotConsumed();
-		waterAccessOrAbyss = new ItemRequirement("Access to Water Altar",
+		waterAccessOrAbyss = new ItemRequirement("Access to the Water Altar",
 			ItemCollections.WATER_ALTAR).showConditioned(notWaterRune).isNotConsumed();
-		waterAccessOrAbyss.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
+		waterAccessOrAbyss.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss");
 		runeEss = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(notWaterRune);
 		dough = new ItemRequirement("Bread dough", ItemID.BREAD_DOUGH).showConditioned(notBread);
 		oakLogs = new ItemRequirement("Oak logs", ItemID.OAK_LOGS).showConditioned(notOak);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -143,7 +143,7 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notAddyPlatebody).isNotConsumed();
 		essence = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(notWaterRunes);
 		waterAccessOrAbyss = new ItemRequirement("Access to the Water Altar", ItemCollections.WATER_ALTAR_WEARABLE).showConditioned(notWaterRunes).isNotConsumed();
-		waterAccessOrAbyss.setTooltip("Water Tiara, Elemental Tiara, or via Abyss");
+		waterAccessOrAbyss.setTooltip("Water Tiara, Elemental Tiara, RC-skill cape or via Abyss");
 		qcCape = new ItemRequirement("Quest cape", ItemCollections.QUEST_CAPE).showConditioned(notQCEmote).isNotConsumed();
 		dorgSphere = new ItemRequirement("Dorgesh-kaan Sphere", ItemID.DORGESH_TELEPORT_ARTIFACT)
 			.showConditioned(new Conditions(notMovario, notRichChest));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeElite.java
@@ -142,9 +142,8 @@ public class LumbridgeElite extends ComplexStateQuestHelper
 		addyBar = new ItemRequirement("Adamantite bar", ItemID.ADAMANTITE_BAR).showConditioned(notAddyPlatebody);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notAddyPlatebody).isNotConsumed();
 		essence = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(notWaterRunes);
-		waterAccessOrAbyss = new ItemRequirement("Access to water altar, or travel through abyss",
-			ItemID.TIARA_WATER).showConditioned(notWaterRunes).isNotConsumed();
-		waterAccessOrAbyss.setTooltip("Water talisman or tiara");
+		waterAccessOrAbyss = new ItemRequirement("Access to the Water Altar", ItemCollections.WATER_ALTAR_WEARABLE).showConditioned(notWaterRunes).isNotConsumed();
+		waterAccessOrAbyss.setTooltip("Water Tiara, Elemental Tiara, or via Abyss");
 		qcCape = new ItemRequirement("Quest cape", ItemCollections.QUEST_CAPE).showConditioned(notQCEmote).isNotConsumed();
 		dorgSphere = new ItemRequirement("Dorgesh-kaan Sphere", ItemID.DORGESH_TELEPORT_ARTIFACT)
 			.showConditioned(new Conditions(notMovario, notRichChest));

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -191,7 +191,7 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		essence = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.ESSENCE_HIGH, 28).showConditioned(notCosmics);
 		cosmicAccessOrAbyss = new ItemRequirement("Access to the Cosmic Altar",
 			ItemCollections.COSMIC_ALTAR).showConditioned(notCosmics).isNotConsumed();
-		cosmicAccessOrAbyss.setTooltip("Cosmic Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss");
+		cosmicAccessOrAbyss.setTooltip("Cosmic Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or via Abyss");
 		bellaSeed = new ItemRequirement("Belladonna seed", ItemID.BELLADONNA_SEED).showConditioned(notBelladonna);
 		seedDib = new ItemRequirement("Seed dibber", ItemID.DIBBER).showConditioned(notBelladonna).isNotConsumed();
 		spade = new ItemRequirement("Spade", ItemID.SPADE).showConditioned(notBelladonna).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -189,9 +189,9 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 		gamesNeck = new ItemRequirement("Games Necklace", ItemCollections.GAMES_NECKLACES).showConditioned(notHundredTears);
 		dorgSphere = new ItemRequirement("Dorgesh-kaan Sphere", ItemID.DORGESH_TELEPORT_ARTIFACT).showConditioned(notTrainToKeld);
 		essence = new ItemRequirement("Pure or Daeyalt essence", ItemCollections.ESSENCE_HIGH, 28).showConditioned(notCosmics);
-		cosmicAccessOrAbyss = new ItemRequirement("Access to cosmic altar, or travel through abyss. Tiara recommended unless using essence pouches",
+		cosmicAccessOrAbyss = new ItemRequirement("Access to the Cosmic Altar",
 			ItemCollections.COSMIC_ALTAR).showConditioned(notCosmics).isNotConsumed();
-		cosmicAccessOrAbyss.setTooltip("Cosmic talisman or tiara");
+		cosmicAccessOrAbyss.setTooltip("Cosmic Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss");
 		bellaSeed = new ItemRequirement("Belladonna seed", ItemID.BELLADONNA_SEED).showConditioned(notBelladonna);
 		seedDib = new ItemRequirement("Seed dibber", ItemID.DIBBER).showConditioned(notBelladonna).isNotConsumed();
 		spade = new ItemRequirement("Spade", ItemID.SPADE).showConditioned(notBelladonna).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
@@ -157,12 +157,14 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		crossbow = new ItemRequirement("A crossbow", ItemCollections.CROSSBOWS).showConditioned(notGrappleLum).isNotConsumed();
 		mithGrap = new ItemRequirement("Mith grapple", ItemID.XBOWS_GRAPPLE_TIP_BOLT_MITHRIL_ROPE).showConditioned(notGrappleLum).isNotConsumed();
 		earthTali = new ItemRequirement("Earth talisman", ItemID.EARTH_TALISMAN).showConditioned(notCraftLava);
+		earthTali.setTooltip("Alternatively, Level 82 Magic and access to Lunar Spellbook for Magic Imbue");
 		fireAccess = new ItemRequirement("Access to fire altar", ItemCollections.FIRE_ALTAR).showConditioned(notCraftLava).isNotConsumed();
-		fireAccess.setTooltip("Fire talisman or tiara");
+		fireAccess.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
 		earthRune = new ItemRequirement("Earth rune", ItemID.EARTHRUNE)
 			.showConditioned(new Conditions(LogicType.OR, notCraftLava, notTPlumb));
 		essence = new ItemRequirement("Pure essence", ItemCollections.ESSENCE_HIGH).showConditioned(notCraftLava);
 		bindingNeck = new ItemRequirement("Binding necklace", ItemID.MAGIC_EMERALD_NECKLACE).showConditioned(notCraftLava);
+		bindingNeck.setTooltip("Optional but advisable.");
 		feathers = new ItemRequirement("Feathers", ItemID.FEATHER).showConditioned(notCatchSalmon);
 		flyFishingRod = new ItemRequirement("Fly fishing rod", ItemID.FLY_FISHING_ROD).showConditioned(notCatchSalmon).isNotConsumed();
 		needle = new ItemRequirement("Needle", ItemID.NEEDLE).showConditioned(notCraftCoif).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeMedium.java
@@ -158,8 +158,8 @@ public class LumbridgeMedium extends ComplexStateQuestHelper
 		mithGrap = new ItemRequirement("Mith grapple", ItemID.XBOWS_GRAPPLE_TIP_BOLT_MITHRIL_ROPE).showConditioned(notGrappleLum).isNotConsumed();
 		earthTali = new ItemRequirement("Earth talisman", ItemID.EARTH_TALISMAN).showConditioned(notCraftLava);
 		earthTali.setTooltip("Alternatively, Level 82 Magic and access to Lunar Spellbook for Magic Imbue");
-		fireAccess = new ItemRequirement("Access to fire altar", ItemCollections.FIRE_ALTAR).showConditioned(notCraftLava).isNotConsumed();
-		fireAccess.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
+		fireAccess = new ItemRequirement("Access to the Fire Altar", ItemCollections.FIRE_ALTAR).showConditioned(notCraftLava).isNotConsumed();
+		fireAccess.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss");
 		earthRune = new ItemRequirement("Earth rune", ItemID.EARTHRUNE)
 			.showConditioned(new Conditions(LogicType.OR, notCraftLava, notTPlumb));
 		essence = new ItemRequirement("Pure essence", ItemCollections.ESSENCE_HIGH).showConditioned(notCraftLava);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
@@ -165,7 +165,7 @@ public class VarrockEasy extends ComplexStateQuestHelper
 		softClay = new ItemRequirement("Soft clay", ItemID.SOFTCLAY).showConditioned(notBowl);
 		earthTali = new ItemRequirement("Access to the Earth Altar", ItemCollections.EARTH_ALTAR)
 			.showConditioned(notEarthRune).isNotConsumed();
-		earthTali.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
+		earthTali.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss");
 		essence = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(notEarthRune);
 		flyRod = new ItemRequirement("Fly fishing rod", ItemID.FLY_FISHING_ROD).showConditioned(notTrout).isNotConsumed();
 		feathers = new ItemRequirement("Feather", ItemID.FEATHER, 10).showConditioned(notTrout);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
@@ -163,9 +163,9 @@ public class VarrockEasy extends ComplexStateQuestHelper
 		axe = new ItemRequirement("Any axe", ItemCollections.AXES).showConditioned(notDyingTree).isNotConsumed();
 		bone = new ItemRequirement("Bones", ItemCollections.BONES).showConditioned(notDogBone);
 		softClay = new ItemRequirement("Soft clay", ItemID.SOFTCLAY).showConditioned(notBowl);
-		earthTali = new ItemRequirement("Access to Earth altar, or travel through abyss", ItemCollections.EARTH_ALTAR)
+		earthTali = new ItemRequirement("Access to the Earth Altar", ItemCollections.EARTH_ALTAR)
 			.showConditioned(notEarthRune).isNotConsumed();
-		earthTali.setTooltip("Earth talisman or tiara");
+		earthTali.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
 		essence = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(notEarthRune);
 		flyRod = new ItemRequirement("Fly fishing rod", ItemID.FLY_FISHING_ROD).showConditioned(notTrout).isNotConsumed();
 		feathers = new ItemRequirement("Feather", ItemID.FEATHER, 10).showConditioned(notTrout);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
@@ -140,7 +140,7 @@ public class VarrockElite extends ComplexStateQuestHelper
 		essence = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(not100Earth);
 		earthTali = new ItemRequirement("Access to the Earth Altar",
 			ItemCollections.EARTH_ALTAR).showConditioned(not100Earth).isNotConsumed();
-		earthTali.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
+		earthTali.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss");
 
 		inBank = new ZoneRequirement(bank);
 		inLumb = new ZoneRequirement(lumb);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
@@ -138,9 +138,9 @@ public class VarrockElite extends ComplexStateQuestHelper
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notRuneDart).isNotConsumed();
 		runeDartTip = new ItemRequirement("Rune dart tip", ItemID.RUNE_DART_TIP);
 		essence = new ItemRequirement("Essence", ItemCollections.ESSENCE_LOW).showConditioned(not100Earth);
-		earthTali = new ItemRequirement("Access to Earth altar, or travel through abyss",
+		earthTali = new ItemRequirement("Access to the Earth Altar",
 			ItemCollections.EARTH_ALTAR).showConditioned(not100Earth).isNotConsumed();
-		earthTali.setTooltip("Earth talisman or tiara");
+		earthTali.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss");
 
 		inBank = new ZoneRequirement(bank);
 		inLumb = new ZoneRequirement(lumb);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessEasy.java
@@ -154,8 +154,9 @@ public class WildernessEasy extends ComplexStateQuestHelper
 		firstTimeAbyss = new VarbitRequirement(626, 1);
 		normalBook = new SpellbookRequirement(Spellbook.NORMAL);
 
-		chaosAccess = new ItemRequirement("Access to Chaos altar, or travel through abyss",
+		chaosAccess = new ItemRequirement("Access to the Chaos altar",
 			ItemCollections.CHAOS_ALTAR).showConditioned(notChaosTemple).isNotConsumed();
+		chaosAccess.setTooltip("Chaos Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or travel through Abyss");
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES).showConditioned(notIronOre).isNotConsumed();
 		teamCape = new ItemRequirement("Any team cape", ItemCollections.TEAM_CAPE).showConditioned(notEquipTeamCape).isNotConsumed();
 		redSpiderEggs = new ItemRequirement("Red spider eggs", ItemID.RED_SPIDERS_EGGS).showConditioned(notSpiderEggs);

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
@@ -361,16 +361,16 @@ public class LunarDiplomacy extends BasicQuestHelper
 		pestle.setHighlightInInventory(true);
 
 		airTalisman = new ItemRequirement("Access to the Air Altar", ItemCollections.AIR_ALTAR).isNotConsumed();
-		airTalisman.setTooltip("Air Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		airTalisman.setTooltip("Air Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		fireTalisman = new ItemRequirement("Access to the Fire Altar", ItemCollections.FIRE_ALTAR).isNotConsumed();
-		fireTalisman.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		fireTalisman.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		earthTalisman = new ItemRequirement("Access to the Earth Altar", ItemCollections.EARTH_ALTAR).isNotConsumed();
-		earthTalisman.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		earthTalisman.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		waterTalisman = new ItemRequirement("Access to the Water Altar", ItemCollections.WATER_ALTAR).isNotConsumed();
-		waterTalisman.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		waterTalisman.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		dramenStaff = new ItemRequirement("Dramen staff", ItemID.DRAMEN_STAFF).isNotConsumed();
 		dramenStaff.setTooltip("You can get another from under Entrana");

--- a/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
+++ b/src/main/java/com/questhelper/helpers/quests/lunardiplomacy/LunarDiplomacy.java
@@ -360,17 +360,17 @@ public class LunarDiplomacy extends BasicQuestHelper
 		pestle = new ItemRequirement("Pestle and mortar", ItemID.PESTLE_AND_MORTAR).isNotConsumed();
 		pestle.setHighlightInInventory(true);
 
-		airTalisman = new ItemRequirement("Air talisman/tiara, or access via the Abyss", ItemID.AIR_TALISMAN).isNotConsumed();
-		airTalisman.addAlternates(ItemID.TIARA_AIR, ItemID.ELEMENTAL_TALISMAN);
+		airTalisman = new ItemRequirement("Access to the Air Altar", ItemCollections.AIR_ALTAR).isNotConsumed();
+		airTalisman.setTooltip("Air Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		fireTalisman = new ItemRequirement("Fire talisman/tiara, or access via the Abyss", ItemID.FIRE_TALISMAN).isNotConsumed();
-		fireTalisman.addAlternates(ItemID.TIARA_FIRE, ItemID.ELEMENTAL_TALISMAN);
+		fireTalisman = new ItemRequirement("Access to the Fire Altar", ItemCollections.FIRE_ALTAR).isNotConsumed();
+		fireTalisman.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		earthTalisman = new ItemRequirement("Earth talisman/tiara, or access via the Abyss", ItemID.EARTH_TALISMAN).isNotConsumed();
-		earthTalisman.addAlternates(ItemID.TIARA_EARTH, ItemID.ELEMENTAL_TALISMAN);
+		earthTalisman = new ItemRequirement("Access to the Earth Altar", ItemCollections.EARTH_ALTAR).isNotConsumed();
+		earthTalisman.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		waterTalisman = new ItemRequirement("Water talisman/tiara, or access via the Abyss", ItemID.WATER_TALISMAN).isNotConsumed();
-		waterTalisman.addAlternates(ItemID.TIARA_WATER, ItemID.ELEMENTAL_TALISMAN);
+		waterTalisman = new ItemRequirement("Access to the Water Altar", ItemCollections.WATER_ALTAR).isNotConsumed();
+		waterTalisman.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
 		dramenStaff = new ItemRequirement("Dramen staff", ItemID.DRAMEN_STAFF).isNotConsumed();
 		dramenStaff.setTooltip("You can get another from under Entrana");

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -397,10 +397,10 @@ public class MourningsEndPartII extends BasicQuestHelper
 	protected void setupRequirements()
 	{
 		deathTalisman = new ItemRequirement("Access to the Death Altar", ItemCollections.DEATH_ALTAR).isNotConsumed();
-		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara");
+		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara or RC-skill cape");
 		deathTalisman.appendToTooltip("or bring the dwarf the 50 items asked later");
 		deathTalismanHeader = new ItemRequirement("Access to Death Altar or 50 items asked of you by a dwarf", ItemCollections.DEATH_ALTAR).isNotConsumed();
-		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara");
+		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara or RC-skill cape");
 
 		mournerBoots = new ItemRequirement("Mourner boots", ItemID.MOURNING_MOURNER_BOOTS, 1, true).isNotConsumed().highlighted();
 		gasMask = new ItemRequirement("Gas mask", ItemID.GASMASK, 1, true).isNotConsumed().highlighted();

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -399,7 +399,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 		deathTalisman = new ItemRequirement("Access to the Death Altar", ItemCollections.DEATH_ALTAR).isNotConsumed();
 		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara or RC-skill cape");
 		deathTalisman.appendToTooltip("or bring the dwarf the 50 items asked later");
-		deathTalismanHeader = new ItemRequirement("Access to Death Altar or 50 items asked of you by a dwarf", ItemCollections.DEATH_ALTAR).isNotConsumed();
+		deathTalismanHeader = new ItemRequirement("Access to the Death Altar or 50 items asked of you by a dwarf", ItemCollections.DEATH_ALTAR).isNotConsumed();
 		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara or RC-skill cape");
 
 		mournerBoots = new ItemRequirement("Mourner boots", ItemID.MOURNING_MOURNER_BOOTS, 1, true).isNotConsumed().highlighted();

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -396,13 +396,11 @@ public class MourningsEndPartII extends BasicQuestHelper
 	@Override
 	protected void setupRequirements()
 	{
-		deathTalisman = new ItemRequirement("Death talisman", ItemID.DEATH_TALISMAN).isNotConsumed();
-		deathTalisman.addAlternates(ItemID.TIARA_DEATH, ItemID.SKILLCAPE_RUNECRAFTING, ItemID.CATALYTIC_TALISMAN, ItemID.TIARA_CATALYTIC);
-		deathTalisman.setTooltip("Catalytic talisman/tiara may be used instead");
+		deathTalisman = new ItemRequirement("Access to the Death Altar", ItemCollections.DEATH_ALTAR).isNotConsumed();
+		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara");
 		deathTalisman.appendToTooltip("or bring the dwarf the 50 items asked later");
-		deathTalismanHeader = new ItemRequirement("Death talisman or 50 items asked of you by a dwarf", ItemID.DEATH_TALISMAN).isNotConsumed();
-		deathTalismanHeader.addAlternates(ItemID.TIARA_DEATH, ItemID.SKILLCAPE_RUNECRAFTING, ItemID.CATALYTIC_TALISMAN, ItemID.TIARA_CATALYTIC);
-		deathTalismanHeader.setTooltip("Catalytic talisman/tiara may be used instead");
+		deathTalismanHeader = new ItemRequirement("Access to Death Altar or 50 items asked of you by a dwarf", ItemCollections.DEATH_ALTAR).isNotConsumed();
+		deathTalisman.setTooltip("Death Talisman/Tiara, Catalytic Talisman/Tiara");
 
 		mournerBoots = new ItemRequirement("Mourner boots", ItemID.MOURNING_MOURNER_BOOTS, 1, true).isNotConsumed().highlighted();
 		gasMask = new ItemRequirement("Gas mask", ItemID.GASMASK, 1, true).isNotConsumed().highlighted();

--- a/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
@@ -201,19 +201,19 @@ public class TheSlugMenace extends BasicQuestHelper
 		essence5.addAlternates(ItemID.BLANKRUNE);
 
 		ItemRequirement airTalisman = new ItemRequirement("Access to the Air Altar", ItemCollections.AIR_ALTAR).isNotConsumed();
-		airTalisman.setTooltip("Air Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		airTalisman.setTooltip("Air Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		ItemRequirement waterTalisman = new ItemRequirement("Access to the Water Altar", ItemCollections.WATER_ALTAR).isNotConsumed();
-		waterTalisman.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		waterTalisman.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		ItemRequirement earthTalisman = new ItemRequirement("Access to the Earth Altar", ItemCollections.EARTH_ALTAR).isNotConsumed();
-		earthTalisman.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		earthTalisman.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		ItemRequirement fireTalisman = new ItemRequirement("Access to the Fire Altar", ItemCollections.FIRE_ALTAR).isNotConsumed();
-		fireTalisman.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
+		fireTalisman.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		ItemRequirement mindTalisman = new ItemRequirement("Access to the Mind Altar", ItemCollections.MIND_ALTAR).isNotConsumed();
-		mindTalisman.setTooltip("Mind Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss.");
+		mindTalisman.setTooltip("Mind Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or via Abyss.");
 
 		accessToAltars = new ItemRequirements("Access to air, water, earth, fire, and mind runecrafting altars",
 			airTalisman, waterTalisman, earthTalisman, fireTalisman, mindTalisman).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
@@ -215,7 +215,7 @@ public class TheSlugMenace extends BasicQuestHelper
 		ItemRequirement mindTalisman = new ItemRequirement("Access to the Mind Altar", ItemCollections.MIND_ALTAR).isNotConsumed();
 		mindTalisman.setTooltip("Mind Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or via Abyss.");
 
-		accessToAltars = new ItemRequirements("Access to air, water, earth, fire, and mind runecrafting altars",
+		accessToAltars = new ItemRequirements("Access to the Air, Water, Earth, Fire, and Mind runecrafting altars",
 			airTalisman, waterTalisman, earthTalisman, fireTalisman, mindTalisman).isNotConsumed();
 
 		necklaceOfPassage = new ItemRequirement("Necklace of Passage", ItemCollections.NECKLACE_OF_PASSAGES);

--- a/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
@@ -200,20 +200,20 @@ public class TheSlugMenace extends BasicQuestHelper
 		essence5 = new ItemRequirement("Rune/pure essence, 15 to be safe", ItemID.BLANKRUNE_HIGH, 5);
 		essence5.addAlternates(ItemID.BLANKRUNE);
 
-		ItemRequirement airTalisman = new ItemRequirement("Air talisman", ItemID.AIR_TALISMAN);
-		airTalisman.addAlternates(ItemID.TIARA_AIR);
+		ItemRequirement airTalisman = new ItemRequirement("Access to the Air Altar", ItemCollections.AIR_ALTAR).isNotConsumed();
+		airTalisman.setTooltip("Air Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		ItemRequirement waterTalisman = new ItemRequirement("Water talisman", ItemID.WATER_TALISMAN);
-		waterTalisman.addAlternates(ItemID.TIARA_WATER);
+		ItemRequirement waterTalisman = new ItemRequirement("Access to the Water Altar", ItemCollections.WATER_ALTAR).isNotConsumed();
+		waterTalisman.setTooltip("Water Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		ItemRequirement earthTalisman = new ItemRequirement("Air talisman", ItemID.EARTH_TALISMAN);
-		earthTalisman.addAlternates(ItemID.TIARA_EARTH);
+		ItemRequirement earthTalisman = new ItemRequirement("Access to the Earth Altar", ItemCollections.EARTH_ALTAR).isNotConsumed();
+		earthTalisman.setTooltip("Earth Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		ItemRequirement fireTalisman = new ItemRequirement("Fire talisman", ItemID.FIRE_TALISMAN);
-		fireTalisman.addAlternates(ItemID.TIARA_FIRE);
+		ItemRequirement fireTalisman = new ItemRequirement("Access to the Fire Altar", ItemCollections.FIRE_ALTAR).isNotConsumed();
+		fireTalisman.setTooltip("Fire Talisman/Tiara, Elemental Talisman/Tiara or via Abyss.");
 
-		ItemRequirement mindTalisman = new ItemRequirement("Mind talisman", ItemID.MIND_TALISMAN);
-		mindTalisman.addAlternates(ItemID.TIARA_MIND);
+		ItemRequirement mindTalisman = new ItemRequirement("Access to the Mind Altar", ItemCollections.MIND_ALTAR).isNotConsumed();
+		mindTalisman.setTooltip("Mind Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss.");
 
 		accessToAltars = new ItemRequirements("Access to air, water, earth, fire, and mind runecrafting altars",
 			airTalisman, waterTalisman, earthTalisman, fireTalisman, mindTalisman).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/quests/whatliesbelow/WhatLiesBelow.java
+++ b/src/main/java/com/questhelper/helpers/quests/whatliesbelow/WhatLiesBelow.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.helpers.quests.whatliesbelow;
 
+import com.questhelper.collections.ItemCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.questinfo.QuestHelperQuest;
@@ -143,9 +144,8 @@ public class WhatLiesBelow extends BasicQuestHelper
 
 		infusedWand = new ItemRequirement("Infused wand", ItemID.SUROK_GLOWINGWAND);
 		infusedWand.setTooltip("You can make another by getting a wand from Surok, and using it on the chaos altar with 15 chaos runes");
-		chaosTalismanOrAbyss = new ItemRequirement("Chaos Talisman or access to the Abyss", ItemID.CHAOS_TALISMAN).isNotConsumed();
-		chaosTalismanOrAbyss.addAlternates(ItemID.TIARA_CHAOS, ItemID.CATALYTIC_TALISMAN, ItemID.TIARA_CATALYTIC);
-		chaosTalismanOrAbyss.setTooltip("If using the Dagon'hai shortcut, catalytic talisman/tiara won't work");
+		chaosTalismanOrAbyss = new ItemRequirement("Access to the Chaos Altar", ItemCollections.CHAOS_ALTAR).isNotConsumed();
+		chaosTalismanOrAbyss.setTooltip("Chaos Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss. If using the Dagon'hai shortcut, Catalytic Talisman/Tiara won't work");
 
 		beaconRing = new ItemRequirement("Beacon ring", ItemID.SUROK_RING);
 		beaconRing.setTooltip("You can get another from Zaff");

--- a/src/main/java/com/questhelper/helpers/quests/whatliesbelow/WhatLiesBelow.java
+++ b/src/main/java/com/questhelper/helpers/quests/whatliesbelow/WhatLiesBelow.java
@@ -145,7 +145,7 @@ public class WhatLiesBelow extends BasicQuestHelper
 		infusedWand = new ItemRequirement("Infused wand", ItemID.SUROK_GLOWINGWAND);
 		infusedWand.setTooltip("You can make another by getting a wand from Surok, and using it on the chaos altar with 15 chaos runes");
 		chaosTalismanOrAbyss = new ItemRequirement("Access to the Chaos Altar", ItemCollections.CHAOS_ALTAR).isNotConsumed();
-		chaosTalismanOrAbyss.setTooltip("Chaos Talisman/Tiara, Catalytic Talisman/Tiara or via Abyss. If using the Dagon'hai shortcut, Catalytic Talisman/Tiara won't work");
+		chaosTalismanOrAbyss.setTooltip("Chaos Talisman/Tiara, Catalytic Talisman/Tiara, RC-skill cape or via Abyss. If using the Dagon'hai shortcut, Catalytic Talisman/Tiara won't work");
 
 		beaconRing = new ItemRequirement("Beacon ring", ItemID.SUROK_RING);
 		beaconRing.setTooltip("You can get another from Zaff");


### PR DESCRIPTION
Fixes some checks whenever access to an altar is required.
Now checks for Elemental Talismans, Elemental Tiaras, Catalytic Talismans, Catalytic Tiaras and the Runecrafting Skill Cape next to the respective talisman of the altar.

Uses `*_WEARABLE` whenever a full inventory of essence is required for the diary task. 
This is technically incorrect, since it can be lowered by wearing Raiments of the Eye pieces

It also does **not** check for an attuned Raiments of the Eye hat, since I don't have the hat and cannot test the varbit. 