### PR TITLE
Land of the Goblins: Include 4 dose goblin potion as well

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
+++ b/src/main/java/com/questhelper/helpers/quests/landofthegoblins/LandOfTheGoblins.java
@@ -384,11 +384,11 @@ public class LandOfTheGoblins extends BasicQuestHelper
 		pharmakosBerryHighlight.setHighlightInInventory(true);
 		toadflaxUnfHighlight = new ItemRequirement("Toadflax potion (unf)", ItemID.TOADFLAXVIAL);
 		toadflaxUnfHighlight.setHighlightInInventory(true);
-		goblinPotion = new ItemRequirement("Goblin potion", Arrays.asList(ItemID.LOTG_1DOSEGOBLIN, ItemID.LOTG_2DOSEGOBLIN, ItemID.LOTG_3DOSEGOBLIN));
+		goblinPotion = new ItemRequirement("Goblin potion", Arrays.asList(ItemID.LOTG_1DOSEGOBLIN, ItemID.LOTG_2DOSEGOBLIN, ItemID.LOTG_3DOSEGOBLIN, ItemID.LOTG_4DOSEGOBLIN));
 		goblinPotion.setTooltip("You can make another with a toadflax potion (unf) and some pharmakos berries from the bush outside the Makeover Mage's house");
 		inGoblinCaveWithGoblinPotion = new Conditions(LogicType.AND, inGoblinCave, goblinPotion);
 		inFrontOfGuardsWithGoblinPotion = new Conditions(LogicType.AND, new ZoneRequirement(guardArea), goblinPotion);
-		goblinPotionHighlight = new ItemRequirement("Goblin potion", Arrays.asList(ItemID.LOTG_1DOSEGOBLIN, ItemID.LOTG_2DOSEGOBLIN, ItemID.LOTG_3DOSEGOBLIN));
+		goblinPotionHighlight = new ItemRequirement("Goblin potion", Arrays.asList(ItemID.LOTG_1DOSEGOBLIN, ItemID.LOTG_2DOSEGOBLIN, ItemID.LOTG_3DOSEGOBLIN, ItemID.LOTG_4DOSEGOBLIN));
 		goblinPotionHighlight.setHighlightInInventory(true);
 		goblinSelectionActive = new WidgetPresenceRequirement(InterfaceID.LotgMakeover.CONFIRM);
 		hasBlackMushroomsOrDye = new Conditions(LogicType.OR, blackMushroom, blackDye);


### PR DESCRIPTION
Grid Master relics prevent you from making potions less than 4 dose or consuming them which prevents the quest from progressing.

Seems there is no harm to adding this in case players decant two potions.