### PR TITLE
Remove Knight's Sword portrait requirement from "Making the sword"

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/theknightssword/TheKnightsSword.java
+++ b/src/main/java/com/questhelper/helpers/quests/theknightssword/TheKnightsSword.java
@@ -226,7 +226,7 @@ public class TheKnightsSword extends BasicQuestHelper
 		allSteps.add(new PanelDetails("Starting off", Arrays.asList(talkToSquire, talkToReldo)));
 		allSteps.add(new PanelDetails("Finding an Imcando", Arrays.asList(talkToThurgo, talkToThurgoAgain), redberryPie));
 		allSteps.add(new PanelDetails("Find the portrait", Arrays.asList(talkToSquire2, goUpCastle1, goUpCastle2, searchCupboard, givePortraitToThurgo)));
-		allSteps.add(new PanelDetails("Making the sword", Arrays.asList(enterDungeon, mineBlurite, bringThurgoOre), pickaxe, portrait, ironBars));
+		allSteps.add(new PanelDetails("Making the sword", Arrays.asList(enterDungeon, mineBlurite, bringThurgoOre), pickaxe, ironBars));
 		allSteps.add(new PanelDetails("Return the sword", Collections.singletonList(finishQuest)));
 		return allSteps;
 	}


### PR DESCRIPTION
The portrait was given to Thurgo in the previous step. It doesn't make sense to require it here unless giving Thurgo the portrait were to be moved to this step.