### PR TITLE
Clarify 65 fishing is only needed for Tai Bwo Wannai trio as iron if Raw Karambwan given is burned

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
+++ b/src/main/java/com/questhelper/helpers/quests/taibwowannaitrio/TaiBwoWannaiTrio.java
@@ -546,7 +546,7 @@ public class TaiBwoWannaiTrio extends BasicQuestHelper
 		req.add(new SkillRequirement(Skill.AGILITY, 15, false));
 		req.add(new SkillRequirement(Skill.COOKING, 30, false));
 		req.add(new SkillRequirement(Skill.FISHING, 5, false));
-		req.add(new ItemRequirement("65 Fishing for Raw Karambwan if any type of Ironman account.", -1, -1));
+		req.add(new ItemRequirement("65 Fishing for Raw Karambwan if any type of Ironman account, if you burn the one given to you.", -1, -1));
 		return req;
 	}
 


### PR DESCRIPTION
Should help ironmen avoid this grind if they want to try their luck at not burning the Raw Karambwan