### PR TITLE
feat: Initial implementation of TopLevelPanelDetails

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/HerbRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/HerbRun.java
@@ -582,9 +582,8 @@ public class HerbRun extends ComplexStateQuestHelper
 	{
 		allSteps = new ArrayList<>();
 
-//		allSteps.add(new PanelDetails("Wait for Herbs", waitForHerbs).withHideCondition(nor(allGrowing)));
-		allSteps.add(new PanelDetails("Wait for Herbs", waitForHerbs));
-		TopLevelPanelDetails farmRunSidebar = new TopLevelPanelDetails("Herb run",
+		allSteps.add(new PanelDetails("Wait for Herbs", waitForHerbs).withHideCondition(nor(allGrowing)));
+		TopLevelPanelDetails farmRunSidebar = new TopLevelPanelDetails(
 				new PanelDetails("Farming Guild", Collections.singletonList(farmingGuildPatch)).withId(0),
 				new PanelDetails("Falador", Collections.singletonList(faladorPatch)).withId(1),
 				new PanelDetails("Ardougne", Collections.singletonList(ardougnePatch)).withId(2),

--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/HerbRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/HerbRun.java
@@ -28,6 +28,7 @@ import com.questhelper.QuestHelperConfig;
 import com.questhelper.collections.ItemCollections;
 import com.questhelper.config.ConfigKeys;
 import com.questhelper.panel.PanelDetails;
+import com.questhelper.panel.TopLevelPanelDetails;
 import com.questhelper.questhelpers.ComplexStateQuestHelper;
 import com.questhelper.questinfo.HelperConfig;
 import com.questhelper.questinfo.QuestHelperQuest;
@@ -130,6 +131,7 @@ public class HerbRun extends ComplexStateQuestHelper
 	ManualRequirement weissReady;
 	ManualRequirement hosidiusReady;
 	ManualRequirement varlamoreReady;
+	Conditions allGrowing;
 
 	// Steps
 	ReorderableConditionalStep steps;
@@ -207,6 +209,10 @@ public class HerbRun extends ComplexStateQuestHelper
 		weissEmpty = new ManualRequirement();
 		hosidiusEmpty = new ManualRequirement();
 		varlamoreEmpty = new ManualRequirement();
+
+		allGrowing = nor(ardougneReady, catherbyReady, faladorReady, farmingGuildReady, harmonyReady, morytaniaReady, trollStrongholdReady, weissReady,
+				hosidiusReady, varlamoreReady, ardougneEmpty, catherbyEmpty, faladorEmpty, farmingGuildEmpty, harmonyEmpty, morytaniaEmpty,
+				trollStrongholdEmpty, weissEmpty, hosidiusEmpty, varlamoreEmpty);
 
 		accessToFarmingGuildPatch = new SkillRequirement(Skill.FARMING, 65);
 
@@ -575,16 +581,22 @@ public class HerbRun extends ComplexStateQuestHelper
 	private void prepopulateSidebarPanels()
 	{
 		allSteps = new ArrayList<>();
-		allSteps.add(new PanelDetails("Farming Guild", Collections.singletonList(farmingGuildPatch)).withId(0));
-		allSteps.add(new PanelDetails("Falador", Collections.singletonList(faladorPatch)).withId(1));
-		allSteps.add(new PanelDetails("Ardougne", Collections.singletonList(ardougnePatch)).withId(2));
-		allSteps.add(new PanelDetails("Catherby", Collections.singletonList(catherbyPatch)).withId(3));
-		allSteps.add(new PanelDetails("Morytania", Collections.singletonList(morytaniaPatch)).withId(4));
-		allSteps.add(new PanelDetails("Hosidius", Collections.singletonList(hosidiusPatch)).withId(5));
-		allSteps.add(new PanelDetails("Varlamore", Collections.singletonList(varlamorePatch)).withId(6));
-		allSteps.add(new PanelDetails("Troll Stronghold", Collections.singletonList(trollStrongholdPatch)).withId(7));
-		allSteps.add(new PanelDetails("Weiss", Collections.singletonList(weissPatch)).withId(8));
-		allSteps.add(new PanelDetails("Harmony Island", Collections.singletonList(harmonyPatch)).withId(9).withHideCondition(nor(accessToHarmony)));
+
+//		allSteps.add(new PanelDetails("Wait for Herbs", waitForHerbs).withHideCondition(nor(allGrowing)));
+		allSteps.add(new PanelDetails("Wait for Herbs", waitForHerbs));
+		TopLevelPanelDetails farmRunSidebar = new TopLevelPanelDetails("Herb run",
+				new PanelDetails("Farming Guild", Collections.singletonList(farmingGuildPatch)).withId(0),
+				new PanelDetails("Falador", Collections.singletonList(faladorPatch)).withId(1),
+				new PanelDetails("Ardougne", Collections.singletonList(ardougnePatch)).withId(2),
+				new PanelDetails("Catherby", Collections.singletonList(catherbyPatch)).withId(3),
+				new PanelDetails("Morytania", Collections.singletonList(morytaniaPatch)).withId(4),
+				new PanelDetails("Hosidius", Collections.singletonList(hosidiusPatch)).withId(5),
+				new PanelDetails("Varlamore", Collections.singletonList(varlamorePatch)).withId(6),
+				new PanelDetails("Troll Stronghold", Collections.singletonList(trollStrongholdPatch)).withId(7),
+				new PanelDetails("Weiss", Collections.singletonList(weissPatch)).withId(8),
+				new PanelDetails("Harmony Island", Collections.singletonList(harmonyPatch)).withId(9).withHideCondition(nor(accessToHarmony))
+		);
+		allSteps.add(farmRunSidebar);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/panel/PanelDetails.java
+++ b/src/main/java/com/questhelper/panel/PanelDetails.java
@@ -37,7 +37,7 @@ import java.util.*;
 public class PanelDetails
 {
 	@Getter
-	int id;
+	int id = -1;
 
 	@Getter
 	String header;

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -417,7 +417,7 @@ public class QuestOverviewPanel extends JPanel
 	{
 		return allQuestStepPanelList.stream()
 			.filter(QuestStepPanel::isCollapsed)
-			.count() == questStepPanelList.size();
+			.count() == allQuestStepPanelList.size();
 	}
 
 	public void setupQuestRequirements(QuestHelper quest)

--- a/src/main/java/com/questhelper/panel/TightTitledBorder.java
+++ b/src/main/java/com/questhelper/panel/TightTitledBorder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.panel;
+
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+
+class TightTitledBorder extends TitledBorder
+{
+    TightTitledBorder(Border border, String title, int justification, int position, Font font, Color color)
+    {
+        super(border, title, justification, position, font, color);
+    }
+
+
+    @Override
+    public Insets getBorderInsets(Component c, Insets insets)
+    {
+        Insets b = (border != null) ? border.getBorderInsets(c) : new Insets(0, 0, 0, 0);
+
+        Font f = getTitleFont();
+        if (f == null) f = c.getFont();
+        FontMetrics fm = c.getFontMetrics(f);
+        int ascent = (title == null || title.isEmpty()) ? 0 : fm.getAscent();
+
+        insets.left   = b.left;
+        insets.right  = b.right;
+        insets.bottom = b.bottom;
+
+        insets.top = Math.max(b.top, ascent + 2);
+
+        return insets;
+    }
+}

--- a/src/main/java/com/questhelper/panel/TopLevelPanelDetails.java
+++ b/src/main/java/com/questhelper/panel/TopLevelPanelDetails.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.panel;
+
+// The intention is to contain a set of PanelDetails.
+// This is intended to be the structure used for containing a reorderable set of PanelDetails
+public class TopLevelPanelDetails extends PanelDetails
+{
+    private final PanelDetails[] panelDetails;
+    
+    public TopLevelPanelDetails(String header, PanelDetails... panelDetails)
+    {
+        super(header);
+        this.panelDetails = panelDetails;
+    }
+    
+    public PanelDetails[] getPanelDetails()
+    {
+        return panelDetails;
+    }
+}

--- a/src/main/java/com/questhelper/panel/TopLevelPanelDetails.java
+++ b/src/main/java/com/questhelper/panel/TopLevelPanelDetails.java
@@ -24,20 +24,24 @@
  */
 package com.questhelper.panel;
 
+import lombok.Getter;
+
 // The intention is to contain a set of PanelDetails.
 // This is intended to be the structure used for containing a reorderable set of PanelDetails
 public class TopLevelPanelDetails extends PanelDetails
 {
+    @Getter
     private final PanelDetails[] panelDetails;
-    
+
+    public TopLevelPanelDetails(PanelDetails... panelDetails)
+    {
+        super("");
+        this.panelDetails = panelDetails;
+    }
+
     public TopLevelPanelDetails(String header, PanelDetails... panelDetails)
     {
         super(header);
         this.panelDetails = panelDetails;
-    }
-    
-    public PanelDetails[] getPanelDetails()
-    {
-        return panelDetails;
     }
 }

--- a/src/main/java/com/questhelper/panel/TopLevelSectionGroup.java
+++ b/src/main/java/com/questhelper/panel/TopLevelSectionGroup.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.panel;
+
+import lombok.Getter;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+
+public class TopLevelSectionGroup extends JPanel
+{
+    private static final int OUTER_VGAP = 8;
+    private static final int OUTER_HGAP = 0;
+
+    private static final int INNER_PAD_TOP    = 10;
+    private static final int INNER_PAD_RIGHT  = 3;
+    private static final int INNER_PAD_BOTTOM = 1;
+    private static final int INNER_PAD_LEFT   = 3;
+
+
+    private static final float TITLE_SCALE = 1.05f;
+    private static final int   TITLE_BOTTOM_GAP = 6;
+
+    private static final int RADIUS = 8;
+    private static final int BORDER_THICK_OUTER = 1;
+    private static final int BORDER_THICK_INNER = 1;
+    private static final int BORDER_INNER_INSET = 1;
+
+    private static final Color BG_FRAME =
+            mix(ColorScheme.DARK_GRAY_HOVER_COLOR, ColorScheme.DARKER_GRAY_COLOR, 0.55f);
+    private static final Color BORDER_OUTER =
+            mix(ColorScheme.DARK_GRAY_HOVER_COLOR, Color.BLACK, 0.45f);
+    private static final Color BORDER_INNER =
+            mix(ColorScheme.BORDER_COLOR, Color.BLACK, 0.15f);
+
+    @Getter
+    private final JPanel contentPanel;
+
+    public TopLevelSectionGroup(String title)
+    {
+        String title1 = title == null ? "" : title.trim();
+
+        setOpaque(false);
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(OUTER_VGAP, OUTER_HGAP, OUTER_VGAP, OUTER_HGAP));
+
+        JPanel inner = new JPanel();
+        inner.setOpaque(false);
+        inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
+        inner.setBorder(new EmptyBorder(
+                INNER_PAD_TOP, INNER_PAD_LEFT, INNER_PAD_BOTTOM, INNER_PAD_RIGHT
+        ));
+
+        JLabel titleLabel;
+        if (!title1.isEmpty())
+        {
+            titleLabel = new JLabel(title1);
+            Font base = FontManager.getRunescapeBoldFont();
+            titleLabel.setFont(base.deriveFont(base.getSize2D() * TITLE_SCALE));
+            titleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+            titleLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+            titleLabel.setOpaque(false);
+
+            inner.add(titleLabel);
+            inner.add(Box.createVerticalStrut(TITLE_BOTTOM_GAP));
+        }
+
+        contentPanel = new JPanel();
+        contentPanel.setOpaque(false);
+        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+        contentPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        inner.add(contentPanel);
+
+        add(inner, BorderLayout.CENTER);
+    }
+
+    @Override
+    protected void paintComponent(Graphics g)
+    {
+        super.paintComponent(g);
+        Graphics2D g2 = (Graphics2D) g.create();
+        try
+        {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+            Insets out = getInsets();
+            int x = out.left;
+            int y = out.top;
+            int w = getWidth()  - out.left - out.right;
+            int h = getHeight() - out.top  - out.bottom;
+
+            // Frame background
+            g2.setColor(BG_FRAME);
+            g2.fillRoundRect(x, y, w, h, RADIUS, RADIUS);
+
+            // Outer border
+            if (BORDER_THICK_OUTER > 0)
+            {
+                g2.setColor(BORDER_OUTER);
+                g2.setStroke(new BasicStroke(BORDER_THICK_OUTER));
+                g2.drawRoundRect(x, y, w - 1, h - 1, RADIUS, RADIUS);
+            }
+
+            if (BORDER_THICK_INNER > 0)
+            {
+                int ix = x + BORDER_INNER_INSET + BORDER_THICK_OUTER;
+                int iy = y + BORDER_INNER_INSET + BORDER_THICK_OUTER;
+                int iw = w - 1 - 2 * (BORDER_INNER_INSET + BORDER_THICK_OUTER);
+                int ih = h - 1 - 2 * (BORDER_INNER_INSET + BORDER_THICK_OUTER);
+
+                if (iw > 0 && ih > 0)
+                {
+                    g2.setColor(BORDER_INNER);
+                    g2.setStroke(new BasicStroke(BORDER_THICK_INNER));
+                    g2.drawRoundRect(ix, iy, iw, ih, Math.max(0, RADIUS - 2), Math.max(0, RADIUS - 2));
+                }
+            }
+        }
+        finally
+        {
+            g2.dispose();
+        }
+    }
+
+    private static Color mix(Color a, Color b, double t)
+    {
+        float clamped = (float)Math.max(0.0, Math.min(1.0, t));
+        int r = Math.round(a.getRed()   * (1 - clamped) + b.getRed()   * clamped);
+        int g = Math.round(a.getGreen() * (1 - clamped) + b.getGreen() * clamped);
+        int bl= Math.round(a.getBlue()  * (1 - clamped) + b.getBlue()  * clamped);
+        return new Color(r, g, bl);
+    }
+}

--- a/src/main/java/com/questhelper/panel/TopLevelSectionGroup.java
+++ b/src/main/java/com/questhelper/panel/TopLevelSectionGroup.java
@@ -29,131 +29,57 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
 import javax.swing.*;
+import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import javax.swing.border.TitledBorder;
 import java.awt.*;
 
 public class TopLevelSectionGroup extends JPanel
 {
-    private static final int OUTER_VGAP = 8;
-    private static final int OUTER_HGAP = 0;
-
-    private static final int INNER_PAD_TOP    = 10;
-    private static final int INNER_PAD_RIGHT  = 3;
-    private static final int INNER_PAD_BOTTOM = 1;
-    private static final int INNER_PAD_LEFT   = 3;
-
-
-    private static final float TITLE_SCALE = 1.05f;
-    private static final int   TITLE_BOTTOM_GAP = 6;
-
-    private static final int RADIUS = 8;
-    private static final int BORDER_THICK_OUTER = 1;
-    private static final int BORDER_THICK_INNER = 1;
-    private static final int BORDER_INNER_INSET = 1;
-
-    private static final Color BG_FRAME =
-            mix(ColorScheme.DARK_GRAY_HOVER_COLOR, ColorScheme.DARKER_GRAY_COLOR, 0.55f);
-    private static final Color BORDER_OUTER =
-            mix(ColorScheme.DARK_GRAY_HOVER_COLOR, Color.BLACK, 0.45f);
-    private static final Color BORDER_INNER =
-            mix(ColorScheme.BORDER_COLOR, Color.BLACK, 0.15f);
-
     @Getter
     private final JPanel contentPanel;
 
     public TopLevelSectionGroup(String title)
     {
+        Border outer = new LineBorder(ColorScheme.DARK_GRAY_HOVER_COLOR, 1, true);
+        Border gap = new EmptyBorder(1, 1, 1, 1);
+        Border innerBorder = new LineBorder(ColorScheme.BORDER_COLOR, 1, true);
+        Border doubleRounded = BorderFactory.createCompoundBorder(outer, BorderFactory.createCompoundBorder(gap, innerBorder));
+
+        TitledBorder titledBorder = new TightTitledBorder(doubleRounded, "", TitledBorder.LEFT, TitledBorder.TOP,
+                FontManager.getRunescapeBoldFont(),  ColorScheme.LIGHT_GRAY_COLOR);
+
         String title1 = title == null ? "" : title.trim();
 
         setOpaque(false);
         setLayout(new BorderLayout());
-        setBorder(new EmptyBorder(OUTER_VGAP, OUTER_HGAP, OUTER_VGAP, OUTER_HGAP));
+        setBorder(new EmptyBorder(0, 0, 0, 0));
 
-        JPanel inner = new JPanel();
-        inner.setOpaque(false);
-        inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
-        inner.setBorder(new EmptyBorder(
-                INNER_PAD_TOP, INNER_PAD_LEFT, INNER_PAD_BOTTOM, INNER_PAD_RIGHT
-        ));
+        JLabel titleLabel = new JLabel(title1);
+        Font base = FontManager.getRunescapeBoldFont();
+        titleLabel.setFont(base.deriveFont(base.getSize2D()));
+        titleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+        titleLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        titleLabel.setOpaque(false);
 
-        JLabel titleLabel;
-        if (!title1.isEmpty())
-        {
-            titleLabel = new JLabel(title1);
-            Font base = FontManager.getRunescapeBoldFont();
-            titleLabel.setFont(base.deriveFont(base.getSize2D() * TITLE_SCALE));
-            titleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-            titleLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-            titleLabel.setOpaque(false);
+        TightTitledBorder framed = new TightTitledBorder(
+                titledBorder,
+                title1,
+                TitledBorder.LEFT,
+                TitledBorder.TOP,
+                base,
+                ColorScheme.LIGHT_GRAY_COLOR
+        );
 
-            inner.add(titleLabel);
-            inner.add(Box.createVerticalStrut(TITLE_BOTTOM_GAP));
-        }
 
         contentPanel = new JPanel();
         contentPanel.setOpaque(false);
         contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
         contentPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        inner.add(contentPanel);
+        contentPanel.setBorder(framed);
 
-        add(inner, BorderLayout.CENTER);
-    }
-
-    @Override
-    protected void paintComponent(Graphics g)
-    {
-        super.paintComponent(g);
-        Graphics2D g2 = (Graphics2D) g.create();
-        try
-        {
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-            Insets out = getInsets();
-            int x = out.left;
-            int y = out.top;
-            int w = getWidth()  - out.left - out.right;
-            int h = getHeight() - out.top  - out.bottom;
-
-            // Frame background
-            g2.setColor(BG_FRAME);
-            g2.fillRoundRect(x, y, w, h, RADIUS, RADIUS);
-
-            // Outer border
-            if (BORDER_THICK_OUTER > 0)
-            {
-                g2.setColor(BORDER_OUTER);
-                g2.setStroke(new BasicStroke(BORDER_THICK_OUTER));
-                g2.drawRoundRect(x, y, w - 1, h - 1, RADIUS, RADIUS);
-            }
-
-            if (BORDER_THICK_INNER > 0)
-            {
-                int ix = x + BORDER_INNER_INSET + BORDER_THICK_OUTER;
-                int iy = y + BORDER_INNER_INSET + BORDER_THICK_OUTER;
-                int iw = w - 1 - 2 * (BORDER_INNER_INSET + BORDER_THICK_OUTER);
-                int ih = h - 1 - 2 * (BORDER_INNER_INSET + BORDER_THICK_OUTER);
-
-                if (iw > 0 && ih > 0)
-                {
-                    g2.setColor(BORDER_INNER);
-                    g2.setStroke(new BasicStroke(BORDER_THICK_INNER));
-                    g2.drawRoundRect(ix, iy, iw, ih, Math.max(0, RADIUS - 2), Math.max(0, RADIUS - 2));
-                }
-            }
-        }
-        finally
-        {
-            g2.dispose();
-        }
-    }
-
-    private static Color mix(Color a, Color b, double t)
-    {
-        float clamped = (float)Math.max(0.0, Math.min(1.0, t));
-        int r = Math.round(a.getRed()   * (1 - clamped) + b.getRed()   * clamped);
-        int g = Math.round(a.getGreen() * (1 - clamped) + b.getGreen() * clamped);
-        int bl= Math.round(a.getBlue()  * (1 - clamped) + b.getBlue()  * clamped);
-        return new Color(r, g, bl);
+        add(contentPanel, BorderLayout.CENTER);
     }
 }


### PR DESCRIPTION
The intention is to allow for sub-sections of sections. The core goal is to allow for sub-ordering of parts of helpers, but also may be a nice QoL for allowing for larger more complex helpers which want to divide up into further chunks.

I've gone with a more subtle border to mark the separate top tier sections. The image demonstrates no text or optional title text which would be useful for complex helpers which need sub-dividing, maybe like DT2 and the likes.

I've kept the save data the same for ordering, where all components with ids in a helper are saved together. This seems to work fine, it means each should have a unique ID but that's a good thing to be doing anyways.

<img width="359" height="796" alt="Screenshot 2025-08-28 135619" src="https://github.com/user-attachments/assets/2dcf6a7b-a370-49d5-89e9-1c275f70214e" />
