### PR TITLE
polish: Cook's Assistant

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -29,6 +29,7 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import static com.questhelper.requirements.util.LogicHelper.and;
+import static com.questhelper.requirements.util.LogicHelper.not;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
@@ -165,19 +166,23 @@ public class CooksAssistant extends BasicQuestHelper
 		setupSteps();
 
 		var steps = new HashMap<Integer, QuestStep>();
-		var doQuest = new ConditionalStep(this, getBucket);
-		doQuest.addStep(and(milk, flour, egg), finishQuest);
-		doQuest.addStep(and(milk, pot, egg, controlsUsed, inMillThird), climbLadderThree);
-		doQuest.addStep(and(milk, pot, egg, controlsUsed, inMillSecond), climbLadderTwoDown);
-		doQuest.addStep(and(milk, pot, egg, controlsUsed), collectFlour);
-		doQuest.addStep(and(milk, pot, egg, grain, inMillThird), fillHopper);
-		doQuest.addStep(and(milk, pot, egg, inMillThird), operateControls);
-		doQuest.addStep(and(milk, pot, egg, grain, inMillSecond), climbLadderTwoUp);
-		doQuest.addStep(and(milk, pot, egg, grain), climbLadderOne);
-		doQuest.addStep(and(milk, pot, egg), getWheat);
-		doQuest.addStep(and(milk, pot), getEgg);
-		doQuest.addStep(and(bucket, pot), milkCow);
-		doQuest.addStep(bucket, getPot);
+
+		var getFlour = new ConditionalStep(this, getPot);
+		getFlour.addStep(and(pot, controlsUsed, inMillThird), climbLadderThree);
+		getFlour.addStep(and(pot, controlsUsed, inMillSecond), climbLadderTwoDown);
+		getFlour.addStep(and(pot, controlsUsed), collectFlour);
+		getFlour.addStep(and(pot, grain, inMillThird), fillHopper);
+		getFlour.addStep(and(pot, inMillThird), operateControls);
+		getFlour.addStep(and(pot, grain, inMillSecond), climbLadderTwoUp);
+		getFlour.addStep(and(pot, grain), climbLadderOne);
+		getFlour.addStep(and(pot), getWheat);
+
+		var doQuest = new ConditionalStep(this, finishQuest);
+		doQuest.addStep(and(not(milk), not(bucket)), getBucket);
+		doQuest.addStep(and(not(flour), not(pot)), getPot);
+		doQuest.addStep(not(egg), getEgg);
+		doQuest.addStep(not(flour), getFlour);
+		doQuest.addStep(not(milk), milkCow);
 
 		steps.put(0, doQuest);
 		steps.put(1, doQuest);
@@ -238,12 +243,6 @@ public class CooksAssistant extends BasicQuestHelper
 			coins.quantity(3)
 		)));
 
-		steps.add(new PanelDetails("Getting the Milk", List.of(
-			milkCow
-		), List.of(
-			bucket
-		)));
-
 		steps.add(new PanelDetails("Getting the Egg", List.of(
 			getEgg
 		)));
@@ -257,6 +256,12 @@ public class CooksAssistant extends BasicQuestHelper
 			collectFlour
 		), List.of(
 			pot
+		)));
+
+		steps.add(new PanelDetails("Getting the Milk", List.of(
+			milkCow
+		), List.of(
+			bucket
 		)));
 
 		steps.add(new PanelDetails("Finishing up", List.of(

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -107,7 +107,7 @@ public class CooksAssistant extends BasicQuestHelper
 		flour.canBeObtainedDuringQuest();
 		bucket = new ItemRequirement("Bucket", ItemID.BUCKET_EMPTY);
 		pot = new ItemRequirement("Pot", ItemID.POT_EMPTY);
-		coins = new ItemRequirement("Coins", ItemCollections.COINS);
+		coins = new ItemRequirement("Coins", ItemCollections.COINS, 3);
 		coins.setTooltip("Necessary if you do not have a pot / bucket");
 		grain = new ItemRequirement("Grain", ItemID.GRAIN);
 
@@ -125,11 +125,11 @@ public class CooksAssistant extends BasicQuestHelper
 		};
 
 		getBucket = new NpcStep(this, lumbridgeShopkeepers, new WorldPoint(3212, 3246, 0),
-			"Purchase a bucket from the Lumbridge General Store.", coins.quantity(3));
+			"Purchase a bucket from the Lumbridge General Store.", coins.quantity(2));
 		getBucket.addWidgetHighlight(WidgetHighlight.createShopItemHighlight(ItemID.BUCKET_EMPTY));
 
 		getPot = new NpcStep(this, lumbridgeShopkeepers, new WorldPoint(3212, 3246, 0),
-			"Purchase a pot from the Lumbridge General Store.", coins.quantity(3));
+			"Purchase a pot from the Lumbridge General Store.", coins.quantity(1));
 
 		getEgg = new ItemStep(this, new WorldPoint(3177, 3296, 0),
 			"Grab an egg from the farm north of Lumbridge.", egg);
