### PR TITLE
feat: Sidebar reordering

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -44,6 +44,7 @@ public interface QuestHelperConfig extends Config
 {
 	String QUEST_HELPER_GROUP = "questhelper";
 	String QUEST_BACKGROUND_GROUP = "questhelpervars";
+	String QUEST_HELPER_SIDEBAR_ORDER_KEY_START = "quest-sidebar-order-";
 
 	enum QuestOrdering implements Comparator<QuestHelper>
 	{

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -77,6 +77,7 @@ import javax.swing.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @PluginDescriptor(
 	name = "Quest Helper",
@@ -400,6 +401,11 @@ public class QuestHelperPlugin extends Plugin
 				questManager.disableShortestPath();
 			}
 		}
+
+		if (event.getKey().contains("quest-sidebar-order-"))
+		{
+			questManager.getSelectedQuest().setSidebarOrder(loadSidebarOrder(questManager.getSelectedQuest()));
+		}
 	}
 
 	@Subscribe
@@ -552,5 +558,25 @@ public class QuestHelperPlugin extends Plugin
 		questHelper.setQuestHelperPlugin(this);
 
 		log.debug("Loaded quest helper {}", quest.name());
+	}
+
+    public void saveSidebarOrder(QuestHelper currentQuest, List<Integer> newOrderIds)
+    {
+		configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "quest-sidebar-order-" + currentQuest.getQuest().getName(), newOrderIds);
+    }
+
+	public List<Integer> loadSidebarOrder(QuestHelper currentQuest)
+	{
+		if (currentQuest == null) return null;
+		String order = configManager.getRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP,
+				"quest-sidebar-order-" + currentQuest.getQuest().getName());
+		if (order == null) return null;
+		order = order.trim();
+		order = order.substring(1, order.length() - 1);
+		return Arrays.stream(order.split(","))
+				.map(String::trim)
+				.filter(s -> !s.isEmpty())
+				.map(Integer::parseInt)
+				.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -402,9 +402,12 @@ public class QuestHelperPlugin extends Plugin
 			}
 		}
 
-		if (event.getKey().contains("quest-sidebar-order-"))
+		if (event.getKey().contains(QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START))
 		{
-			questManager.getSelectedQuest().setSidebarOrder(loadSidebarOrder(questManager.getSelectedQuest()));
+			if (questManager.getSelectedQuest() != null)
+			{
+				questManager.getSelectedQuest().setSidebarOrder(loadSidebarOrder(questManager.getSelectedQuest()));
+			}
 		}
 	}
 
@@ -562,14 +565,14 @@ public class QuestHelperPlugin extends Plugin
 
     public void saveSidebarOrder(QuestHelper currentQuest, List<Integer> newOrderIds)
     {
-		configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, "quest-sidebar-order-" + currentQuest.getQuest().getName(), newOrderIds);
+		configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().getName(), newOrderIds);
     }
 
 	public List<Integer> loadSidebarOrder(QuestHelper currentQuest)
 	{
 		if (currentQuest == null) return null;
 		String order = configManager.getRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP,
-				"quest-sidebar-order-" + currentQuest.getQuest().getName());
+				QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().getName());
 		if (order == null) return null;
 		order = order.trim();
 		order = order.substring(1, order.length() - 1);

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -565,14 +565,14 @@ public class QuestHelperPlugin extends Plugin
 
     public void saveSidebarOrder(QuestHelper currentQuest, List<Integer> newOrderIds)
     {
-		configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().getName(), newOrderIds);
+		configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().name(), newOrderIds);
     }
 
 	public List<Integer> loadSidebarOrder(QuestHelper currentQuest)
 	{
 		if (currentQuest == null) return null;
 		String order = configManager.getRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP,
-				QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().getName());
+				QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().name());
 		if (order == null) return null;
 		order = order.trim();
 		order = order.substring(1, order.length() - 1);

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -565,12 +565,13 @@ public class QuestHelperPlugin extends Plugin
 
     public void saveSidebarOrder(QuestHelper currentQuest, List<Integer> newOrderIds)
     {
+		if (currentQuest == null || currentQuest.getQuest() == null) return;
 		configManager.setRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP, QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().name(), newOrderIds);
     }
 
 	public List<Integer> loadSidebarOrder(QuestHelper currentQuest)
 	{
-		if (currentQuest == null) return null;
+		if (currentQuest == null || currentQuest.getQuest() == null) return null;
 		String order = configManager.getRSProfileConfiguration(QuestHelperConfig.QUEST_HELPER_GROUP,
 				QuestHelperConfig.QUEST_HELPER_SIDEBAR_ORDER_KEY_START + currentQuest.getQuest().name());
 		if (order == null) return null;

--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
@@ -47,11 +47,7 @@ import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.runelite.RuneliteRequirement;
 import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
-import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.NpcStep;
-import com.questhelper.steps.ObjectStep;
-import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.*;
 import com.questhelper.steps.widget.LunarSpells;
 import com.questhelper.steps.widget.NormalSpells;
 import java.util.Set;
@@ -166,7 +162,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		setupSteps();
 		farmingHandler = new FarmingHandler(client, configManager);
 
-		ConditionalStep steps = new ConditionalStep(this, waitForTree, spade, coins, rake, compost
+		ReorderableConditionalStep steps = new ReorderableConditionalStep(this, waitForTree, spade, coins, rake, compost
 			, farmersOutfit, gracefulOutfit);
 
 		// Farming Guild Tree -> Farming Guild Fruit Tree -> Lumbridge -> Falador -> Taverley
@@ -187,7 +183,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		farmingGuildStep.addStep(and(accessToFarmingGuildFruitTreePatch, nor(farmingGuildFruitStates.getIsProtected(), usingCompostorNothing)), guildFruitProtect);
 
 		steps.addStep(and(accessToFarmingGuildTreePatch, nand(farmingGuildTreeStates.getIsGrowing(),
-			farmingGuildFruitStates.getIsGrowing())), farmingGuildStep.setId(0));
+			farmingGuildFruitStates.getIsGrowing())), farmingGuildStep.withId(0));
 
 		lumbridgeStep = new ConditionalStep(this, lumbridgeTreePatchCheckHealth);
 		lumbridgeStep.addStep(lumbridgeStates.getIsUnchecked(), lumbridgeTreePatchCheckHealth);
