### PR TITLE
ci: downgrade & pin workflow dependencies

### DIFF
--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -7,14 +7,14 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: temurin
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
 
       - name: Build using latest runelite snapshot version
         run: ./gradlew --refresh-dependencies -Puse.snapshot clean build -x test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,14 +17,14 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: temurin
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
 
       - name: Execute Gradle build
         run: gradle build
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Upload shadowJar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: quest-helper-shadow
           path: build/libs/quest-helper-*-all.jar


### PR DESCRIPTION
setup-gradle v4.4.2 bumped gradle from v8 to v9, so we gotta slow down

When I pushed the gradle bump, gradle was still using v8 in workflows, but when it was merged in they had done a little minor version breaking change

