### PR TITLE
Demon Slayer: Remove alternate NPC

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/demonslayer/DemonSlayer.java
+++ b/src/main/java/com/questhelper/helpers/quests/demonslayer/DemonSlayer.java
@@ -174,7 +174,6 @@ public class DemonSlayer extends BasicQuestHelper
 		talkToAris.addDialogStep("Ok, here you go.");
 		talkToAris.addDialogStep("Okay, where is he? I'll kill him for you!");
 		talkToAris.addDialogStep("So how did Wally kill Delrith?");
-		talkToAris.addAlternateNpcs(11868);
 		talkToPrysin = new NpcStep(this, NpcID.SIR_PRYSIN, new WorldPoint(3203, 3472, 0), "Talk to Sir Prysin in the south west corner of Varrock Castle.");
 		talkToPrysin.addDialogStep("Aris said I should come and talk to you.");
 		talkToPrysin.addDialogStep("I need to find Silverlight.");


### PR DESCRIPTION
When Gypsy Aris was removed in 40b0cbc549c151be678e891911b61c9fd5e24c21 the alternate NPC was redundant.