### PR TITLE
feat: Redirect to https://oldschool.runescape.wiki/w/{item}#Item_sources

### DIFF
--- a/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/ItemRequirement.java
@@ -646,11 +646,11 @@ public class ItemRequirement extends AbstractRequirement
 	public String getWikiUrl()
 	{
 		if (getUrlSuffix() != null) {
-			return "https://oldschool.runescape.wiki/w/" + getUrlSuffix();
+			return "https://oldschool.runescape.wiki/w/" + getUrlSuffix() + "#Item_sources";
 		}
 
 		if (getId() != -1) {
-			return "https://oldschool.runescape.wiki/w/Special:Lookup?type=item&id=" + getId();
+			return "https://oldschool.runescape.wiki/w/Special:Lookup?type=item&id=" + getId() + "#Item_sources";
 		}
 
 		return null;


### PR DESCRIPTION
Closes #2474

Redirects to the item's item sources section in the wiki. Tested for numerous items, for items that do not have an item sources section in the wiki, it redirects to top of the page (existing functionality) and for `ItemCollections` such as chargeable items it also redirects to the top of the page.

This seems to be because, the item sources Url looks something like "https://oldschool.runescape.wiki/w/Ring_of_dueling#Item_sources" however any `Item_ID` or valid Url suffix for such item is like "https://oldschool.runescape.wiki/w/Ring_of_dueling#(8)" therefore the addition of `#Item_Sources` does not correspond to the wiki url.

If further changes can be made, I'm happy to discuss for these such `ItemCollections` however for most collections like `BOWS` or `AXES` there is no `Sources` section anyway in the wiki unless a specific item is selected so I assume it is fine to keep as is.