### PR TITLE
Feat: Add EMPTY_HANDS and BARE_HANDS.

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/PerseriyaSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/PerseriyaSteps.java
@@ -455,9 +455,7 @@ public class PerseriyaSteps extends ConditionalStep
 		natureAxonPresent = new NpcRequirement(NpcID.DT2_SCAR_MAZE_3_PATHING_NPC, "Abyssal Axon (Nature)");
 		completedAxonRoom = new VarbitRequirement(VarbitID.DT2_SCAR_MAZE_CHALLENGE_1_DONE, 1);
 
-		nothingInHands = and(new NoItemRequirement("Weapon", ItemSlots.WEAPON),
-			new NoItemRequirement("Shield", ItemSlots.SHIELD));
-		((Conditions) nothingInHands).setText("Nothing equipped in your hands");
+		nothingInHands = new NoItemRequirement("Nothing equipped in your hands.", ItemSlots.EMPTY_HANDS);
 
 		inNorthOfAbyssRoom2 = new ZoneRequirement(northAbyssRoom2P1, northAbyssRoom2P2, northAbyssRoom2P3, northAbyssRoom2P4, northAbyssRoom2P5);
 		inNerveRoom = new ZoneRequirement(nerveRoom1, nerveRoom2, nerveRoom3);

--- a/src/main/java/com/questhelper/helpers/quests/forgettabletale/ForgettableTale.java
+++ b/src/main/java/com/questhelper/helpers/quests/forgettabletale/ForgettableTale.java
@@ -69,7 +69,7 @@ public class ForgettableTale extends BasicQuestHelper
 
 	Requirement inKelgdagrim, inWolfUnderground, inPubUpstairs, inConsortium, inPuzzleRoom, givenBeerToDrunkenDwarf,
 		rowdyDwarfMadeRequest, gotRowdySeed, gotKhorvakSeed, gotGaussSeed, plotRaked, keldaGrowing, keldaGrown,
-		addedWater, addedYeast, addedHop, addedMalt, keldaBrewed, keldaInBarrel, handsFree, shieldFree;
+		addedWater, addedYeast, addedHop, addedMalt, keldaBrewed, keldaInBarrel, handsFree;
 
 	Requirement inPurple, inYellow, inBlue, inGreen, inSilver, inWhite, inBrown;
 
@@ -448,8 +448,7 @@ public class ForgettableTale extends BasicQuestHelper
 		inSilver = new VarbitRequirement(VarbitID.GIANTDWARF_CURRENT_COMPANY, 6); // Silver Cog
 		inBrown = new VarbitRequirement(VarbitID.GIANTDWARF_CURRENT_COMPANY, 7); // Brown Engine
 
-		handsFree = new NoItemRequirement("No weapon equipped", ItemSlots.WEAPON);
-		shieldFree = new NoItemRequirement("No shield equipped", ItemSlots.SHIELD);
+		handsFree = new NoItemRequirement("No weapon or shield equipped", ItemSlots.EMPTY_HANDS);
 
 		// 837 = 1, entered first puzzle
 		// 839 = 1, cutscene entering done
@@ -654,7 +653,7 @@ public class ForgettableTale extends BasicQuestHelper
 		goDownFromDirector = new ObjectStep(this, ObjectID.DWARF_KELDAGRIM_WIDE_STAIRS_UPPER, new WorldPoint(2895, 10210, 1),
 			"Go downstairs.");
 		takeSecretCart = new ObjectStep(this, ObjectID.KELDAGRIM_TRAIN_CART, new WorldPoint(2919, 10164, 0),
-			"", handsFree, shieldFree);
+			"", handsFree);
 
 		searchBox1 = new ObjectStep(this, ObjectID.KELDAGRIM_TRACK_JUNCTION_CARD_BOX, new WorldPoint(1862, 4954, 1),
 			"Search the box.");

--- a/src/main/java/com/questhelper/helpers/quests/pandemonium/Pandemonium.java
+++ b/src/main/java/com/questhelper/helpers/quests/pandemonium/Pandemonium.java
@@ -190,7 +190,7 @@ public class Pandemonium extends BasicQuestHelper
 		cargoNotPickedUp = not(cargoPickedUp);
 		cargoInCargoHold = and(cargoPickedUp, not(holdingCargo));
 
-		nothingInHands = new NoItemRequirement("Nothing equipped in your hands.",ItemSlots.WEAPON, ItemSlots.SHIELD);
+		nothingInHands = new NoItemRequirement("Nothing equipped in your hands.",ItemSlots.EMPTY_HANDS);
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WhileGuthixSleeps.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WhileGuthixSleeps.java
@@ -984,7 +984,7 @@ public class WhileGuthixSleeps extends BasicQuestHelper
 		placedEarthBlock = new VarbitRequirement(VarbitID.WGS_EARTH_KEY_USED, 1);
 		notPlacedFireBlock = new VarbitRequirement(VarbitID.WGS_FIRE_KEY_USED, 0);
 
-		noWeaponOrShieldEquipped = new ComplexRequirement("No weapon or shield equipped", new NoItemRequirement("", ItemSlots.WEAPON), new NoItemRequirement("", ItemSlots.SHIELD));
+		noWeaponOrShieldEquipped = new NoItemRequirement("Nothing equipped in your hands", ItemSlots.EMPTY_HANDS);
 
 		airCavity = new Zone(new WorldPoint(4107, 5095, 0), new WorldPoint(4119, 5116, 0));
 		inAirCavity = new ZoneRequirement(airCavity);


### PR DESCRIPTION
Solves #2443.

Adds `ItemSlots.EMPTY_HANDS` and `ItemSlots.BARE_HANDS`. 
Refactors quests checking for weapon and shield to use this instead.

Strictly speaking, the naming is wrong, as it _could_ also be used to check that both a Weapon and a Shield are equipped.
However, currently `ItemSlots` are only used in a `NoItemRequirement`.

Futhermore, `BARE_HANDS` is currently unused in quests, but added to be clear that `EMPTY_HANDS` does not check for gloves. In game, the check exists for Falconry and Aerial Fishing; you cannot wear weapons, shield or gloves when starting those actions.