@@ -196,7 +192,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		lumbridgeStep.addStep(lumbridgeStates.getIsStump(), lumbridgeTreePatchDig);
 		lumbridgeStep.addStep(nor(usingCompostorNothing, lumbridgeStates.getIsProtected()), lumbridgeTreeProtect);
 
-		steps.addStep(nor(lumbridgeStates.getIsGrowing()), lumbridgeStep.setId(1));
+		steps.addStep(nor(lumbridgeStates.getIsGrowing()), lumbridgeStep.withId(1));
 
 		faladorStep = new ConditionalStep(this, faladorTreePatchCheckHealth);
 		faladorStep.addStep(faladorStates.getIsUnchecked(), faladorTreePatchCheckHealth);
@@ -205,7 +201,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		faladorStep.addStep(faladorStates.getIsStump(), faladorTreePatchDig);
 		faladorStep.addStep(nor(usingCompostorNothing, faladorStates.getIsProtected()), faladorTreeProtect);
 
-		steps.addStep(nor(faladorStates.getIsGrowing()), faladorStep.setId(2));
+		steps.addStep(nor(faladorStates.getIsGrowing()), faladorStep.withId(2));
 
 		taverleyStep = new ConditionalStep(this, taverleyTreePatchCheckHealth);
 		taverleyStep.addStep(taverleyStates.getIsUnchecked(), taverleyTreePatchCheckHealth);
@@ -214,7 +210,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		taverleyStep.addStep(taverleyStates.getIsStump(), taverleyTreePatchDig);
 		taverleyStep.addStep(nor(usingCompostorNothing, taverleyStates.getIsProtected()), taverleyTreeProtect);
 
-		steps.addStep(nor(taverleyStates.getIsGrowing()), taverleyStep.setId(3));
+		steps.addStep(nor(taverleyStates.getIsGrowing()), taverleyStep.withId(3));
 
 		varrockStep = new ConditionalStep(this, varrockTreePatchCheckHealth);
 		varrockStep.addStep(varrockStates.getIsUnchecked(), varrockTreePatchCheckHealth);
@@ -223,7 +219,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		varrockStep.addStep(varrockStates.getIsStump(), varrockTreePatchDig);
 		varrockStep.addStep(nor(usingCompostorNothing, varrockStates.getIsProtected()), varrockTreeProtect);
 
-		steps.addStep(nor(varrockStates.getIsGrowing()), varrockStep.setId(4));
+		steps.addStep(nor(varrockStates.getIsGrowing()), varrockStep.withId(4));
 
 		strongholdStep = new ConditionalStep(this, gnomeStrongholdFruitTreePatchCheckHealth);
 		strongholdStep.addStep(gnomeStrongholdFruitStates.getIsUnchecked(), gnomeStrongholdFruitTreePatchCheckHealth);
@@ -239,7 +235,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		strongholdStep.addStep(nor(usingCompostorNothing, gnomeStrongholdTreeStates.getIsProtected()), strongholdTreeProtect);
 
 		steps.addStep(nand(gnomeStrongholdTreeStates.getIsGrowing(),
-			gnomeStrongholdFruitStates.getIsGrowing()), strongholdStep.setId(5));
+			gnomeStrongholdFruitStates.getIsGrowing()), strongholdStep.withId(5));
 
 		villageStep = new ConditionalStep(this, gnomeVillageFruitTreePatchCheckHealth);
 		villageStep.addStep(gnomeVillageStates.getIsUnchecked(), gnomeVillageFruitTreePatchCheckHealth);
@@ -248,7 +244,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		villageStep.addStep(gnomeVillageStates.getIsStump(), gnomeVillageFruitTreePatchDig);
 		villageStep.addStep(nor(usingCompostorNothing, gnomeVillageStates.getIsProtected()), villageFruitProtect);
 
-		steps.addStep(nor(gnomeVillageStates.getIsGrowing()), villageStep.setId(6));
+		steps.addStep(nor(gnomeVillageStates.getIsGrowing()), villageStep.withId(6));
 
 		catherbyStep = new ConditionalStep(this, catherbyFruitTreePatchCheckHealth);
 		catherbyStep.addStep(catherbyStates.getIsUnchecked(), catherbyFruitTreePatchCheckHealth);
@@ -257,7 +253,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		catherbyStep.addStep(catherbyStates.getIsStump(), catherbyFruitTreePatchDig);
 		catherbyStep.addStep(nor(usingCompostorNothing, catherbyStates.getIsProtected()), catherbyFruitProtect);
 
-		steps.addStep(nor(catherbyStates.getIsGrowing()), catherbyStep.setId(7));
+		steps.addStep(nor(catherbyStates.getIsGrowing()), catherbyStep.withId(7));
 
 		brimhavenStep = new ConditionalStep(this, brimhavenFruitTreePatchCheckHealth);
 		brimhavenStep.addStep(brimhavenStates.getIsUnchecked(), brimhavenFruitTreePatchCheckHealth);
@@ -266,7 +262,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		brimhavenStep.addStep(brimhavenStates.getIsStump(), brimhavenFruitTreePatchDig);
 		brimhavenStep.addStep(nor(usingCompostorNothing, brimhavenStates.getIsProtected()), brimhavenFruitProtect);
 
-		steps.addStep(nor(brimhavenStates.getIsGrowing()), brimhavenStep.setId(8));
+		steps.addStep(nor(brimhavenStates.getIsGrowing()), brimhavenStep.withId(8));
 
 		lletyaStep = new ConditionalStep(this, lletyaFruitTreePatchCheckHealth);
 		lletyaStep.addStep(lletyaStates.getIsUnchecked(), lletyaFruitTreePatchCheckHealth);
@@ -275,7 +271,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		lletyaStep.addStep(lletyaStates.getIsStump(), lletyaFruitTreePatchDig);
 		lletyaStep.addStep(nor(usingCompostorNothing, lletyaStates.getIsProtected()), lletyaFruitProtect);
 
