### PR TITLE
fix: One Small Favour

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/onesmallfavour/OneSmallFavour.java
+++ b/src/main/java/com/questhelper/helpers/quests/onesmallfavour/OneSmallFavour.java
@@ -511,7 +511,7 @@ public class OneSmallFavour extends BasicQuestHelper
 		talkToYanni = new NpcStep(this, NpcID.SHILOANTIQUES, new WorldPoint(2836, 2983, 0), "Talk to Yanni Salika in Shilo Village. CKR fairy ring or take cart from Brimhaven.");
 		talkToYanni.addDialogStep("Yes.");
 		talkToYanni.addDialogSteps("Is there anything else interesting to do around here?", "Ok, see you in a tick!");
-		talkToJungleForester = new NpcStep(this, new int[]{NpcID.JUNGLEFORESTER_F, NpcID.JUNGLEFORESTER_M}, new WorldPoint(2861, 2942, 0), "Talk to a Jungle Forester south of Shilo Village.", true, bluntAxe);
+		talkToJungleForester = new NpcStep(this, new int[]{NpcID.JUNGLEFORESTER_F, NpcID.JUNGLEFORESTER_M}, new WorldPoint(2861, 2942, 0), "Talk to a Jungle Forester south of Shilo Village.", true);
 		talkToJungleForester.addDialogSteps("I'll get going then!", "I need to talk to you about red mahogany.");
 		talkToJungleForester.addDialogStep("Okay, I'll take your axe to get it sharpened.");
 		talkToBrian = new NpcStep(this, NpcID.BRIAN, new WorldPoint(3027, 3249, 0), "Talk to Brian in the Port Sarim axe shop.", bluntAxe);


### PR DESCRIPTION
One of the first steps of the quest is to talk to a Jungle Forester south of Shilo to receive his blunt axe to be sharpened. However, the talkToJungleForestStep incorrectly listed the blunt axe as a requirement. This change removes that requirement (it's still correctly a requirement for the talkToBrian step).