### PR TITLE
feat: add option to always show debug overlay in developer mode

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -692,4 +692,24 @@ public interface QuestHelperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigSection(
+		position = 5,
+		name = "Development",
+		description = "Options that configure the quest helper development experience",
+		closedByDefault = true
+	)
+	String developmentSection = "developmentSection";
+
+	@ConfigItem(
+		keyName = "devShowOverlayOnLaunch",
+		name = "Show overlay on launch",
+		description = "Show the dev overlay (::questhelperdebug) on launch",
+		position = 4,
+		section = developmentSection
+	)
+	default boolean devShowOverlayOnLaunch()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -199,6 +199,14 @@ public class QuestHelperPlugin extends Plugin
 
 		questOverlayManager.startUp();
 
+		if (developerMode)
+		{
+			if (config.devShowOverlayOnLaunch())
+			{
+				questOverlayManager.addDebugOverlay();
+			}
+		}
+
 		final BufferedImage icon = Icon.QUEST_ICON.getImage();
 
 		panel = new QuestHelperPanel(this, questManager, configManager);
@@ -230,6 +238,11 @@ public class QuestHelperPlugin extends Plugin
 		eventBus.unregister(playerStateManager);
 		eventBus.unregister(runeliteObjectManager);
 		eventBus.unregister(worldMapAreaManager);
+		if (developerMode)
+		{
+			// We don't check if it was added, since removing an unadded overlay is a no-op
+			questOverlayManager.removeDebugOverlay();
+		}
 		questOverlayManager.shutDown();
 		playerStateManager.shutDown();
 
@@ -408,6 +421,18 @@ public class QuestHelperPlugin extends Plugin
 			if (questManager.getSelectedQuest() != null)
 			{
 				questManager.getSelectedQuest().setSidebarOrder(loadSidebarOrder(questManager.getSelectedQuest()));
+			}
+		}
+
+		if (developerMode && "devShowOverlayOnLaunch".equals(event.getKey()))
+		{
+			if (config.devShowOverlayOnLaunch())
+			{
+				questOverlayManager.addDebugOverlay();
+			}
+			else
+			{
+				questOverlayManager.removeDebugOverlay();
 			}
 		}
 	}


### PR DESCRIPTION
essentially just saves me from typing ::questhelperdebug enable every time i restart the client
