### PR TITLE
fix: speed up sidebar step test

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/MonolithPuzzle.java
+++ b/src/main/java/com/questhelper/helpers/quests/thepathofglouphrie/MonolithPuzzle.java
@@ -250,6 +250,10 @@ public class MonolithPuzzle extends DetailedOwnerStep
 	private boolean tileHasBigMonolith(Tile[][] tiles, int sceneX, int sceneY)
 	{
 		var tile = tiles[sceneX][sceneY];
+		if (tile == null) {
+			// Tiles normally aren't null, but in tests they can be.
+			return false;
+		}
 		for (var gameObject : tile.getGameObjects())
 		{
 			if (gameObject != null && gameObject.getId() == BIG_MONOLITH)

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -838,15 +838,25 @@ public class DetailedQuestStep extends QuestStep
 	@Override
 	public void setShortestPath()
 	{
-		if (worldPoint != null && !isLineDrawn())
+		if (worldPoint == null)
 		{
-			WorldPoint playerWp = client.getLocalPlayer().getWorldLocation();
-			if (getQuestHelper().getConfig().useShortestPath() && playerWp != null) {
-				Map<String, Object> data = new HashMap<>();
-				data.put("start", playerWp);
-				data.put("target", worldPoint);
-				eventBus.post(new PluginMessage("shortestpath", "path", data));
-			}
+			return;
+		}
+		if (isLineDrawn())
+		{
+			return;
+		}
+		var playerWp = client.getLocalPlayer().getWorldLocation();
+		if (playerWp == null)
+		{
+			return;
+		}
+		if (getQuestHelper().getConfig().useShortestPath())
+		{
+			Map<String, Object> data = new HashMap<>();
+			data.put("start", playerWp);
+			data.put("target", worldPoint);
+			eventBus.post(new PluginMessage("shortestpath", "path", data));
 		}
 	}
 

--- a/src/test/java/com/questhelper/MockedTest.java
+++ b/src/test/java/com/questhelper/MockedTest.java
@@ -32,6 +32,8 @@ import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectMan
 import com.questhelper.statemanagement.AchievementDiaryStepManager;
 import com.questhelper.statemanagement.PlayerStateManager;
 import net.runelite.api.*;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.callback.Hooks;
 import net.runelite.client.chat.ChatMessageManager;
@@ -43,12 +45,14 @@ import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.AsyncBufferedImage;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import javax.inject.Named;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.IntStream;
 
 import static org.mockito.Mockito.*;
 
@@ -128,19 +132,45 @@ public abstract class MockedTest extends MockedTestBase
 		when(questHelperConfig.solvePuzzles()).thenReturn(true);
 		when(spriteManager.getSprite(SpriteID.TAB_QUESTS, 0)).thenReturn(new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB));
 
+
 		AchievementDiaryStepManager.setup(configManager);
 
+		var mockedScene = mock(Scene.class);
+		when(mockedScene.getTiles()).thenReturn(new Tile[1][Constants.SCENE_SIZE][Constants.SCENE_SIZE]);
+
 		WorldView mockedWorldView = mock(WorldView.class);
+		when(mockedWorldView.getScene()).thenReturn(mockedScene);
 
 		@SuppressWarnings("unchecked")
 		IndexedObjectSet<? extends NPC> npcSetMock = (IndexedObjectSet<? extends NPC>) mock(IndexedObjectSet.class);
 		when(npcSetMock.iterator()).thenReturn(Collections.emptyIterator());
 		doReturn(npcSetMock).when(mockedWorldView).npcs();
 		when(client.getTopLevelWorldView()).thenReturn(mockedWorldView);
+		when(client.getScene()).thenReturn(mockedScene); // TODO: We should not have to mock this
+		var mockedItemContainer = Mockito.mock(ItemContainer.class);
+		when(mockedItemContainer.getItems()).thenReturn(new Item[0]);
+		when(client.getItemContainer(anyInt())).thenReturn(mockedItemContainer);
+
+		var mockedPlayer = Mockito.mock(Player.class);
+		when(mockedPlayer.getLocalLocation()).thenReturn(new LocalPoint(1, 1, 1));
+		when(client.getLocalPlayer()).thenReturn(mockedPlayer);
+		when(client.getWorldView(anyInt())).thenReturn(mockedWorldView);
 
 		ItemComposition itemComposition = mock(ItemComposition.class);
 		when(itemComposition.getName()).thenReturn("Test item");
 		when(itemManager.getItemComposition(anyInt())).thenReturn(itemComposition);
+		when(itemManager.getImage(anyInt())).thenReturn(new AsyncBufferedImage(clientThread, 10, 10, BufferedImage.TYPE_INT_ARGB));
+
+		// Varbit mocking
+		// DT2
+		when(client.getVarbitValue(VarbitID.DT2_SCAR_MAZE_1_RIFT_1)).thenReturn(1);
+		when(client.getVarbitValue(VarbitID.DT2_SCAR_MAZE_1_RIFT_2)).thenReturn(1);
+		when(client.getVarbitValue(VarbitID.DT2_SCAR_MAZE_1_RIFT_3)).thenReturn(1);
+		when(client.getVarbitValue(VarbitID.DT2_SCAR_MAZE_1_RIFT_4)).thenReturn(1);
+		when(client.getVarbitValue(VarbitID.DT2_SCAR_MAZE_1_RIFT_5)).thenReturn(1);
+		when(client.getVarbitValue(VarbitID.DT2_SCAR_MAZE_1_RIFT_6)).thenReturn(1);
+		// Balloon flight
+		when(client.getVarbitValue(VarbitID.ZEP_IF_CURRENT_MAP)).thenReturn(1);
 	}
 
 }

