### PR TITLE
Fix empty rune pouch

### DIFF
--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Item;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 
@@ -42,7 +43,7 @@ public class ItemAndLastUpdated
     // last game tick item container was changed
     @Getter
     private int lastUpdated = -1;
-    private Item[] items;
+    private Item[] items = new Item[0];
 
     @Setter
     private Callable<Item[]> specialMethodToObtainItems;
@@ -65,7 +66,7 @@ public class ItemAndLastUpdated
      *
      * @return an {@link Item}[] of items currently thought to be in the container.
      */
-    public @Nullable Item[] getItems()
+    public @Nonnull Item[] getItems()
     {
         if (specialMethodToObtainItems != null)
         {

--- a/src/main/java/com/questhelper/managers/QuestContainerManager.java
+++ b/src/main/java/com/questhelper/managers/QuestContainerManager.java
@@ -101,9 +101,9 @@ public class QuestContainerManager
         if (result)
         {
             Item[] runesInPouch = QuestContainerManager.getRunePouchData().getItems();
-            assert runesInPouch != null;
             for (Item runePouchItem : runesInPouch)
             {
+                if (runePouchItem == null) continue;
                 inventoryMap.computeIfPresent(runePouchItem.getId(), (currentVal, existingItem) -> new Item(currentVal, existingItem.getQuantity() + runePouchItem.getQuantity()));
                 inventoryMap.putIfAbsent(runePouchItem.getId(), runePouchItem);
             }


### PR DESCRIPTION
Both makes sure the rune pouch can't be Null for the Item[], as well as ensures each item in it isn't Null. fixes #2187 