### PR TITLE
fix: A Porcine of Interest slashItem tooltip

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
@@ -101,7 +101,7 @@ public class APorcineOfInterest extends BasicQuestHelper
 		rope.setHighlightInInventory(true);
 
 		slashItem = new ItemRequirement("A knife or slash weapon", ItemID.KNIFE).isNotConsumed();
-		slashItem.setTooltip("Except abyssal whip, abyssal tentacle, or dragon claws.");
+		slashItem.setTooltip("Except abyssal whip, abyssal tentacle, noxious halberd, or dragon claws.");
 
 		reinforcedGoggles = new ItemRequirement("Reinforced goggles", ItemID.SLAYER_REINFORCED_GOGGLES, 1, true).isNotConsumed();
 		reinforcedGoggles.setTooltip("You can get another pair from Spria");


### PR DESCRIPTION
The slash item tool tip during the quest doesn't mention Noxious Halberd as being a slash weapon that doesn't work https://oldschool.runescape.wiki/w/A_Porcine_of_Interest