### PR TITLE
Update Warriors Guild entrance coordinates

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorHard.java
@@ -289,7 +289,7 @@ public class FaladorHard extends ComplexStateQuestHelper
 			"Equip your Proselyte armor and pray at the altar in Port Sarim.", prosyHelm, prosyChest, prosyLegs);
 
 		//Warriors Guild
-		enterWarriorsGuild = new ObjectStep(this, ObjectID.WARGUILD_DOOR_FRONT, new WorldPoint(2869, 3546, 0),
+		enterWarriorsGuild = new ObjectStep(this, ObjectID.WARGUILD_DOOR_FRONT, new WorldPoint(2877, 3546, 0),
 			"Enter the Warriors Guild, in Burthorpe. You can get here faster by teleporting with a combat bracelet or a games necklace.");
 
 		//Dwarven Helm


### PR DESCRIPTION
Fixes issue #2372 

Realized I should've waited to complete the diary step before submitting so that I could fully test/verify... but since it's a simple coord change probably fine :-) here's a screenshot from the web tool showing that the updated coords match the Warrior's Guild

<img width="992" height="622" alt="image" src="https://github.com/user-attachments/assets/c789df04-df3f-4d73-920a-c94112a07378" />