--- a/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
+++ b/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
@@ -180,47 +180,86 @@ public class QuestHelperTest extends MockedTest
 		}
 	}
 
-	void checkSteps(QuestHelper helper, boolean shouldError, Set<QuestStep> checkedSteps, QuestStep step)
+	void checkStep(QuestHelper helper, QuestOverviewPanel questOverviewPanel, boolean shouldError, QuestStep step) {
+		when(helper.getCurrentStep()).thenReturn(step);
+
+		var rawText = step.getText();
+		var text = rawText == null ? "" : String.join("\n", rawText);
+
+		questOverviewPanel.updateHighlight(this.client, step); // getactivestep?
+
+		// All steps must have at least one category/step that's erected
+		// If all panels are collapsed, it means the step this fails on needs to be either:
+		// 1. Added as a substep to another step
+		// 2. Added as a panel step
+		if (shouldError)
+		{
+			assertFalse(questOverviewPanel.isAllCollapsed(), String.format("Quest(%s) step(%s) is missing a side panel step", helper.getQuest().getName(), text));
+		}
+		else
+		{
+			if (questOverviewPanel.isAllCollapsed())
+			{
+				System.out.format("For quest %s, step '%s' is missing sub steps or should be added to panel\n", helper.getQuest(), text);
+			}
+		}
+	}
+
+	void checkSteps(QuestHelper helper, QuestOverviewPanel questOverviewPanel, boolean shouldError, Set<QuestStep> checkedSteps, QuestStep step)
 	{
 		assertNotNull(step);
 
 		if (step instanceof OwnerStep)
 		{
+			helper.startUpStep(step);
 			for (var innerStep : ((OwnerStep) step).getSteps())
 			{
 				if (checkedSteps.contains(innerStep)) continue;
 				checkedSteps.add(innerStep);
-				checkSteps(helper, shouldError, checkedSteps, innerStep);
+				checkSteps(helper, questOverviewPanel, shouldError, checkedSteps, innerStep);
 			}
+			helper.shutDownStep();
 		}
 		else
 		{
-			when(helper.getCurrentStep()).thenReturn(step);
-
-			var rawText = step.getText();
-			var text = rawText == null ? "" : String.join("\n", rawText);
-
-			var questOverviewPanel = new QuestOverviewPanel(this.questHelperPlugin, this.questHelperPlugin.getQuestManager());
-			questOverviewPanel.addQuest(helper, true);
-			questOverviewPanel.updateHighlight(this.client, helper.getCurrentStep().getActiveStep());
-
-			// All steps must have at least one category/step that's erected
-			// If all panels are collapsed, it means the step this fails on needs to be either:
-			// 1. Added as a substep to another step
-			// 2. Added as a panel step
-			if (shouldError)
-			{
-				assertFalse(questOverviewPanel.isAllCollapsed(), String.format("Quest(%s) step(%s) is missing a side panel step", helper.getQuest().getName(), text));
-			}
-			else
-			{
-				if (questOverviewPanel.isAllCollapsed())
-				{
-					System.out.format("For quest %s, step '%s' is missing sub steps or should be added to panel\n", helper.getQuest(), text);
-				}
-			}
+			checkStep(helper, questOverviewPanel, shouldError, step);
 		}
 	}
