### PR TITLE
feat: allow disabling of world map hint

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -535,6 +535,17 @@ public interface QuestHelperConfig extends Config
 	default boolean solvePuzzles() { return true; }
 
 	@ConfigItem(
+		keyName = "showWorldMapPoint",
+		name = "Display world map point",
+		description = "Choose whether the arrow & icon of your current step should be visible on the world map.<br>Changing this will take effect next time your quest step updates.",
+		section = hintsSection
+	)
+	default boolean showWorldMapPoint()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 			keyName = "useShortestPath",
 			name = "Use 'Shortest Path' plugin",
 			description = "If you have the 'Shortest Path' plugin downloaded, it will be used to show routes to locations",

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -169,8 +169,11 @@ public class DetailedQuestStep extends QuestStep
 		super.startUp();
 		if (worldPoint != null)
 		{
-			mapPoint = new QuestHelperWorldMapPoint(worldPoint, getQuestImage());
-			worldMapPointManager.add(mapPoint);
+			if (questHelper.getConfig().showWorldMapPoint())
+			{
+				mapPoint = new QuestHelperWorldMapPoint(worldPoint, getQuestImage());
+				worldMapPointManager.add(mapPoint);
+			}
 
 			setShortestPath();
 		}
@@ -251,8 +254,11 @@ public class DetailedQuestStep extends QuestStep
 			}
 			if (worldPoint != null)
 			{
-				mapPoint = new QuestHelperWorldMapPoint(worldPoint, getQuestImage());
-				worldMapPointManager.add(mapPoint);
+				if (questHelper.getConfig().showWorldMapPoint())
+				{
+					mapPoint = new QuestHelperWorldMapPoint(worldPoint, getQuestImage());
+					worldMapPointManager.add(mapPoint);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Requested in Discord by Aesto https://discord.com/channels/772056816242130964/776427467560321034/1399132311215407278

Seems like this fit in with the concept of allowing users to get as little guidance as they want

No default behaviour has changed. I kept the implementation minimal by not making the setting automatically update, so it only updates the next time your quest step updates, which I think is fair.
