### PR TITLE
feat: add a quest reload button in developer mode

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -71,6 +71,7 @@ import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.swing.*;
@@ -462,7 +463,7 @@ public class QuestHelperPlugin extends Plugin
 		return questBankManager.getBankTagService().getPluginBankTagItemsForSections(false);
 	}
 
-	public QuestHelper getSelectedQuest()
+	public @Nullable QuestHelper getSelectedQuest()
 	{
 		return questManager.getSelectedQuest();
 	}

--- a/src/main/java/com/questhelper/managers/QuestManager.java
+++ b/src/main/java/com/questhelper/managers/QuestManager.java
@@ -44,6 +44,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.plugins.PluginManager;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -93,6 +94,7 @@ public class QuestManager
 	private boolean developerMode;
 
 	@Getter
+	@Nullable
 	private QuestHelper selectedQuest;
 	private boolean loadQuestList = false;
 	private QuestHelperPanel panel;

--- a/src/main/java/com/questhelper/panel/QuestHelperPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestHelperPanel.java
@@ -95,6 +95,8 @@ public class QuestHelperPanel extends PluginPanel
 	private static final ImageIcon COLLAPSED_ICON;
 	private static final ImageIcon EXPANDED_ICON;
 
+	private int nextDesiredScrollValue = 0;
+
 	static
 	{
 		DISCORD_ICON = Icon.DISCORD.getIcon(img -> ImageUtil.resizeImage(img, 16, 16));
@@ -389,6 +391,23 @@ public class QuestHelperPanel extends PluginPanel
 		questOverviewWrapper.setLayout(new BorderLayout());
 		questOverviewWrapper.add(questOverviewPanel, BorderLayout.NORTH);
 
+		if (questHelperPlugin.isDeveloperMode())
+		{
+			// If in developer mode, add this "reload quest" button.
+			// It's always visible under the search bar, and reloads the currently
+			// active quest, and ensures you're scrolled back to where you were.
+			var reloadQuest = new JButton("reload quest");
+			reloadQuest.addActionListener((ev) -> {
+				nextDesiredScrollValue = scrollableContainer.getVerticalScrollBar().getValue();
+				var currentQuest = questHelperPlugin.getSelectedQuest();
+				if (currentQuest != null) {
+					currentQuest.uninitializeRequirements();
+				}
+				setSelectedQuest(questHelperPlugin.getSelectedQuest());
+			});
+			searchQuestsPanel.add(reloadQuest, BorderLayout.SOUTH);
+		}
+
 		refreshSkillFiltering();
 	}
 
@@ -534,7 +553,10 @@ public class QuestHelperPanel extends PluginPanel
 		questOverviewPanel.addQuest(quest, isActive);
 		questActive = true;
 
-		SwingUtilities.invokeLater(() -> scrollableContainer.getVerticalScrollBar().setValue(0));
+		SwingUtilities.invokeLater(() -> {
+			scrollableContainer.getVerticalScrollBar().setValue(nextDesiredScrollValue);
+			nextDesiredScrollValue = 0;
+		});
 
 		repaint();
 		revalidate();

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -256,6 +256,14 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		hasInitialized = true;
 	}
 
+	/// Uninitialize requirements, meaning next time the quest is started it'll recreate all zones & requirements.
+	///
+	/// Intended for developer mode
+	public void uninitializeRequirements()
+	{
+		hasInitialized = false;
+	}
+
 	public List<ItemRequirement> getItemRequirements()
 	{
 		return null;


### PR DESCRIPTION
It's awkwardly placed underneath the search bar to ensure it's always visible without having to scroll up in the current quest.

I didn't bother hiding it when no quest is enabled, since it's only a dev mode thing.

<img width="1139" height="707" alt="image" src="https://github.com/user-attachments/assets/38a8a318-0039-487b-9ac8-e8d13d56cb6b" />
