### PR TITLE
polish: improve cog search step for Elemental Workshop II

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/elementalworkshopii/ElementalWorkshopII.java
+++ b/src/main/java/com/questhelper/helpers/quests/elementalworkshopii/ElementalWorkshopII.java
@@ -482,7 +482,7 @@ public class ElementalWorkshopII extends BasicQuestHelper
 		connectPipes = new ConnectPipes(this);
 
 		getCogsAndPipe = new ObjectStep(this, ObjectID.ELEMENTAL_WORKSHOP_2_BOX_1,
-			"Search the various marked crates on the catwalk and below for 3 cogs and a pipe.",
+			"Search the marked crates on the catwalk AND DOWN THE STAIRS for 3 cogs and a pipe.",
 			smallCog, mediumCog, largeCog, pipe);
 		((ObjectStep) getCogsAndPipe).addAlternateObjects(ObjectID.ELEMENTAL_WORKSHOP_2_BOX_2, ObjectID.ELEMENTAL_WORKSHOP_2_BOX_3,
 			ObjectID.ELEMENTAL_WORKSHOP_2_BOX_4, ObjectID.ELEMENTAL_WORKSHOP_2_BOX_5, ObjectID.ELEMENTAL_WORKSHOP_2_BOX_6, ObjectID.ELEMENTAL_WORKSHOP_2_BOX_7,


### PR DESCRIPTION
I’ve run into this step several times and ended up circling the catwalk for crates I already cleared.

This change emphasizes the STAIRS instruction in ALL CAPS to make the next step more obvious.