### PR TITLE
Add option to filter sea charting steps by Ocean.

### DIFF
--- a/src/main/java/com/questhelper/helpers/activities/charting/ChartingTaskInterface.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/ChartingTaskInterface.java
@@ -31,4 +31,6 @@ public interface ChartingTaskInterface
 	void setupRequiredAndRecommended(ChartingTaskDefinition definition);
 	Requirement getIncompleteRequirement();
 	Requirement getCanDoRequirement();
+	String getOcean();
+	void addOceanFilterHideCondition(Requirement oceanFilterHideCondition);
 }

--- a/src/main/java/com/questhelper/helpers/activities/charting/ChartingTasksData.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/ChartingTasksData.java
@@ -341,7 +341,7 @@ public final class ChartingTasksData
 			new ChartingTaskDefinition(ChartingType.GENERIC, "Find the corpse of a wayward shifter on a small island south of Red Rock.", new WorldPoint(2804, 2460, 0), "Unquiet Ocean", 1, VarbitID.SAILING_CHARTING_GENERIC_DEAD_SHIFTER_COMPLETE),
 			new ChartingTaskDefinition(ChartingType.DIVING, "With help from a mermaid guide, document the water depth north of Red Rock.", new WorldPoint(2788, 2548, 0), "Unquiet Ocean", 38, VarbitID.SAILING_CHARTING_MERMAID_GUIDE_RED_REEF_COMPLETE, "The answer is 10 watermelons.", List.of(ItemID.WATERMELON))
 			, new ChartingTaskDefinition(ChartingType.CRATE, "Find a Sealed crate near Red Rock and sample the contents.", new WorldPoint(2778, 2523, 0), "Unquiet Ocean", 12, VarbitID.SAILING_CHARTING_DRINK_CRATE_REDDEST_RUM_COMPLETE, ItemID.SAILING_CHARTING_DRINK_CRATE_REDDEST_RUM),
