### PR TITLE
polish: Barbarian training mithril dragon requirements

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/barbariantraining/BarbarianTraining.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/barbariantraining/BarbarianTraining.java
@@ -666,7 +666,8 @@ public class BarbarianTraining extends BasicQuestHelper
 			bow, oakLogs, tinderbox, axe,
 			feathers, knife,
 			hammer, bronzeBar.quantity(2), logs.quantity(3),
-			attackPotion, roe);
+			attackPotion, roe,
+			antifireShield, combatGear);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/miniquests/barbariantraining/BarbarianTraining.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/barbariantraining/BarbarianTraining.java
@@ -677,6 +677,12 @@ public class BarbarianTraining extends BasicQuestHelper
 	}
 
 	@Override
+	public List<String> getCombatRequirements()
+	{
+		return Collections.singletonList("Mithril Dragon (level 304)");
+	}
+
+	@Override
 	public List<String> getNotes()
 	{
 		return Collections.singletonList("If the helper is out of sync, open up the Quest Journal to re-sync it.");


### PR DESCRIPTION
Addresses the final point on #1907 where combat gear, and an anti-dragon shield are required to fight a level 304 Mithril dragon.