### PR TITLE
Add Food recommendation to Vardorvis section of DT2

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/VardorvisSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/VardorvisSteps.java
@@ -67,7 +67,7 @@ public class VardorvisSteps extends ConditionalStep
 		inAnyStranglewood, inVardorvisArea, unlockedShortcut, defeatedVardorvis, templeKeyNearby, kasondeAggressive, givenKasondeKey, defeatedKasonde,
 		kasondeRevealedMedallion, gotVardorvisMedallion, inVault;
 	ItemRequirement potionNote, strangePotion, freezes, berry, herb, unfinishedSerum, serumWithHerb, stranglerSerum, templeKey,
-		vardorvisMedallion;
+		vardorvisMedallion, food;
 	Zone stranglewood, towerDefenseRoom, stranglewoodPyramidRoom, vardorvisArea, vault;
 
 	QuestBank questBank;
@@ -139,6 +139,7 @@ public class VardorvisSteps extends ConditionalStep
 
 		potionNote = new ItemRequirement("Potion note", ItemID.DT2_KASONDE_NOTE);
 		strangePotion = new ItemRequirement("Strange potion", ItemID.DT2_KASONDE_POTION);
+		food = new ItemRequirement("Bring high healing food to tank the infected.", -1);
 		freezes = new ItemRequirement("Freezing spells STRONGLY recommended + reasonable mage accuracy", -1);
 		berry = new ItemRequirement("Argian berries", ItemID.DT2_STRANGLEWOOD_BERRIES);
 		berry.setTooltip("You can get another from the south-west corner of The Stranglewood");
@@ -249,6 +250,7 @@ public class VardorvisSteps extends ConditionalStep
 
 		defendKasonde = new DetailedQuestStep(getQuestHelper(), "Defend Kasonde! Read the sidebar for more details.");
 		defendKasonde.addRecommended(freezes);
+		defendKasonde.addRecommended(food);
 		defendKasondeSidebar.addSubSteps(defendKasonde);
 
 		// TODO: Get actual coordinate and ladder ID!


### PR DESCRIPTION
vardorvis section doesn't tell you to get food until half way into the section and this is kinda annoying, thought adding a reminder to the start of the section where most people gear up would be better