### PR TITLE
feat: add VarbitBuilder class

### DIFF
--- a/src/main/java/com/questhelper/requirements/var/VarbitBuilder.java
+++ b/src/main/java/com/questhelper/requirements/var/VarbitBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, pajlada <https://github.com/pajlada>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.requirements.var;
+
+/// VarbitBuilder can be used to build VarbitRequirements in case your
+/// quest needs to refer to multiple states of the same varbit.
+public class VarbitBuilder
+{
+	/// The Varbit ID
+	private final int id;
+
+	/// Create a VarbitBuilder for the given Varbit ID `id`.
+	public VarbitBuilder(int id)
+	{
+		this.id = id;
+	}
+
+	/// Returns a VarbitRequirement with the EQUALS operator for the given value.
+	public VarbitRequirement eq(int value)
+	{
+		return new VarbitRequirement(id, value);
+	}
+}


### PR DESCRIPTION
This class is intended to help you build multiple VarbitRequirements based on a single Varbit ID

Example:
```java
var sheep1State = new VarbitBuilder(VarbitID.SHEEP_STATE);

var sheep1Prodded = sheep1State.eq(1);
var sheep1Burned = sheep1State.eq(2);
var sheep1Eaten = sheep1State.eq(3);
```

More functions for the builder similar to eq can be added easily on demand