-		steps.addStep(and(accessToLletya, nor(lletyaStates.getIsGrowing())), lletyaStep.setId(9));
+		steps.addStep(and(accessToLletya, nor(lletyaStates.getIsGrowing())), lletyaStep.withId(9));
 
 		fossilIslandStep = new ConditionalStep(this, eastHardwoodTreePatchCheckHealth);
 		fossilIslandStep.addStep(eastHardwoodStates.getIsUnchecked(), eastHardwoodTreePatchCheckHealth);
@@ -298,7 +294,7 @@ public class TreeRun extends ComplexStateQuestHelper
 
 		steps.addStep(and(accessToFossilIsland,
 			nand(eastHardwoodStates.getIsGrowing(), westHardwoodStates.getIsGrowing(), middleHardwoodStates.getIsGrowing())),
-			fossilIslandStep.setId(10));
+			fossilIslandStep.withId(10));
 
 		savannahStep = new ConditionalStep(this, savannahCheckHealth);
 		savannahStep.addStep(savannahStates.getIsUnchecked(), savannahCheckHealth);
@@ -307,7 +303,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		savannahStep.addStep(savannahStates.getIsStump(), savannahDig);
 		savannahStep.addStep(nor(usingCompostorNothing, savannahStates.getIsProtected()), savannahProtect);
 
-		steps.addStep(and(accessToSavannah, nor(savannahStates.getIsGrowing())), savannahStep.setId(11));
+		steps.addStep(and(accessToSavannah, nor(savannahStates.getIsGrowing())), savannahStep.withId(11));
 
 		return steps;
 	}
@@ -903,54 +899,54 @@ public class TreeRun extends ComplexStateQuestHelper
 		// IDEA: Can add ID to each step. onLoad and onConfigChanged it checks id ordering.
 		List<PanelDetails> allSteps = new ArrayList<>();
 		PanelDetails farmingGuildPanel = new PanelDetails("Farming Guild", Arrays.asList(farmingGuildTreePatchCheckHealth, farmingGuildTreePatchClear,
-				farmingGuildFruitTreePatchCheckHealth, farmingGuildFruitTreePatchClear)).addId(0);
+				farmingGuildFruitTreePatchCheckHealth, farmingGuildFruitTreePatchClear)).withId(0);
 		farmingGuildPanel.setLockingStep(farmingGuildStep);
 		allSteps.add(farmingGuildPanel);
 
-		PanelDetails lumbridgePanel = new PanelDetails("Lumbridge", Arrays.asList(lumbridgeTreePatchCheckHealth, lumbridgeTreePatchClear)).addId(1);
+		PanelDetails lumbridgePanel = new PanelDetails("Lumbridge", Arrays.asList(lumbridgeTreePatchCheckHealth, lumbridgeTreePatchClear)).withId(1);
 		lumbridgePanel.setLockingStep(lumbridgeStep);
 		allSteps.add(lumbridgePanel);
 
-		PanelDetails faladorPanel = new PanelDetails("Falador", Arrays.asList(faladorTreePatchCheckHealth, faladorTreePatchClear)).addId(2);
+		PanelDetails faladorPanel = new PanelDetails("Falador", Arrays.asList(faladorTreePatchCheckHealth, faladorTreePatchClear)).withId(2);
 		faladorPanel.setLockingStep(faladorStep);
 		allSteps.add(faladorPanel);
-		PanelDetails taverleyPanel = new PanelDetails("Taverley", Arrays.asList(taverleyTreePatchCheckHealth, taverleyTreePatchClear)).addId(3);
+		PanelDetails taverleyPanel = new PanelDetails("Taverley", Arrays.asList(taverleyTreePatchCheckHealth, taverleyTreePatchClear)).withId(3);
 		taverleyPanel.setLockingStep(taverleyStep);
 		allSteps.add(taverleyPanel);
 
-		PanelDetails varrockPanel = new PanelDetails("Varrock", Arrays.asList(varrockTreePatchCheckHealth, varrockTreePatchClear)).addId(4);
+		PanelDetails varrockPanel = new PanelDetails("Varrock", Arrays.asList(varrockTreePatchCheckHealth, varrockTreePatchClear)).withId(4);
 		varrockPanel.setLockingStep(varrockStep);
 		allSteps.add(varrockPanel);
 
 		PanelDetails gnomeStrongholdPanel = new PanelDetails("Gnome Stronghold", Arrays.asList(gnomeStrongholdFruitTreePatchCheckHealth, gnomeVillageFruitTreePatchClear,
-			gnomeStrongholdTreePatchCheckHealth, gnomeStrongholdTreePatchClear)).addId(5);
+			gnomeStrongholdTreePatchCheckHealth, gnomeStrongholdTreePatchClear)).withId(5);
 		gnomeStrongholdPanel.setLockingStep(strongholdStep);
 		allSteps.add(gnomeStrongholdPanel);
 
 		PanelDetails villagePanel = new PanelDetails("Tree Gnome Village", Arrays.asList(gnomeVillageFruitTreePatchCheckHealth,
-				gnomeVillageFruitTreePatchClear)).addId(6);
+				gnomeVillageFruitTreePatchClear)).withId(6);
 		villagePanel.setLockingStep(villageStep);
 		allSteps.add(villagePanel);
 
-		PanelDetails catherbyPanel = new PanelDetails("Catherby", Arrays.asList(catherbyFruitTreePatchCheckHealth, catherbyFruitTreePatchClear)).addId(7);
+		PanelDetails catherbyPanel = new PanelDetails("Catherby", Arrays.asList(catherbyFruitTreePatchCheckHealth, catherbyFruitTreePatchClear)).withId(7);
 		catherbyPanel.setLockingStep(catherbyStep);
 		allSteps.add(catherbyPanel);
 
-		PanelDetails brimhavenPanel = new PanelDetails("Brimhaven", Arrays.asList(brimhavenFruitTreePatchCheckHealth, brimhavenFruitTreePatchClear)).addId(8);
+		PanelDetails brimhavenPanel = new PanelDetails("Brimhaven", Arrays.asList(brimhavenFruitTreePatchCheckHealth, brimhavenFruitTreePatchClear)).withId(8);
 		brimhavenPanel.setLockingStep(brimhavenStep);
 		allSteps.add(brimhavenPanel);
 
