### PR TITLE
fix: add Amy's saw (offhand) as a possible Saw

### DIFF
--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -170,6 +170,7 @@ public enum ItemCollections
 	SAW("Saw", ImmutableList.of(
 		ItemID.POH_SAW,
 		ItemID.WEARABLE_SAW,
+		ItemID.WEARABLE_SAW_OFFHAND,
 		ItemID.EYEGLO_CRYSTAL_SAW
 	)),
 


### PR DESCRIPTION
Only tested in the "Scrambled!" quest, but unless Jagex spaghetti has taken over it should work everywhere where the
mainhand version works.