-			new ChartingTaskDefinition(ChartingType.CURRENT, "Test the currents south of the pest-filled island near the Void Knights' Outpost.", new WorldPoint(2665, 2560, 0), new WorldPoint(2654, 2610, 0), "Unquiet Ocean", 22, VarbitID.SAILING_CHARTING_CURRENT_DUCK_PEST_ISLAND_COMPLETE)
+			new ChartingTaskDefinition(ChartingType.CURRENT, "Test the currents south of the pest-filled island near the Void Knights' Outpost.", new WorldPoint(2665, 2560, 0), new WorldPoint(2654, 2610, 0), "Ardent Ocean", 22, VarbitID.SAILING_CHARTING_CURRENT_DUCK_PEST_ISLAND_COMPLETE)
 		)),
 		new ChartingSeaSection(19, "Anglerfish's Light", List.of(
 			// Extra

--- a/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingCaveTelescopeStep.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingCaveTelescopeStep.java
@@ -28,12 +28,13 @@ import com.questhelper.helpers.activities.charting.ChartingTaskDefinition;
 import com.questhelper.helpers.activities.charting.ChartingTaskInterface;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.steps.ConditionalStep;
-import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.ObjectStep;
 import lombok.Getter;
 import net.runelite.api.Skill;
@@ -47,6 +48,8 @@ public class ChartingCaveTelescopeStep extends ConditionalStep implements Charti
 {
 	private Requirement incompleteRequirement;
 	private Requirement canDoRequirement;
+	private Requirement completedRequirement;
+	private final String ocean;
 
 	public ChartingCaveTelescopeStep(QuestHelper questHelper, ChartingTaskDefinition definition, Requirement... requirements)
 	{
@@ -55,6 +58,8 @@ public class ChartingCaveTelescopeStep extends ConditionalStep implements Charti
 			"Enter the cave on the Pandemonium island."),
 			"[" + definition.getType().getDisplayName() + "] " + definition.getDescription()
 			);
+
+		this.ocean = definition.getOcean();
 
 		ZoneRequirement inCaveZone = new ZoneRequirement(new Zone(12178));
 		var useTelescopeStep = new ChartingTelescopeStep(questHelper, definition, requirements);
@@ -67,7 +72,7 @@ public class ChartingCaveTelescopeStep extends ConditionalStep implements Charti
 	private void setupSidebarRequirements(ChartingTaskDefinition definition)
 	{
 		var sailingRequirement = new SkillRequirement(Skill.SAILING, Math.max(1, definition.getLevel()));
-		var completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
+		this.completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
 		var levelNotMet = nor(sailingRequirement);
 		levelNotMet.setText("You need to meet level " + sailingRequirement.getRequiredLevel() + " Sailing.");
 
@@ -82,6 +87,13 @@ public class ChartingCaveTelescopeStep extends ConditionalStep implements Charti
 	public void setupRequiredAndRecommended(ChartingTaskDefinition definition)
 	{
 		// Not implemented in ConditionalStep. Not needed for this so won't bother
+	}
+
+	@Override
+	public void addOceanFilterHideCondition(Requirement oceanFilterHideCondition)
+	{
+		// Hide if completed OR doesn't match ocean filter
+		conditionToHideInSidebar(new Conditions(LogicType.OR, completedRequirement, oceanFilterHideCondition));
 	}
 }
 

--- a/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingPuzzleWrapStep.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingPuzzleWrapStep.java
@@ -28,7 +28,9 @@ import com.questhelper.helpers.activities.charting.ChartingTaskDefinition;
 import com.questhelper.helpers.activities.charting.ChartingTaskInterface;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.steps.PuzzleWrapperStep;
 import com.questhelper.steps.QuestStep;
@@ -38,6 +40,7 @@ import static com.questhelper.requirements.util.LogicHelper.nor;
 public class ChartingPuzzleWrapStep extends PuzzleWrapperStep implements ChartingTaskInterface
 {
 	private final ChartingTaskInterface questStep;
+	private final Requirement completedRequirement;
 
 	public ChartingPuzzleWrapStep(QuestHelper questHelper, QuestStep questStep, QuestStep noAnswerStep, ChartingTaskDefinition definition)
 	{
@@ -47,8 +50,8 @@ public class ChartingPuzzleWrapStep extends PuzzleWrapperStep implements Chartin
 		var sailingRequirement = new SkillRequirement(Skill.SAILING, Math.max(1, definition.getLevel()));
 		var levelNotMet = nor(sailingRequirement);
 		levelNotMet.setText("You need to meet level " + sailingRequirement.getRequiredLevel() + " Sailing.");
-		var completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
-		
+		this.completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
+
 		conditionToHideInSidebar(completedRequirement);
 		conditionToFadeInSidebar(levelNotMet);
 	}
@@ -69,5 +72,18 @@ public class ChartingPuzzleWrapStep extends PuzzleWrapperStep implements Chartin
 	public void setupRequiredAndRecommended(ChartingTaskDefinition definition)
 	{
 		// Hopefully implemented in the wrapped step?
+	}
+
+	@Override
+	public String getOcean()
+	{
+		return questStep.getOcean();
+	}
+
+	@Override
+	public void addOceanFilterHideCondition(Requirement oceanFilterHideCondition)
+	{
+		// Hide if completed OR doesn't match ocean filter
+		conditionToHideInSidebar(new Conditions(LogicType.OR, completedRequirement, oceanFilterHideCondition));
 	}
 }

--- a/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingTaskObjectStep.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingTaskObjectStep.java
@@ -28,7 +28,9 @@ import com.questhelper.helpers.activities.charting.ChartingTaskDefinition;
 import com.questhelper.helpers.activities.charting.ChartingTaskInterface;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.steps.ObjectStep;
 import lombok.Getter;
@@ -41,6 +43,8 @@ public class ChartingTaskObjectStep extends ObjectStep implements ChartingTaskIn
 {
 	private Requirement incompleteRequirement;
 	protected Requirement canDoRequirement;
+	private Requirement completedRequirement;
+	private String ocean;
 
 	ChartingTaskObjectStep(QuestHelper questHelper, int objectID, ChartingTaskDefinition definition, Requirement... requirements)
 	{
@@ -61,13 +65,15 @@ public class ChartingTaskObjectStep extends ObjectStep implements ChartingTaskIn
 			setHideMinimapLines(true);
 		}
 
+		this.ocean = definition.getOcean();
+
 		var sailingRequirement = new SkillRequirement(Skill.SAILING, Math.max(1, definition.getLevel()));
 		addRequirement(sailingRequirement);
 
 		// Additional reqs and recc
 		setupRequiredAndRecommended(definition);
 
-		var completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
+		this.completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
 		var levelNotMet = nor(sailingRequirement);
 		levelNotMet.setText("You need to meet level " + sailingRequirement.getRequiredLevel() + " Sailing.");
 		conditionToHideInSidebar(completedRequirement);
@@ -89,5 +95,12 @@ public class ChartingTaskObjectStep extends ObjectStep implements ChartingTaskIn
 		{
 			addRecommended(definition.getAdditionalRecommended());
 		}
+	}
+
+	@Override
+	public void addOceanFilterHideCondition(Requirement oceanFilterHideCondition)
+	{
+		// Hide if completed OR doesn't match ocean filter
+		conditionToHideInSidebar(new Conditions(LogicType.OR, completedRequirement, oceanFilterHideCondition));
 	}
 }

--- a/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingTaskStep.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingTaskStep.java
@@ -28,7 +28,9 @@ import com.questhelper.helpers.activities.charting.ChartingHelper;
 import com.questhelper.helpers.activities.charting.ChartingTaskDefinition;
 import com.questhelper.helpers.activities.charting.ChartingTaskInterface;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.steps.DetailedQuestStep;
 import lombok.Getter;
@@ -41,6 +43,8 @@ public final class ChartingTaskStep extends DetailedQuestStep implements Chartin
 {
 	private Requirement incompleteRequirement;
 	private Requirement canDoRequirement;
+	private Requirement completedRequirement;
+	private String ocean;
 
 	public ChartingTaskStep(ChartingHelper helper, ChartingTaskDefinition definition)
 	{
@@ -61,10 +65,12 @@ public final class ChartingTaskStep extends DetailedQuestStep implements Chartin
 			setHideMinimapLines(true);
 		}
 
+		this.ocean = definition.getOcean();
+
 		var sailingRequirement = new SkillRequirement(Skill.SAILING, Math.max(1, definition.getLevel()));
 		addRequirement(sailingRequirement);
 
-		var completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
+		this.completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
 		var levelNotMet = nor(sailingRequirement);
 		levelNotMet.setText("You need to meet level " + sailingRequirement.getRequiredLevel() + " Sailing.");
 		conditionToHideInSidebar(completedRequirement);
@@ -72,6 +78,13 @@ public final class ChartingTaskStep extends DetailedQuestStep implements Chartin
 
 		canDoRequirement = and(new VarbitRequirement(definition.getVarbitId(), 0), sailingRequirement);
 		incompleteRequirement = new VarbitRequirement(definition.getVarbitId(), 0);
+	}
+
+	@Override
+	public void addOceanFilterHideCondition(Requirement oceanFilterHideCondition)
+	{
+		// Hide if completed OR doesn't match ocean filter
+		conditionToHideInSidebar(new Conditions(LogicType.OR, completedRequirement, oceanFilterHideCondition));
 	}
 
 	@Override

--- a/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingWeatherStep.java
+++ b/src/main/java/com/questhelper/helpers/activities/charting/steps/ChartingWeatherStep.java
@@ -28,12 +28,13 @@ import com.questhelper.helpers.activities.charting.ChartingTaskDefinition;
 import com.questhelper.helpers.activities.charting.ChartingTaskInterface;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.conditional.Conditions;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.steps.ConditionalStep;
 import com.questhelper.steps.DetailedQuestStep;
-import com.questhelper.steps.QuestStep;
 import lombok.Getter;
 import net.runelite.api.Skill;
 import net.runelite.api.gameval.ItemID;
@@ -47,6 +48,8 @@ public class ChartingWeatherStep extends ConditionalStep implements ChartingTask
 {
 	private Requirement incompleteRequirement;
 	private Requirement canDoRequirement;
+	private Requirement completedRequirement;
+	private final String ocean;
 
 	// Steps
 	private ChartingTaskNpcStep talkToNpcStep;
@@ -60,6 +63,8 @@ public class ChartingWeatherStep extends ConditionalStep implements ChartingTask
 	public ChartingWeatherStep(QuestHelper questHelper, ChartingTaskDefinition definition, Requirement... requirements)
 	{
 		super(questHelper, new DetailedQuestStep(questHelper, "Loading weather charting task..."));
+
+		this.ocean = definition.getOcean();
 
 		setupRequirements();
 		setupSteps(questHelper, definition, requirements);
@@ -115,7 +120,7 @@ public class ChartingWeatherStep extends ConditionalStep implements ChartingTask
 	private void setupSidebarRequirements(ChartingTaskDefinition definition)
 	{
 		var sailingRequirement = new SkillRequirement(Skill.SAILING, Math.max(1, definition.getLevel()));
-		var completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
+		this.completedRequirement = new VarbitRequirement(definition.getVarbitId(), 1);
 		var levelNotMet = nor(sailingRequirement);
 		levelNotMet.setText("You need to meet level " + sailingRequirement.getRequiredLevel() + " Sailing.");
 
@@ -130,5 +135,12 @@ public class ChartingWeatherStep extends ConditionalStep implements ChartingTask
 	public void setupRequiredAndRecommended(ChartingTaskDefinition definition)
 	{
 		// Should've been implemented in substeps. Needed if we used any reqs for blocking
+	}
+
+	@Override
+	public void addOceanFilterHideCondition(Requirement oceanFilterHideCondition)
+	{
+		// Hide if completed OR doesn't match ocean filter
+		conditionToHideInSidebar(new Conditions(LogicType.OR, completedRequirement, oceanFilterHideCondition));
 	}
 }


### PR DESCRIPTION
Should close #2464 and close #2446 

I found one task that was incorrectly categorised while I was charting the Ardent sea for testing, but there may be others.

I think this is useful for people who want to quickly finish off an ocean to claim the bonus xp.

Bonus steps that happen to be in the same ocean will also be shown.

I'm not a Java dev in my day job so sorry if anything isn't idiomatic.