-		PanelDetails lletyaPanel = new PanelDetails("Llyeta", Arrays.asList(lletyaFruitTreePatchCheckHealth, lletyaFruitTreePatchClear)).addId(9);
+		PanelDetails lletyaPanel = new PanelDetails("Llyeta", Arrays.asList(lletyaFruitTreePatchCheckHealth, lletyaFruitTreePatchClear)).withId(9);
 		lletyaPanel.setLockingStep(lletyaStep);
 		allSteps.add(lletyaPanel);
 
 		PanelDetails fossilIslandPanel = new PanelDetails("Fossil Island", Arrays.asList(eastHardwoodTreePatchCheckHealth, eastHardwoodTreePatchClear,
 			middleHardwoodTreePatchCheckHealth, middleHardwoodTreePatchClear,
-			westHardwoodTreePatchCheckHealth, westHardwoodTreePatchClear)).addId(10);
+			westHardwoodTreePatchCheckHealth, westHardwoodTreePatchClear)).withId(10);
 		fossilIslandPanel.setLockingStep(fossilIslandStep);
 		allSteps.add(fossilIslandPanel);
 
-		PanelDetails savannahPanel = new PanelDetails("Avium Savannah", Arrays.asList(savannahCheckHealth, savannahClear, savannahPlant)).addId(11);
+		PanelDetails savannahPanel = new PanelDetails("Avium Savannah", Arrays.asList(savannahCheckHealth, savannahClear, savannahPlant)).withId(11);
 		savannahPanel.setLockingStep(savannahStep);
 		allSteps.add(savannahPanel);
 		return allSteps;

--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
@@ -187,7 +187,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		farmingGuildStep.addStep(and(accessToFarmingGuildFruitTreePatch, nor(farmingGuildFruitStates.getIsProtected(), usingCompostorNothing)), guildFruitProtect);
 
 		steps.addStep(and(accessToFarmingGuildTreePatch, nand(farmingGuildTreeStates.getIsGrowing(),
-			farmingGuildFruitStates.getIsGrowing())), farmingGuildStep);
+			farmingGuildFruitStates.getIsGrowing())), farmingGuildStep.setId(0));
 
 		lumbridgeStep = new ConditionalStep(this, lumbridgeTreePatchCheckHealth);
 		lumbridgeStep.addStep(lumbridgeStates.getIsUnchecked(), lumbridgeTreePatchCheckHealth);
@@ -196,7 +196,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		lumbridgeStep.addStep(lumbridgeStates.getIsStump(), lumbridgeTreePatchDig);
 		lumbridgeStep.addStep(nor(usingCompostorNothing, lumbridgeStates.getIsProtected()), lumbridgeTreeProtect);
 
-		steps.addStep(nor(lumbridgeStates.getIsGrowing()), lumbridgeStep);
+		steps.addStep(nor(lumbridgeStates.getIsGrowing()), lumbridgeStep.setId(1));
 
 		faladorStep = new ConditionalStep(this, faladorTreePatchCheckHealth);
 		faladorStep.addStep(faladorStates.getIsUnchecked(), faladorTreePatchCheckHealth);
@@ -205,7 +205,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		faladorStep.addStep(faladorStates.getIsStump(), faladorTreePatchDig);
 		faladorStep.addStep(nor(usingCompostorNothing, faladorStates.getIsProtected()), faladorTreeProtect);
 
-		steps.addStep(nor(faladorStates.getIsGrowing()), faladorStep);
+		steps.addStep(nor(faladorStates.getIsGrowing()), faladorStep.setId(2));
 
 		taverleyStep = new ConditionalStep(this, taverleyTreePatchCheckHealth);
 		taverleyStep.addStep(taverleyStates.getIsUnchecked(), taverleyTreePatchCheckHealth);
@@ -214,7 +214,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		taverleyStep.addStep(taverleyStates.getIsStump(), taverleyTreePatchDig);
 		taverleyStep.addStep(nor(usingCompostorNothing, taverleyStates.getIsProtected()), taverleyTreeProtect);
 
-		steps.addStep(nor(taverleyStates.getIsGrowing()), taverleyStep);
+		steps.addStep(nor(taverleyStates.getIsGrowing()), taverleyStep.setId(3));
 
 		varrockStep = new ConditionalStep(this, varrockTreePatchCheckHealth);
 		varrockStep.addStep(varrockStates.getIsUnchecked(), varrockTreePatchCheckHealth);
@@ -223,7 +223,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		varrockStep.addStep(varrockStates.getIsStump(), varrockTreePatchDig);
 		varrockStep.addStep(nor(usingCompostorNothing, varrockStates.getIsProtected()), varrockTreeProtect);
 
-		steps.addStep(nor(varrockStates.getIsGrowing()), varrockStep);
+		steps.addStep(nor(varrockStates.getIsGrowing()), varrockStep.setId(4));
 
 		strongholdStep = new ConditionalStep(this, gnomeStrongholdFruitTreePatchCheckHealth);
 		strongholdStep.addStep(gnomeStrongholdFruitStates.getIsUnchecked(), gnomeStrongholdFruitTreePatchCheckHealth);
@@ -239,7 +239,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		strongholdStep.addStep(nor(usingCompostorNothing, gnomeStrongholdTreeStates.getIsProtected()), strongholdTreeProtect);
 
 		steps.addStep(nand(gnomeStrongholdTreeStates.getIsGrowing(),
-			gnomeStrongholdFruitStates.getIsGrowing()), strongholdStep);
+			gnomeStrongholdFruitStates.getIsGrowing()), strongholdStep.setId(5));
 
 		villageStep = new ConditionalStep(this, gnomeVillageFruitTreePatchCheckHealth);
 		villageStep.addStep(gnomeVillageStates.getIsUnchecked(), gnomeVillageFruitTreePatchCheckHealth);
@@ -248,7 +248,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		villageStep.addStep(gnomeVillageStates.getIsStump(), gnomeVillageFruitTreePatchDig);
 		villageStep.addStep(nor(usingCompostorNothing, gnomeVillageStates.getIsProtected()), villageFruitProtect);
 
-		steps.addStep(nor(gnomeVillageStates.getIsGrowing()), villageStep);
+		steps.addStep(nor(gnomeVillageStates.getIsGrowing()), villageStep.setId(6));
 
 		catherbyStep = new ConditionalStep(this, catherbyFruitTreePatchCheckHealth);
 		catherbyStep.addStep(catherbyStates.getIsUnchecked(), catherbyFruitTreePatchCheckHealth);
