### PR TITLE
add return description and fairy ring

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/holygrail/HolyGrail.java
+++ b/src/main/java/com/questhelper/helpers/quests/holygrail/HolyGrail.java
@@ -78,6 +78,7 @@ public class HolyGrail extends BasicQuestHelper
 	ItemRequirement sixtyCoins;
 	ItemRequirement thirtyCoins;
 	ItemRequirement draynorTele;
+	ItemRequirement feldipTeleport;
 
 	// Mid-quest item requirements
 	ItemRequirement holyTableNapkin;


### PR DESCRIPTION
closes: https://github.com/Zoinkwiz/quest-helper/issues/2392

Just finished up this quest and saw this was an issue. Added the requested information to the step and extra item required.