@@ -247,7 +247,7 @@ public class CooksAssistant extends BasicQuestHelper
 			getBucket,
 			getPot
 		), List.of(
-			coins.quantity(3)
+			coins
 		)));
 
 		steps.add(new PanelDetails("Getting the Egg", List.of(

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -126,6 +126,7 @@ public class CooksAssistant extends BasicQuestHelper
 		getBucket.addAlternateNpcs(NpcID.GENERALASSISTANT1);
 		getPot = new NpcStep(this, NpcID.GENERALSHOPKEEPER1, new WorldPoint(3212, 3246, 0),
 			"Purchase a pot from the Lumbridge General Store.", coins.quantity(3));
+		// TODO: highlight a pot to purchase
 		getPot.addAlternateNpcs(NpcID.GENERALASSISTANT1);
 		milkCow = new ObjectStep(this, ObjectID.FAT_COW, new WorldPoint(3254, 3272, 0),
 			"Milk the cow north-east of Lumbridge.", bucket);

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -119,18 +119,20 @@ public class CooksAssistant extends BasicQuestHelper
 
 	public void setupSteps()
 	{
-		getEgg = new ItemStep(this, new WorldPoint(3177, 3296, 0),
-			"Grab an egg from the farm north of Lumbridge.", egg);
-		getBucket = new NpcStep(this, NpcID.GENERALSHOPKEEPER1, new WorldPoint(3212, 3246, 0),
+		var lumbridgeShopkeepers = new int[]{
+			NpcID.GENERALSHOPKEEPER1,
+			NpcID.GENERALASSISTANT1,
+		};
+
+		getBucket = new NpcStep(this, lumbridgeShopkeepers, new WorldPoint(3212, 3246, 0),
 			"Purchase a bucket from the Lumbridge General Store.", coins.quantity(3));
 		getBucket.addWidgetHighlight(WidgetHighlight.createShopItemHighlight(ItemID.BUCKET_EMPTY));
-		getBucket.addAlternateNpcs(NpcID.GENERALASSISTANT1);
-		getPot = new NpcStep(this, NpcID.GENERALSHOPKEEPER1, new WorldPoint(3212, 3246, 0),
+
+		getPot = new NpcStep(this, lumbridgeShopkeepers, new WorldPoint(3212, 3246, 0),
 			"Purchase a pot from the Lumbridge General Store.", coins.quantity(3));
-		// TODO: highlight a pot to purchase
-		getPot.addAlternateNpcs(NpcID.GENERALASSISTANT1);
-		milkCow = new ObjectStep(this, ObjectID.FAT_COW, new WorldPoint(3254, 3272, 0),
-			"Milk the cow north-east of Lumbridge.", bucket);
+
+		getEgg = new ItemStep(this, new WorldPoint(3177, 3296, 0),
+			"Grab an egg from the farm north of Lumbridge.", egg);
 		getWheat = new ObjectStep(this, ObjectID.FAI_VARROCK_WHEAT_CORNER, new WorldPoint(3161, 3292, 0),
 			"Pick some wheat north of Lumbridge.");
 		climbLadderOne = new ObjectStep(this, ObjectID.QIP_COOK_LADDER, new WorldPoint(3164, 3307, 0),
@@ -153,9 +155,14 @@ public class CooksAssistant extends BasicQuestHelper
 		collectFlour = new ObjectStep(this, ObjectID.MILLBASE_FLOUR, new WorldPoint(3166, 3306, 0),
 			"Collect the flour in the bin.", pot.highlighted());
 		collectFlour.addIcon(ItemID.POT_EMPTY);
-		finishQuest = new NpcStep(this, NpcID.POH_SERVANT_COOK_WOMAN, new WorldPoint(3206, 3214, 0),
+
+		milkCow = new ObjectStep(this, ObjectID.FAT_COW, new WorldPoint(3172, 3317, 0),
+			"Milk the dairy cow north of Lumbridge.", bucket);
+
+		finishQuest = new NpcStep(this, NpcID.COOK, new WorldPoint(3206, 3214, 0),
 			"Give the Cook in Lumbridge Castle's kitchen the required items to finish the quest.",
 			egg, milk, flour);
+		finishQuest.addAlternateNpcs(NpcID.POH_SERVANT_COOK_WOMAN);
 		finishQuest.addDialogSteps("What's wrong?", "Can I help?", "Yes.");
 	}
 

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -31,6 +31,7 @@ import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import static com.questhelper.requirements.util.LogicHelper.and;
 import static com.questhelper.requirements.util.LogicHelper.not;
+import com.questhelper.requirements.npc.DialogRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
@@ -70,6 +71,10 @@ public class CooksAssistant extends BasicQuestHelper
 	Zone millThird;
 
 	// Miscellaneous requirements
+	DialogRequirement hasTurnedInMilk;
+	DialogRequirement hasTurnedInFlour;
+	DialogRequirement hasTurnedInEgg;
+
 	VarbitRequirement controlsUsed;
 
 	ZoneRequirement inMillSecond;
@@ -100,11 +105,18 @@ public class CooksAssistant extends BasicQuestHelper
 	@Override
 	protected void setupRequirements()
 	{
+		hasTurnedInMilk = new DialogRequirement("Here's a bucket of milk.");
+		hasTurnedInFlour = new DialogRequirement("Here's a pot of flour.");
+		hasTurnedInEgg = new DialogRequirement("Here's a fresh egg.");
+
 		egg = new ItemRequirement("Egg", ItemID.EGG);
+		egg.setConditionToHide(hasTurnedInEgg);
 		egg.canBeObtainedDuringQuest();
 		milk = new ItemRequirement("Bucket of milk", ItemID.BUCKET_MILK);
+		milk.setConditionToHide(hasTurnedInMilk);
 		milk.canBeObtainedDuringQuest();
 		flour = new ItemRequirement("Pot of flour", ItemID.POT_FLOUR);
+		flour.setConditionToHide(hasTurnedInFlour);
 		flour.canBeObtainedDuringQuest();
 		bucket = new ItemRequirement("Bucket", ItemID.BUCKET_EMPTY);
 		pot = new ItemRequirement("Pot", ItemID.POT_EMPTY);
@@ -176,6 +188,7 @@ public class CooksAssistant extends BasicQuestHelper
 
 		var steps = new HashMap<Integer, QuestStep>();
 
+
 		var getFlour = new ConditionalStep(this, getPot);
 		getFlour.addStep(and(pot, controlsUsed, inMillThird), climbLadderThree);
 		getFlour.addStep(and(pot, controlsUsed, inMillSecond), climbLadderTwoDown);
@@ -187,11 +200,11 @@ public class CooksAssistant extends BasicQuestHelper
 		getFlour.addStep(and(pot), getWheat);
 
 		var doQuest = new ConditionalStep(this, finishQuest);
-		doQuest.addStep(and(not(milk), not(bucket)), getBucket);
-		doQuest.addStep(and(not(flour), not(pot)), getPot);
-		doQuest.addStep(not(egg), getEgg);
-		doQuest.addStep(not(flour), getFlour);
-		doQuest.addStep(not(milk), milkCow);
+		doQuest.addStep(and(not(milk), not(bucket), not(hasTurnedInMilk)), getBucket);
+		doQuest.addStep(and(not(flour), not(pot), not(hasTurnedInFlour)), getPot);
+		doQuest.addStep(and(not(egg), not(hasTurnedInEgg)), getEgg);
+		doQuest.addStep(and(not(flour), not(hasTurnedInFlour)), getFlour);
+		doQuest.addStep(and(not(milk), not(hasTurnedInMilk)), milkCow);
 
 		steps.put(0, doQuest);
 		steps.put(1, doQuest);

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -130,6 +130,7 @@ public class CooksAssistant extends BasicQuestHelper
 
 		getPot = new NpcStep(this, lumbridgeShopkeepers, new WorldPoint(3212, 3246, 0),
 			"Purchase a pot from the Lumbridge General Store.", coins.quantity(1));
+		getPot.addWidgetHighlight(WidgetHighlight.createShopItemHighlight(ItemID.POT_EMPTY));
 
 		getEgg = new ItemStep(this, new WorldPoint(3177, 3296, 0),
 			"Grab an egg from the farm north of Lumbridge.", egg);

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -27,66 +27,70 @@ package com.questhelper.helpers.quests.cooksassistant;
 import com.questhelper.collections.ItemCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
-import com.questhelper.requirements.Requirement;
-import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
+import static com.questhelper.requirements.util.LogicHelper.and;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.*;
+import com.questhelper.steps.ConditionalStep;
+import com.questhelper.steps.ItemStep;
+import com.questhelper.steps.NpcStep;
+import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.QuestStep;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.ObjectID;
 
-import java.util.*;
-
 public class CooksAssistant extends BasicQuestHelper
 {
-	//Items Required
-	ItemRequirement egg, milk, flour, bucket, pot, coins, grain;
+	// Required items
+	ItemRequirement egg;
+	ItemRequirement milk;
+	ItemRequirement flour;
+	ItemRequirement bucket;
+	ItemRequirement pot;
+	ItemRequirement coins;
+	ItemRequirement grain;
 
-	Requirement controlsUsed;
+	// Zones
+	Zone millSecond;
+	Zone millThird;
 
-	QuestStep getEgg, getWheat, milkCow, climbLadderOne, climbLadderTwoUp, climbLadderTwoDown, climbLadderThree, fillHopper,
-		operateControls, collectFlour, finishQuest;
+	// Miscellaneous requirements
+	VarbitRequirement controlsUsed;
 
-	NpcStep getPot, getBucket;
+	ZoneRequirement inMillSecond;
+	ZoneRequirement inMillThird;
 
-	Zone millSecond, millThird;
-
-	Requirement inMillSecond, inMillThird;
+	// Steps
+	NpcStep getBucket;
+	NpcStep getPot;
+	ObjectStep milkCow;
+	ItemStep getEgg;
+	ObjectStep getWheat;
+	ObjectStep climbLadderOne;
+	ObjectStep fillHopper;
+	ObjectStep operateControls;
+	ObjectStep climbLadderThree;
+	ObjectStep collectFlour;
+	ObjectStep climbLadderTwoUp;
+	ObjectStep climbLadderTwoDown;
+	NpcStep finishQuest;
 
 	@Override
-	public Map<Integer, QuestStep> loadSteps()
+	protected void setupZones()
 	{
-		initializeRequirements();
-		setupConditions();
-		setupSteps();
-
-		Map<Integer, QuestStep> steps = new HashMap<>();
-		ConditionalStep doQuest = new ConditionalStep(this, getBucket);
-		doQuest.addStep(new Conditions(milk, flour, egg), finishQuest);
-		doQuest.addStep(new Conditions(milk, pot, egg, controlsUsed, inMillThird), climbLadderThree);
-		doQuest.addStep(new Conditions(milk, pot, egg, controlsUsed, inMillSecond), climbLadderTwoDown);
-		doQuest.addStep(new Conditions(milk, pot, egg, controlsUsed), collectFlour);
-		doQuest.addStep(new Conditions(milk, pot, egg, grain, inMillThird), fillHopper);
-		doQuest.addStep(new Conditions(milk, pot, egg, inMillThird), operateControls);
-		doQuest.addStep(new Conditions(milk, pot, egg, grain, inMillSecond), climbLadderTwoUp);
-		doQuest.addStep(new Conditions(milk, pot, egg, grain), climbLadderOne);
-		doQuest.addStep(new Conditions(milk, pot, egg), getWheat);
-		doQuest.addStep(new Conditions(milk, pot), getEgg);
-		doQuest.addStep(new Conditions(bucket, pot), milkCow);
-		doQuest.addStep(bucket, getPot);
-
-		steps.put(0, doQuest);
-		steps.put(1, doQuest);
-
-		return steps;
+		millSecond = new Zone(new WorldPoint(3162, 3311, 1), new WorldPoint(3171, 3302, 1));
+		millThird = new Zone(new WorldPoint(3162, 3311, 2), new WorldPoint(3171, 3302, 2));
 	}
 
 	@Override
@@ -105,17 +109,7 @@ public class CooksAssistant extends BasicQuestHelper
 		grain = new ItemRequirement("Grain", ItemID.GRAIN);
 
 		controlsUsed = new VarbitRequirement(4920, 1);
-	}
 
-	@Override
-	protected void setupZones()
-	{
-		millSecond = new Zone(new WorldPoint(3162, 3311, 1), new WorldPoint(3171, 3302, 1));
-		millThird = new Zone(new WorldPoint(3162, 3311, 2), new WorldPoint(3171, 3302, 2));
-	}
-
-	public void setupConditions()
-	{
 		inMillSecond = new ZoneRequirement(millSecond);
 		inMillThird = new ZoneRequirement(millThird);
 	}
@@ -162,19 +156,49 @@ public class CooksAssistant extends BasicQuestHelper
 	}
 
 	@Override
+	public Map<Integer, QuestStep> loadSteps()
+	{
+		initializeRequirements();
+		setupSteps();
+
+		var steps = new HashMap<Integer, QuestStep>();
+		ConditionalStep doQuest = new ConditionalStep(this, getBucket);
+		doQuest.addStep(and(milk, flour, egg), finishQuest);
+		doQuest.addStep(and(milk, pot, egg, controlsUsed, inMillThird), climbLadderThree);
+		doQuest.addStep(and(milk, pot, egg, controlsUsed, inMillSecond), climbLadderTwoDown);
+		doQuest.addStep(and(milk, pot, egg, controlsUsed), collectFlour);
+		doQuest.addStep(and(milk, pot, egg, grain, inMillThird), fillHopper);
+		doQuest.addStep(and(milk, pot, egg, inMillThird), operateControls);
+		doQuest.addStep(and(milk, pot, egg, grain, inMillSecond), climbLadderTwoUp);
+		doQuest.addStep(and(milk, pot, egg, grain), climbLadderOne);
+		doQuest.addStep(and(milk, pot, egg), getWheat);
+		doQuest.addStep(and(milk, pot), getEgg);
+		doQuest.addStep(and(bucket, pot), milkCow);
+		doQuest.addStep(bucket, getPot);
+
+		steps.put(0, doQuest);
+		steps.put(1, doQuest);
+
+		return steps;
+	}
+
+
+	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		ArrayList<ItemRequirement> reqs = new ArrayList<>();
-		reqs.add(egg);
-		reqs.add(flour);
-		reqs.add(milk);
-		return reqs;
+		return List.of(
+			egg,
+			flour,
+			milk
+		);
 	}
 
 	@Override
 	public List<ItemRequirement> getItemRecommended()
 	{
-		return Collections.singletonList(coins);
+		return List.of(
+			coins
+		);
 	}
 
 	@Override
@@ -186,26 +210,60 @@ public class CooksAssistant extends BasicQuestHelper
 	@Override
 	public List<ExperienceReward> getExperienceRewards()
 	{
-		return Collections.singletonList(new ExperienceReward(Skill.COOKING, 300));
+		return List.of(
+			new ExperienceReward(Skill.COOKING, 300)
+		);
 	}
 
 	@Override
 	public List<UnlockReward> getUnlockRewards()
 	{
-		return Collections.singletonList(new UnlockReward("Permission to use The Cook's range."));
+		return List.of(
+			new UnlockReward("Permission to use The Cook's range.")
+		);
 	}
 
 	@Override
 	public List<PanelDetails> getPanels()
 	{
-		List<PanelDetails> allSteps = new ArrayList<>();
-		allSteps.add(new PanelDetails("Starting off", Arrays.asList(getBucket, getPot), coins.quantity(3)));
-		allSteps.add(new PanelDetails("Getting the Milk", Collections.singletonList(milkCow), bucket));
-		allSteps.add(new PanelDetails("Getting the Egg", Collections.singletonList(getEgg)));
-		allSteps.add(new PanelDetails("Getting the Flour", Arrays.asList(getWheat, climbLadderOne, fillHopper,
-			operateControls, climbLadderThree, collectFlour), pot));
-		allSteps.add(new PanelDetails("Finishing up", Collections.singletonList(finishQuest), egg, flour, milk));
+		var steps = new ArrayList<PanelDetails>();
 
-		return allSteps;
+		steps.add(new PanelDetails("Starting off", List.of(
+			getBucket,
+			getPot
+		), List.of(
+			coins.quantity(3)
+		)));
+
+		steps.add(new PanelDetails("Getting the Milk", List.of(
+			milkCow
+		), List.of(
+			bucket
+		)));
+
+		steps.add(new PanelDetails("Getting the Egg", List.of(
+			getEgg
+		)));
+
+		steps.add(new PanelDetails("Getting the Flour", List.of(
+			getWheat,
+			climbLadderOne,
+			fillHopper,
+			operateControls,
+			climbLadderThree,
+			collectFlour
+		), List.of(
+			pot
+		)));
+
+		steps.add(new PanelDetails("Finishing up", List.of(
+			finishQuest
+		), List.of(
+			egg,
+			flour,
+			milk
+		)));
+
+		return steps;
 	}
 }

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -163,7 +163,7 @@ public class CooksAssistant extends BasicQuestHelper
 		setupSteps();
 
 		var steps = new HashMap<Integer, QuestStep>();
-		ConditionalStep doQuest = new ConditionalStep(this, getBucket);
+		var doQuest = new ConditionalStep(this, getBucket);
 		doQuest.addStep(and(milk, flour, egg), finishQuest);
 		doQuest.addStep(and(milk, pot, egg, controlsUsed, inMillThird), climbLadderThree);
 		doQuest.addStep(and(milk, pot, egg, controlsUsed, inMillSecond), climbLadderTwoDown);

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -49,6 +49,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.VarbitID;
 
 public class CooksAssistant extends BasicQuestHelper
 {
@@ -108,7 +109,7 @@ public class CooksAssistant extends BasicQuestHelper
 		coins.setTooltip("Necessary if you do not have a pot / bucket");
 		grain = new ItemRequirement("Grain", ItemID.GRAIN);
 
-		controlsUsed = new VarbitRequirement(4920, 1);
+		controlsUsed = new VarbitRequirement(VarbitID.MILL_FLOUR, 1);
 
 		inMillSecond = new ZoneRequirement(millSecond);
 		inMillThird = new ZoneRequirement(millThird);

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -30,7 +30,9 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import static com.questhelper.requirements.util.LogicHelper.and;
-import static com.questhelper.requirements.util.LogicHelper.not;
+import static com.questhelper.requirements.util.LogicHelper.nand;
+import static com.questhelper.requirements.util.LogicHelper.nor;
+import static com.questhelper.requirements.util.LogicHelper.or;
 import com.questhelper.requirements.npc.DialogRequirement;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.Zone;
@@ -74,6 +76,7 @@ public class CooksAssistant extends BasicQuestHelper
 	DialogRequirement hasTurnedInMilk;
 	DialogRequirement hasTurnedInFlour;
 	DialogRequirement hasTurnedInEgg;
+	DialogRequirement hasTurnedInEverything;
 
 	VarbitRequirement controlsUsed;
 
@@ -108,15 +111,16 @@ public class CooksAssistant extends BasicQuestHelper
 		hasTurnedInMilk = new DialogRequirement("Here's a bucket of milk.");
 		hasTurnedInFlour = new DialogRequirement("Here's a pot of flour.");
 		hasTurnedInEgg = new DialogRequirement("Here's a fresh egg.");
+		hasTurnedInEverything = new DialogRequirement("You've brought me everything I need! I am saved!");
 
 		egg = new ItemRequirement("Egg", ItemID.EGG);
-		egg.setConditionToHide(hasTurnedInEgg);
+		egg.setConditionToHide(or(hasTurnedInEgg, hasTurnedInEverything));
 		egg.canBeObtainedDuringQuest();
 		milk = new ItemRequirement("Bucket of milk", ItemID.BUCKET_MILK);
-		milk.setConditionToHide(hasTurnedInMilk);
+		milk.setConditionToHide(or(hasTurnedInMilk, hasTurnedInEverything));
 		milk.canBeObtainedDuringQuest();
 		flour = new ItemRequirement("Pot of flour", ItemID.POT_FLOUR);
-		flour.setConditionToHide(hasTurnedInFlour);
+		flour.setConditionToHide(or(hasTurnedInFlour, hasTurnedInEverything));
 		flour.canBeObtainedDuringQuest();
 		bucket = new ItemRequirement("Bucket", ItemID.BUCKET_EMPTY);
 		pot = new ItemRequirement("Pot", ItemID.POT_EMPTY);
@@ -200,11 +204,12 @@ public class CooksAssistant extends BasicQuestHelper
 		getFlour.addStep(and(pot), getWheat);
 
 		var doQuest = new ConditionalStep(this, finishQuest);
-		doQuest.addStep(and(not(milk), not(bucket), not(hasTurnedInMilk)), getBucket);
-		doQuest.addStep(and(not(flour), not(pot), not(hasTurnedInFlour)), getPot);
-		doQuest.addStep(and(not(egg), not(hasTurnedInEgg)), getEgg);
-		doQuest.addStep(and(not(flour), not(hasTurnedInFlour)), getFlour);
-		doQuest.addStep(and(not(milk), not(hasTurnedInMilk)), milkCow);
+		doQuest.addStep(hasTurnedInEverything, finishQuest);
+		doQuest.addStep(nor(milk, bucket, hasTurnedInMilk), getBucket);
+		doQuest.addStep(nor(flour, pot, hasTurnedInFlour), getPot);
+		doQuest.addStep(nor(egg, hasTurnedInEgg), getEgg);
+		doQuest.addStep(nor(flour, hasTurnedInFlour), getFlour);
+		doQuest.addStep(nor(milk, hasTurnedInMilk), milkCow);
 
 		steps.put(0, doQuest);
 		steps.put(1, doQuest);

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -30,7 +30,6 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import static com.questhelper.requirements.util.LogicHelper.and;
-import static com.questhelper.requirements.util.LogicHelper.nand;
 import static com.questhelper.requirements.util.LogicHelper.nor;
 import static com.questhelper.requirements.util.LogicHelper.or;
 import com.questhelper.requirements.npc.DialogRequirement;

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Trevor <https://github.com/Trevor159>
+ * Copyright (c) 2025, pajlada <https://github.com/pajlada>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
+++ b/src/main/java/com/questhelper/helpers/quests/cooksassistant/CooksAssistant.java
@@ -40,6 +40,7 @@ import com.questhelper.steps.ItemStep;
 import com.questhelper.steps.NpcStep;
 import com.questhelper.steps.ObjectStep;
 import com.questhelper.steps.QuestStep;
+import com.questhelper.steps.widget.WidgetHighlight;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -121,7 +122,7 @@ public class CooksAssistant extends BasicQuestHelper
 			"Grab an egg from the farm north of Lumbridge.", egg);
 		getBucket = new NpcStep(this, NpcID.GENERALSHOPKEEPER1, new WorldPoint(3212, 3246, 0),
 			"Purchase a bucket from the Lumbridge General Store.", coins.quantity(3));
-		getBucket.addWidgetHighlightWithItemIdRequirement(300, 16, ItemID.BUCKET_EMPTY, true);
+		getBucket.addWidgetHighlight(WidgetHighlight.createShopItemHighlight(ItemID.BUCKET_EMPTY));
 		getBucket.addAlternateNpcs(NpcID.GENERALASSISTANT1);
 		getPot = new NpcStep(this, NpcID.GENERALSHOPKEEPER1, new WorldPoint(3212, 3246, 0),
 			"Purchase a pot from the Lumbridge General Store.", coins.quantity(3));

--- a/src/main/java/com/questhelper/steps/widget/WidgetHighlight.java
+++ b/src/main/java/com/questhelper/steps/widget/WidgetHighlight.java
@@ -117,6 +117,18 @@ public class WidgetHighlight extends AbstractWidgetHighlight
 		return w;
 	}
 
+	/**
+	 * Create a widget highlight that highlights an item inside the shop interface (e.g. general store)
+	 * @param itemIdRequirement The ID of the item to highlight
+	 * @return a fully built WidgetHighlight
+	 */
+	public static WidgetHighlight createShopItemHighlight(int itemIdRequirement)
+	{
+		var w = new WidgetHighlight(InterfaceID.Shopmain.ITEMS, true);
+		w.itemIdRequirement = itemIdRequirement;
+		return w;
+	}
+
 	@Override
 	public void highlightChoices(Graphics2D graphics, Client client, QuestHelperPlugin questHelper)
 	{


### PR DESCRIPTION
Same idea as the previous polishes, some refactor commits first, and then the actual meaty updates (if any)

I believe I cleaned up this fairly recently so it shouldn't need many changes

What's actually changed:
Some highlights
fixed cook NPC ID (it was just NpcID.COOK). Confirmed in normal f2p worlds & speedrun worlds
changed the order to egg -> mill -> milk to match speedrun strategies
changed which cow to milk to the one north of lumbridge instead