@@ -257,7 +257,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		catherbyStep.addStep(catherbyStates.getIsStump(), catherbyFruitTreePatchDig);
 		catherbyStep.addStep(nor(usingCompostorNothing, catherbyStates.getIsProtected()), catherbyFruitProtect);
 
-		steps.addStep(nor(catherbyStates.getIsGrowing()), catherbyStep);
+		steps.addStep(nor(catherbyStates.getIsGrowing()), catherbyStep.setId(7));
 
 		brimhavenStep = new ConditionalStep(this, brimhavenFruitTreePatchCheckHealth);
 		brimhavenStep.addStep(brimhavenStates.getIsUnchecked(), brimhavenFruitTreePatchCheckHealth);
@@ -266,7 +266,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		brimhavenStep.addStep(brimhavenStates.getIsStump(), brimhavenFruitTreePatchDig);
 		brimhavenStep.addStep(nor(usingCompostorNothing, brimhavenStates.getIsProtected()), brimhavenFruitProtect);
 
-		steps.addStep(nor(brimhavenStates.getIsGrowing()), brimhavenStep);
+		steps.addStep(nor(brimhavenStates.getIsGrowing()), brimhavenStep.setId(8));
 
 		lletyaStep = new ConditionalStep(this, lletyaFruitTreePatchCheckHealth);
 		lletyaStep.addStep(lletyaStates.getIsUnchecked(), lletyaFruitTreePatchCheckHealth);
@@ -275,7 +275,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		lletyaStep.addStep(lletyaStates.getIsStump(), lletyaFruitTreePatchDig);
 		lletyaStep.addStep(nor(usingCompostorNothing, lletyaStates.getIsProtected()), lletyaFruitProtect);
 
-		steps.addStep(and(accessToLletya, nor(lletyaStates.getIsGrowing())), lletyaStep);
+		steps.addStep(and(accessToLletya, nor(lletyaStates.getIsGrowing())), lletyaStep.setId(9));
 
 		fossilIslandStep = new ConditionalStep(this, eastHardwoodTreePatchCheckHealth);
 		fossilIslandStep.addStep(eastHardwoodStates.getIsUnchecked(), eastHardwoodTreePatchCheckHealth);
@@ -298,7 +298,7 @@ public class TreeRun extends ComplexStateQuestHelper
 
 		steps.addStep(and(accessToFossilIsland,
 			nand(eastHardwoodStates.getIsGrowing(), westHardwoodStates.getIsGrowing(), middleHardwoodStates.getIsGrowing())),
-			fossilIslandStep);
+			fossilIslandStep.setId(10));
 
 		savannahStep = new ConditionalStep(this, savannahCheckHealth);
 		savannahStep.addStep(savannahStates.getIsUnchecked(), savannahCheckHealth);
@@ -307,7 +307,7 @@ public class TreeRun extends ComplexStateQuestHelper
 		savannahStep.addStep(savannahStates.getIsStump(), savannahDig);
 		savannahStep.addStep(nor(usingCompostorNothing, savannahStates.getIsProtected()), savannahProtect);
 
-		steps.addStep(and(accessToSavannah, nor(savannahStates.getIsGrowing())), savannahStep);
+		steps.addStep(and(accessToSavannah, nor(savannahStates.getIsGrowing())), savannahStep.setId(11));
 
 		return steps;
 	}
@@ -900,54 +900,57 @@ public class TreeRun extends ComplexStateQuestHelper
 	@Override
 	public List<PanelDetails> getPanels()
 	{
+		// IDEA: Can add ID to each step. onLoad and onConfigChanged it checks id ordering.
 		List<PanelDetails> allSteps = new ArrayList<>();
-		PanelDetails farmingGuildPanel = new PanelDetails("Farming Guild", Arrays.asList(farmingGuildTreePatchCheckHealth, farmingGuildTreePatchClear, farmingGuildFruitTreePatchCheckHealth, farmingGuildFruitTreePatchClear));
+		PanelDetails farmingGuildPanel = new PanelDetails("Farming Guild", Arrays.asList(farmingGuildTreePatchCheckHealth, farmingGuildTreePatchClear,
+				farmingGuildFruitTreePatchCheckHealth, farmingGuildFruitTreePatchClear)).addId(0);
 		farmingGuildPanel.setLockingStep(farmingGuildStep);
 		allSteps.add(farmingGuildPanel);
 
-		PanelDetails lumbridgePanel = new PanelDetails("Lumbridge", Arrays.asList(lumbridgeTreePatchCheckHealth, lumbridgeTreePatchClear));
+		PanelDetails lumbridgePanel = new PanelDetails("Lumbridge", Arrays.asList(lumbridgeTreePatchCheckHealth, lumbridgeTreePatchClear)).addId(1);
 		lumbridgePanel.setLockingStep(lumbridgeStep);
 		allSteps.add(lumbridgePanel);
 
-		PanelDetails faladorPanel = new PanelDetails("Falador", Arrays.asList(faladorTreePatchCheckHealth, faladorTreePatchClear));
+		PanelDetails faladorPanel = new PanelDetails("Falador", Arrays.asList(faladorTreePatchCheckHealth, faladorTreePatchClear)).addId(2);
 		faladorPanel.setLockingStep(faladorStep);
 		allSteps.add(faladorPanel);
-		PanelDetails taverleyPanel = new PanelDetails("Taverley", Arrays.asList(taverleyTreePatchCheckHealth, taverleyTreePatchClear));
+		PanelDetails taverleyPanel = new PanelDetails("Taverley", Arrays.asList(taverleyTreePatchCheckHealth, taverleyTreePatchClear)).addId(3);
 		taverleyPanel.setLockingStep(taverleyStep);
 		allSteps.add(taverleyPanel);
 
-		PanelDetails varrockPanel = new PanelDetails("Varrock", Arrays.asList(varrockTreePatchCheckHealth, varrockTreePatchClear));
+		PanelDetails varrockPanel = new PanelDetails("Varrock", Arrays.asList(varrockTreePatchCheckHealth, varrockTreePatchClear)).addId(4);
 		varrockPanel.setLockingStep(varrockStep);
 		allSteps.add(varrockPanel);
 
 		PanelDetails gnomeStrongholdPanel = new PanelDetails("Gnome Stronghold", Arrays.asList(gnomeStrongholdFruitTreePatchCheckHealth, gnomeVillageFruitTreePatchClear,
-			gnomeStrongholdTreePatchCheckHealth, gnomeStrongholdTreePatchClear));
+			gnomeStrongholdTreePatchCheckHealth, gnomeStrongholdTreePatchClear)).addId(5);
 		gnomeStrongholdPanel.setLockingStep(strongholdStep);
 		allSteps.add(gnomeStrongholdPanel);
 