+
+	/*
+	@Test
+	void testSingleStep()
+	{
+		var quest = QuestHelperQuest.MISTHALIN_MYSTERY;
+		var shouldError = false;
+
+		when(questHelperConfig.solvePuzzles()).thenReturn(true);
+
+		AchievementDiaryStepManager.setup(configManager);
+
+		var helper = Mockito.spy(quest.getQuestHelper());
+		helper.setQuest(quest);
+
+		this.injector.injectMembers(helper);
+		helper.setInjector(this.injector);
+		helper.setQuestHelperPlugin(questHelperPlugin);
+		helper.setConfig(questHelperConfig);
+		helper.init();
+		helper.startUp(questHelperConfig);
+
+		when(this.questHelperPlugin.getSelectedQuest()).thenReturn(helper);
+
+		var questOverviewPanel = new QuestOverviewPanel(this.questHelperPlugin, this.questHelperPlugin.getQuestManager());
+
+		var realHelper = (MisthalinMystery) helper;
+
+		var step = realHelper.playD;
+		helper.startUpStep(realHelper.puzzlePlayPiano);
+		helper.startUpStep(step);
+
+		checkStep(helper, questOverviewPanel, shouldError, step);
+	}
+	 */
 
 	/// The intent of this test is to ensure that each potentially reachable step in a quest helper has a sidebar
 	/// step associated with it.
@@ -266,16 +305,21 @@ public class QuestHelperTest extends MockedTest
 			}
 
 			this.injector.injectMembers(helper);
+			helper.setInjector(this.injector);
 			helper.setQuestHelperPlugin(questHelperPlugin);
 			helper.setConfig(questHelperConfig);
 			helper.init();
+			helper.startUp(questHelperConfig);
 
 			var shouldError = optedInQuests.contains(quest);
 
 			when(this.questHelperPlugin.getSelectedQuest()).thenReturn(helper);
 
+			var questOverviewPanel = new QuestOverviewPanel(this.questHelperPlugin, this.questHelperPlugin.getQuestManager());
+
 			if (helper instanceof BasicQuestHelper)
 			{
+				questOverviewPanel.addQuest(helper, false);
 				var basicHelper = (BasicQuestHelper) helper;
 				var steps = basicHelper.getStepList();
 				var sortedSteps = steps.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
@@ -284,10 +328,11 @@ public class QuestHelperTest extends MockedTest
 					var step = e.getValue();
 					if (checkedSteps.contains(step)) continue;
 					checkedSteps.add(step);
+					helper.startUpStep(step);
 
 					assertNotNull(step);
 
-					checkSteps(helper, shouldError, checkedSteps, step);
+					checkSteps(helper, questOverviewPanel, shouldError, checkedSteps, step);
 				}
 			}
 			else if (helper instanceof ComplexStateQuestHelper)


### PR DESCRIPTION
This does more stuff, but is also faster

In the sidebar step checker, we now properly initialize and start up/shut down all steps we're checking. This is a lot more work, hence why we have to much a lot more data in the MockedTest now.
However, with some moving stuff around, I've managed to reduce the test run from ~1m20s to ~20s on my machine. Hopefully this is reflected in CI times too
