### PR TITLE
fix: The Great Brain Robbery correctly requires a disposable hammer

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -218,7 +218,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		plank = new ItemRequirement("Plank", ItemID.WOODPLANK);
 		fur = new ItemRequirement("Fur", ItemID.FUR);
 		fur.addAlternates(ItemID.WEREWOLVE_FUR, ItemID.GREY_WOLF_FUR);
-		hammer = new ItemRequirement("Hammer", ItemCollections.HAMMER).isNotConsumed();
+		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).isNotConsumed();
 		hammer.setTooltip("a standard hammer, NOT Imcando Hammer, as it will be given to Dr. Fenkenstrain");
 		nails = new ItemRequirement("Nails", ItemCollections.NAILS);
 		holySymbol = new ItemRequirement("Holy symbol", ItemID.BLESSEDSTAR).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
+++ b/src/main/java/com/questhelper/helpers/quests/thegreatbrainrobbery/TheGreatBrainRobbery.java
@@ -218,7 +218,7 @@ public class TheGreatBrainRobbery extends BasicQuestHelper
 		plank = new ItemRequirement("Plank", ItemID.WOODPLANK);
 		fur = new ItemRequirement("Fur", ItemID.FUR);
 		fur.addAlternates(ItemID.WEREWOLVE_FUR, ItemID.GREY_WOLF_FUR);
-		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).isNotConsumed();
+		hammer = new ItemRequirement("Hammer", ItemID.HAMMER);
 		hammer.setTooltip("a standard hammer, NOT Imcando Hammer, as it will be given to Dr. Fenkenstrain");
 		nails = new ItemRequirement("Nails", ItemCollections.NAILS);
 		holySymbol = new ItemRequirement("Holy symbol", ItemID.BLESSEDSTAR).isNotConsumed();


### PR DESCRIPTION
Relates to issue: https://github.com/Zoinkwiz/quest-helper/issues/2133

ItemID.IMCANDO_HAMMER was allowed for the quest, but a real hammer is needed to hand in the hammer to Frankenstein.

The hammer is consumed