-		PanelDetails villagePanel = new PanelDetails("Tree Gnome Village", Arrays.asList(gnomeVillageFruitTreePatchCheckHealth, gnomeVillageFruitTreePatchClear));
+		PanelDetails villagePanel = new PanelDetails("Tree Gnome Village", Arrays.asList(gnomeVillageFruitTreePatchCheckHealth,
+				gnomeVillageFruitTreePatchClear)).addId(6);
 		villagePanel.setLockingStep(villageStep);
 		allSteps.add(villagePanel);
 
-		PanelDetails catherbyPanel = new PanelDetails("Catherby", Arrays.asList(catherbyFruitTreePatchCheckHealth, catherbyFruitTreePatchClear));
+		PanelDetails catherbyPanel = new PanelDetails("Catherby", Arrays.asList(catherbyFruitTreePatchCheckHealth, catherbyFruitTreePatchClear)).addId(7);
 		catherbyPanel.setLockingStep(catherbyStep);
 		allSteps.add(catherbyPanel);
 
-		PanelDetails brimhavenPanel = new PanelDetails("Brimhaven", Arrays.asList(brimhavenFruitTreePatchCheckHealth, brimhavenFruitTreePatchClear));
+		PanelDetails brimhavenPanel = new PanelDetails("Brimhaven", Arrays.asList(brimhavenFruitTreePatchCheckHealth, brimhavenFruitTreePatchClear)).addId(8);
 		brimhavenPanel.setLockingStep(brimhavenStep);
 		allSteps.add(brimhavenPanel);
 
-		PanelDetails lletyaPanel = new PanelDetails("Llyeta", Arrays.asList(lletyaFruitTreePatchCheckHealth, lletyaFruitTreePatchClear));
+		PanelDetails lletyaPanel = new PanelDetails("Llyeta", Arrays.asList(lletyaFruitTreePatchCheckHealth, lletyaFruitTreePatchClear)).addId(9);
 		lletyaPanel.setLockingStep(lletyaStep);
 		allSteps.add(lletyaPanel);
 
 		PanelDetails fossilIslandPanel = new PanelDetails("Fossil Island", Arrays.asList(eastHardwoodTreePatchCheckHealth, eastHardwoodTreePatchClear,
 			middleHardwoodTreePatchCheckHealth, middleHardwoodTreePatchClear,
-			westHardwoodTreePatchCheckHealth, westHardwoodTreePatchClear));
+			westHardwoodTreePatchCheckHealth, westHardwoodTreePatchClear)).addId(10);
 		fossilIslandPanel.setLockingStep(fossilIslandStep);
 		allSteps.add(fossilIslandPanel);
 
-		PanelDetails savannahPanel = new PanelDetails("Avium Savannah", Arrays.asList(savannahCheckHealth, savannahClear, savannahPlant));
+		PanelDetails savannahPanel = new PanelDetails("Avium Savannah", Arrays.asList(savannahCheckHealth, savannahClear, savannahPlant)).addId(11);
 		savannahPanel.setLockingStep(savannahStep);
 		allSteps.add(savannahPanel);
 		return allSteps;

