### PR TITLE
fix: add additional information to cabin fever plunder step

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/cabinfever/CabinFever.java
+++ b/src/main/java/com/questhelper/helpers/quests/cabinfever/CabinFever.java
@@ -545,7 +545,7 @@ public class CabinFever extends BasicQuestHelper
 		useRopeOnSailToLoot = new ObjectStep(this, ObjectID.FEVER_SAIL1_HOISTEDL_CLIMB, new WorldPoint(1817, 4830, 2), "Use a rope on the hoisted sail.", ropeHighlight);
 		useRopeOnSailToLoot.addIcon(ItemID.ROPE);
 
-		lootEnemyShip = new ObjectStep(this, ObjectID.FEVER_MULTI_CHEST, "Plunder the chest, loot the crate and ransack the barrel for 10 plunder.", loot10);
+		lootEnemyShip = new ObjectStep(this, ObjectID.FEVER_MULTI_CHEST, "Plunder the chest, loot the crate and ransack the barrel for 10 plunder. Switch world after looting to make plunder respawn instantly.", loot10);
 		lootEnemyShip.addAlternateObjects(ObjectID.FEVER_MULTI_CRATE, ObjectID.FEVER_MULTI_BARREL);
 
 		hopWorld = new DetailedQuestStep(this, "Hop worlds so that the chest resets.");


### PR DESCRIPTION
When you have to loot the chest, crate and barrel during cabin fever, you only get 6 plunder, but you need 10 in total, which makes this step a bit confusing. According to the wiki, it can take up to 5 minutes for the plunder to respawn. I therefore think it would be helpful to tell the player to switch worlds for the loot to respawn instantly.

Source: [https://oldschool.runescape.wiki/w/Cabin_Fever#Retaliation!](https://oldschool.runescape.wiki/w/Cabin_Fever#Retaliation!)