### PR TITLE
fix: add swamp cave rope varbit check to ASoH

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/anothersliceofham/AnotherSliceOfHam.java
+++ b/src/main/java/com/questhelper/helpers/quests/anothersliceofham/AnotherSliceOfHam.java
@@ -61,7 +61,7 @@ import java.util.*;
 public class AnotherSliceOfHam extends BasicQuestHelper
 {
 	//Items Required
-	ItemRequirement lightSource, tinderbox, combatGearRangedMagic, combatGear;
+	ItemRequirement lightSource, tinderbox, combatGearRangedMagic, combatGear, ropeForEntrance;
 
 	ItemRequirement lumbridgeTeleports;
 
@@ -69,6 +69,8 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 		armourShard, axeHead, helmetFragment, shieldFragment, swordFragment, mace, ancientMace;
 
 	FollowerRequirement zanikFollower;
+
+	VarbitRequirement addedRopeToHole;
 
 	Requirement inBasement, inTunnels, inMines, inCityF0, inCityF1, inRailway, inTower, inGoblinVillage, inSwamp,
 		inBase, atCrate, inFinalRoom;
@@ -143,12 +145,16 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 	@Override
 	protected void setupRequirements()
 	{
+		addedRopeToHole = new VarbitRequirement(VarbitID.SWAMP_CAVES_ROPED_ENTRANCE, 1);
+
 		lightSource = new ItemRequirement("A light source", ItemCollections.LIGHT_SOURCES).isNotConsumed();
 
 		lumbridgeTeleports = new ItemRequirement("Lumbridge teleports", ItemID.POH_TABLET_LUMBRIDGETELEPORT, 3);
 
 		zanikFollower = new FollowerRequirement("Zanik following you. If she's not, retrieve her from the " +
 			"Dorgesh-Kaan railway", NpcID.SLICE_ZANIK_FOLLOWER);
+
+		ropeForEntrance = new ItemRequirement("Rope", ItemID.ROPE).highlighted().hideConditioned(addedRopeToHole);
 
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX).isNotConsumed();
 
@@ -330,7 +336,7 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 			"Talk to the Sergeants in Lumbridge Swamp.", combatGear, ancientMace, lightSource);
 
 		enterSwamp = new ObjectStep(this, ObjectID.GOBLIN_CAVE_ENTRANCE, new WorldPoint(3169, 3172, 0),
-			"Enter the Lumbridge Swamp Caves.", combatGear, ancientMace, lightSource);
+			"Enter the Lumbridge Swamp Caves.", combatGear, ancientMace, lightSource, ropeForEntrance);
 
 		climbEnterHamBase = new ObjectStep(this, ObjectID.SLICE_LADDER_SWAMP, new WorldPoint(3171, 9568, 0),
 			"Climb down the ladder to the secret H.A.M. base.");
@@ -409,7 +415,7 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(lightSource, tinderbox, combatGearRangedMagic);
+		return Arrays.asList(lightSource, tinderbox, combatGearRangedMagic, ropeForEntrance);
 	}
 
 	@Override
@@ -461,7 +467,7 @@ public class AnotherSliceOfHam extends BasicQuestHelper
 		allSteps.add(new PanelDetails("To Goblin Village", Arrays.asList(goTalkToOldak, talkToGenerals, goUpLadder,
 			killHamMageAndArcher, talkToGeneralsAgain), combatGearRangedMagic));
 		allSteps.add(new PanelDetails("Saving Zanik", Arrays.asList(talkToSergeant, enterSwamp, climbEnterHamBase,
-			goToCrate, lureHamMember, enterFinalFight, useSpecial, untieZanik), combatGear, ancientMace, lightSource));
+			goToCrate, lureHamMember, enterFinalFight, useSpecial, untieZanik), combatGear, ancientMace, lightSource, ropeForEntrance));
 		return allSteps;
 	}
 


### PR DESCRIPTION
Fixes #2404 by adding a check for the varbit that indicates a rope has been added to the Lumbridge Swamp Cave surface entrance.