--- a/src/main/java/com/questhelper/panel/PanelDetails.java
+++ b/src/main/java/com/questhelper/panel/PanelDetails.java
@@ -37,6 +37,10 @@ import java.util.*;
 public class PanelDetails
 {
 	@Getter
+	@Setter
+	int id;
+
+	@Getter
 	String header;
 
 	@Getter
@@ -87,6 +91,12 @@ public class PanelDetails
 	{
 		this(header, steps, requirements);
 		this.recommended = recommended;
+	}
+
+	public PanelDetails addId(int id)
+	{
+		this.id = id;
+		return this;
 	}
 
 	public void setDisplayCondition(Requirement req)

--- a/src/main/java/com/questhelper/panel/PanelDetails.java
+++ b/src/main/java/com/questhelper/panel/PanelDetails.java
@@ -37,7 +37,6 @@ import java.util.*;
 public class PanelDetails
 {
 	@Getter
-	@Setter
 	int id;
 
 	@Getter
@@ -93,7 +92,7 @@ public class PanelDetails
 		this.recommended = recommended;
 	}
 
-	public PanelDetails addId(int id)
+	public PanelDetails withId(int id)
 	{
 		this.id = id;
 		return this;

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -281,9 +281,9 @@ public class QuestOverviewPanel extends JPanel
 			setupQuestRequirements(quest);
 			introPanel.setVisible(true);
 			boolean draggable = steps.stream().anyMatch((panelDetails -> panelDetails.id != 0));
-			if (draggable)
+			List<Integer> order = questHelperPlugin.loadSidebarOrder(currentQuest);
+			if (draggable && order != null)
 			{
-				List<Integer> order = questHelperPlugin.loadSidebarOrder(currentQuest);
 				Map<Integer, Integer> idx = new HashMap<>();
 				for (int i = 0; i < order.size(); i++)
 					idx.put(order.get(i), i);

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -719,6 +719,10 @@ public class QuestOverviewPanel extends JPanel
 		@Override
 		public void mousePressed(MouseEvent e)
 		{
+			if (e.getButton() != MouseEvent.BUTTON1)
+			{
+				return;
+			}
 			draggingPanel = panel;
 			startY = e.getYOnScreen();
 		}
@@ -758,6 +762,10 @@ public class QuestOverviewPanel extends JPanel
 		@Override
 		public void mouseReleased(MouseEvent e)
 		{
+			if (e.getButton() != MouseEvent.BUTTON1)
+			{
+				return;
+			}
 			draggingPanel = null;
 			 List<Integer> newOrderIds = questStepPanelList.stream()
 			     .map(p -> p.getPanelDetails().getId())

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -764,7 +764,7 @@ public class QuestOverviewPanel extends JPanel
 			     .collect(Collectors.toList());
 			 questHelperPlugin.saveSidebarOrder(currentQuest, newOrderIds);
 		}
-		
+
 		@Override public void mouseMoved(MouseEvent e) { }
 	}
 }

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -677,7 +677,7 @@ public class QuestOverviewPanel extends JPanel
 	private void makeDraggable(QuestStepPanel newStep)
 	{
 		JLabel grip = new JLabel("\u2630");
-		grip.setBorder(new EmptyBorder(5, 5, 5, 10));
+		grip.setBorder(new EmptyBorder(0, 0, 3, 0));
 		grip.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
 
 		GripDragListener listener = new GripDragListener(newStep);

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -28,6 +28,7 @@ import com.questhelper.QuestHelperPlugin;
 import com.questhelper.managers.QuestManager;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.steps.QuestStep;
+import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -46,6 +47,7 @@ public class QuestStepPanel extends JPanel
 {
 	private static final int TITLE_PADDING = 5;
 
+	@Getter
 	private final PanelDetails panelDetails;
 	private final QuestHelperPlugin questHelperPlugin;
 
@@ -53,6 +55,7 @@ public class QuestStepPanel extends JPanel
 	private final JLabel headerLabel = JGenerator.makeJLabel();
 	private final JPanel bodyPanel = new JPanel();
 	private final JCheckBox lockStep = new JCheckBox();
+	@Getter
 	private final JPanel leftTitleContainer;
 	private final JPanel viewControls;
 	private final HashMap<QuestStep, JTextPane> steps = new HashMap<>();

--- a/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -129,7 +129,8 @@ public class QuestStepPanel extends JPanel
 
 		if (panelDetails.getRecommended() != null)
 		{
-			recommendedItemsPanel = new QuestRequirementsPanel("Bring the following items:", panelDetails.getRecommended(), questManager, false);
+			recommendedItemsPanel = new QuestRequirementsPanel("Optionally bring the following items:", panelDetails.getRecommended(), questManager,
+					false);
 			bodyPanel.add(recommendedItemsPanel, BorderLayout.CENTER);
 		}
 		else
@@ -217,13 +218,13 @@ public class QuestStepPanel extends JPanel
 			setLockable(panelDetails.getLockingQuestSteps() != null &&
 				(panelDetails.getVars() == null || panelDetails.getVars().contains(currentQuest.getVar())));
 
-			for (QuestStep step : getSteps())
+			for (QuestStep sidebarStep : getSteps())
 			{
-				if (step.getConditionToHide() != null && step.getConditionToHide().check(client)) continue;
-				if (step.containsSteps(newStep, new HashSet<>()))
+				if (sidebarStep.getConditionToHide() != null && sidebarStep.getConditionToHide().check(client)) continue;
+				if (sidebarStep.containsSteps(newStep, new HashSet<>()))
 				{
 					highlighted = true;
-					updateHighlight(step);
+					updateHighlight(sidebarStep);
 					break;
 				}
 			}

--- a/src/main/java/com/questhelper/questhelpers/BasicQuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/BasicQuestHelper.java
@@ -68,7 +68,7 @@ public abstract class BasicQuestHelper extends QuestHelper
 		this.config = config;
 		instantiateSteps(steps.values());
 		var = getVar();
-		sidebarOrder = questHelperPlugin.loadSidebarOrder(getQuest().getQuestHelper());
+		sidebarOrder = questHelperPlugin.loadSidebarOrder(this);
 		startUpStep(steps.get(var));
 	}
 

--- a/src/main/java/com/questhelper/questhelpers/BasicQuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/BasicQuestHelper.java
@@ -68,6 +68,7 @@ public abstract class BasicQuestHelper extends QuestHelper
 		this.config = config;
 		instantiateSteps(steps.values());
 		var = getVar();
+		sidebarOrder = questHelperPlugin.loadSidebarOrder(getQuest().getQuestHelper());
 		startUpStep(steps.get(var));
 	}
 

--- a/src/main/java/com/questhelper/questhelpers/ComplexStateQuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/ComplexStateQuestHelper.java
@@ -53,7 +53,7 @@ public abstract class ComplexStateQuestHelper extends QuestHelper
 		this.config = config;
 		instantiateSteps(Collections.singletonList(step));
 		var = getVar();
-		sidebarOrder = questHelperPlugin.loadSidebarOrder(getQuest().getQuestHelper());
+		sidebarOrder = questHelperPlugin.loadSidebarOrder(this);
 		startUpStep(step);
 	}
 

--- a/src/main/java/com/questhelper/questhelpers/ComplexStateQuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/ComplexStateQuestHelper.java
@@ -53,6 +53,7 @@ public abstract class ComplexStateQuestHelper extends QuestHelper
 		this.config = config;
 		instantiateSteps(Collections.singletonList(step));
 		var = getVar();
+		sidebarOrder = questHelperPlugin.loadSidebarOrder(getQuest().getQuestHelper());
 		startUpStep(step);
 	}
 

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -96,6 +96,10 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 
 	private boolean hasInitialized;
 
