### PR TITLE
feat(DigStep): allow customizing spade and highlight requirement

### DIFF
--- a/src/main/java/com/questhelper/steps/DigStep.java
+++ b/src/main/java/com/questhelper/steps/DigStep.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Trevor <https://github.com/Trevor159>
+ * Copyright (c) 2025, pajlada <https://github.com/pajlada>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This PR allows helpers to customize DigStep behaviour by specifying a custom spade (e.g. with a custom tooltip), and specifying when the spade should be highlighted.

To be used by the X Marks the Spot polish pass
