### PR TITLE
fix fire altar item collection

### DIFF
--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -1417,7 +1417,7 @@ public enum ItemCollections
 			ItemID.TIARA_ELEMENTAL
 		).build()),
 	FIRE_ALTAR(new ImmutableList.Builder<Integer>()
-		.addAll(AIR_ALTAR_WEARABLE.getItems()).add(
+		.addAll(FIRE_ALTAR_WEARABLE.getItems()).add(
 			ItemID.ELEMENTAL_TALISMAN,
 			ItemID.FIRE_TALISMAN
 		).build()),


### PR DESCRIPTION
Resolves https://github.com/Zoinkwiz/quest-helper/issues/2402

`FIRE_ALTAR` Collection was erroneously using the wrong `WEARABLE` collection.