+	@Getter
+	@Setter
+	protected List<Integer> sidebarOrder;
+
 	@Override
 	public void configure(Binder binder)
 	{

--- a/src/main/java/com/questhelper/steps/ConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ConditionalStep.java
@@ -70,7 +70,7 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	@Setter
 	protected boolean checkAllChildStepsOnListenerCall = false;
 
-	protected final LinkedHashMap<Requirement, QuestStep> steps;
+	protected LinkedHashMap<Requirement, QuestStep> steps;
 	protected final HashMap<Integer, QuestStep> orderedSteps;
 	protected final List<ChatMessageRequirement> chatConditions = new ArrayList<>();
 	protected final List<NpcCondition> npcConditions = new ArrayList<>();
@@ -323,55 +323,26 @@ public class ConditionalStep extends QuestStep implements OwnerStep
 	{
 		Requirement lastPossibleCondition = null;
 
-		List<Integer> sidebarOrder = questHelper.getSidebarOrder();
-		boolean sidebarOrderDefined = sidebarOrder != null;
-		int bestFoundPos = Integer.MAX_VALUE;
-
 		for (Requirement conditions : steps.keySet())
 		{
-			QuestStep step = steps.get(conditions);
-			boolean stepIsLocked = step.isLocked();
+			boolean stepIsLocked = steps.get(conditions).isLocked();
 			if (conditions != null && conditions.check(client) && !stepIsLocked)
 			{
-				if (sidebarOrderDefined && step.id != null)
-				{
-					int pos = sidebarOrder.indexOf(step.id);
-					if (pos < bestFoundPos)
-					{
-						bestFoundPos = pos;
-						lastPossibleCondition = conditions;
-					}
-					continue;
-				}
-				startUpStep(step);
+				startUpStep(steps.get(conditions));
 				return;
 			}
-			else if (step.isBlocker() && stepIsLocked)
+			else if (steps.get(conditions).isBlocker() && stepIsLocked)
 			{
 				startUpStep(steps.get(lastPossibleCondition));
 				return;
 			}
 			else if (conditions != null && !stepIsLocked)
 			{
-				if (sidebarOrderDefined && step.id != null)
-				{
-					int pos = sidebarOrder.indexOf(step.id);
-					if (pos < bestFoundPos)
-					{
-						bestFoundPos = pos;
-						lastPossibleCondition = conditions;
-						continue;
-					}
-				}
 				lastPossibleCondition = conditions;
 			}
 		}
 
-		if (sidebarOrderDefined)
-		{
-			startUpStep(steps.get(lastPossibleCondition));
-		}
-		else if (!steps.get(null).isLocked())
+		if (!steps.get(null).isLocked())
 		{
 			startUpStep(steps.get(null));
 		}

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -98,6 +98,9 @@ public abstract class QuestStep implements Module
 	TooltipManager tooltipManager;
 
 	@Getter
+	protected Integer id = null;
+
+	@Getter
 	protected List<String> text;
 
 	@Getter
@@ -211,6 +214,12 @@ public abstract class QuestStep implements Module
 
 	public void shutDown()
 	{
+	}
+
+	public QuestStep setId(Integer id)
+	{
+		this.id = id;
+		return this;
 	}
 
 	public void addSubSteps(QuestStep... substep)

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -216,7 +216,7 @@ public abstract class QuestStep implements Module
 	{
 	}
 
-	public QuestStep setId(Integer id)
+	public QuestStep withId(Integer id)
 	{
 		this.id = id;
 		return this;

--- a/src/main/java/com/questhelper/steps/ReorderableConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ReorderableConditionalStep.java
@@ -1,0 +1,55 @@
+package com.questhelper.steps;
+
+import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.requirements.Requirement;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+public class ReorderableConditionalStep extends ConditionalStep
+{
+
+    List<Integer> sideOrder = new ArrayList<>();
+    public ReorderableConditionalStep(QuestHelper questHelper, QuestStep step, Requirement... requirements)
+    {
+        super(questHelper, step, requirements);
+    }
+
+    private void organiseSteps()
+    {
+        LinkedHashMap<Requirement, QuestStep> newSteps = new LinkedHashMap<>();
+        for (Integer sidebarId : sideOrder)
+        {
+            for (Requirement req : steps.keySet())
+            {
+                QuestStep step = steps.get(req);
+                if (step.getId() == null) continue;
+                if (step.getId().equals(sidebarId))
+                {
+                    newSteps.put(req, step);
+                    break;
+                }
+            }
+        }
+        for (Requirement req : steps.keySet())
+        {
+            QuestStep step = steps.get(req);
+            if (step.getId() == null) newSteps.put(req, step);
+        }
+        steps = newSteps;
+    }
+
+    @Override
+    protected void updateSteps()
+    {
+        List<Integer> sidebarOrder = questHelper.getSidebarOrder();
+        if (sidebarOrder != this.sideOrder)
+        {
+            this.sideOrder = sidebarOrder;
+            organiseSteps();
+        }
+
+        super.updateSteps();
+    }
+}

--- a/src/main/java/com/questhelper/steps/ReorderableConditionalStep.java
+++ b/src/main/java/com/questhelper/steps/ReorderableConditionalStep.java
@@ -47,7 +47,7 @@ public class ReorderableConditionalStep extends ConditionalStep
         if (sidebarOrder != this.sideOrder)
         {
             this.sideOrder = sidebarOrder;
-            organiseSteps();
+            if (sideOrder != null) organiseSteps();
         }
 
         super.updateSteps();


### PR DESCRIPTION
This PR adds the ability for specific helpers to have reorganizable sidebars. This doesn't usually make sense for normal quests, but can be quite nice for repeatable content where players have ordering preferences like Farm Runs.

The current implementation allows for IDs to be attached to quest steps, and to side panel sections. The side panel by default is in the order of declaration as normal, but if you use a grip on a sidebar element to drag it up or down, it will save the new order by ID to the config.

<img width="351" height="568" alt="image" src="https://github.com/user-attachments/assets/1cf6a01e-8b83-4bc7-8e75-710e9958098f" />

The ConditionalStep current step check now will, if ids are specified, find the passing step which has the earliest index in the ordered list. This means it will for these helpers have to check all steps which is less efficient then the normal first-pass is used, but works especially when we're only dealing with lists of like 10 items.

## Logic currently requires all sidebar sections to be movable

Currently the logic for if a sidebar section will simply use a step if is lacking an ID with all other sections having IDs. This is nice for helpers where all sidebar sections are intended to have movability as it shows you what step is missing it (aka the selected one).

This current setup does not support only certain sidebar step sections being movable within limited ranges, as that'd overcomplicate things at this stage. Possibly useful at some point, but I'd lean to leaving that for another day where we discover such a need.

## ID Generation

I don't really like having such a manual definition process for matching IDs for panels and steps. Ideally I'd go for something like an auto-generated ID for a sidebar section, and then defining a sidebar section in assosciation with a step to link them. However, my concern for this is that any changes to sidebar steps which make them unique would then change them, which for the save functionality could be problematic.

I could possibly look to only define the id once for the sidebar panel, and then pass the sidebar panel in for each conditional step. I wanted to give this a bit more thought though to see if any better ideas would emerge.