### PR TITLE
fix tiara requirement name

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorEasy.java
@@ -156,16 +156,16 @@ public class FaladorEasy extends ComplexStateQuestHelper
 		notBluriteLimbs = new VarplayerRequirement(VarPlayerID.FALADOR_ACHIEVEMENT_DIARY, false, 10);
 
 		//Required
-		bucket = new ItemRequirement("Bucket", ItemID.BUCKET_EMPTY).showConditioned(notFilledWater).isNotConsumed();
-		tiara = new ItemRequirement("Silver Tiara", ItemID.TIARA).showConditioned(notMindTiara);
-		mindTalisman = new ItemRequirement("Mind Talisman", ItemID.MIND_TALISMAN).showConditioned(notMindTiara);
-		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(new Conditions(LogicType.OR, notMotherloadMine, notBluriteLimbs)).isNotConsumed();
+		bucket = requirementFactory.newItem(ItemID.BUCKET_EMPTY).showConditioned(notFilledWater).isNotConsumed();
+		tiara = requirementFactory.newItem(ItemID.TIARA).showConditioned(notMindTiara);
+		mindTalisman = requirementFactory.newItem(ItemID.MIND_TALISMAN).showConditioned(notMindTiara);
+		hammer = requirementFactory.newItem(ItemID.HAMMER).showConditioned(new Conditions(LogicType.OR, notMotherloadMine, notBluriteLimbs)).isNotConsumed();
 		pickaxe = new ItemRequirement("Any Pickaxe", ItemCollections.PICKAXES)
 			.showConditioned(new Conditions(LogicType.OR, notMotherloadMine, notBluriteLimbs)).isNotConsumed();
 		combatGear = new ItemRequirement("A range or mage attack to kill a Duck (Level 1)", -1, -1).showConditioned(notKilledDuck).isNotConsumed();
 		combatGear.setDisplayItemId(BankSlotIcons.getRangedCombatGear());
-		bluriteOre = new ItemRequirement("Blurite Ore", ItemID.BLURITE_ORE);
-		bluriteBar = new ItemRequirement("Blurite Bar", ItemID.BLURITE_BAR);
+		bluriteOre = requirementFactory.newItem(ItemID.BLURITE_ORE);
+		bluriteBar = requirementFactory.newItem(ItemID.BLURITE_BAR);
 		bluriteOre.canBeObtainedDuringQuest();
 		bluriteBar.canBeObtainedDuringQuest();
 

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -35,6 +35,7 @@ import com.questhelper.questinfo.ExternalQuestResources;
 import com.questhelper.questinfo.HelperConfig;
 import com.questhelper.questinfo.QuestHelperQuest;
 import com.questhelper.requirements.Requirement;
+import com.questhelper.requirements.RequirementFactory;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.rewards.*;
 import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectManager;
@@ -69,6 +70,9 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 
 	@Inject
 	protected RuneliteObjectManager runeliteObjectManager;
+
+	@Inject
+	protected RequirementFactory requirementFactory;
 
 	@Getter
 	@Setter

--- a/src/main/java/com/questhelper/requirements/RequirementFactory.java
+++ b/src/main/java/com/questhelper/requirements/RequirementFactory.java
@@ -1,0 +1,27 @@
+package com.questhelper.requirements;
+
+import com.questhelper.requirements.item.ItemRequirement;
+import lombok.NonNull;
+import net.runelite.client.game.ItemManager;
+import javax.inject.Inject;
+
+/**
+ * Assists construction of {@link ItemRequirement}s.
+ */
+public class RequirementFactory {
+
+	private final ItemManager itemManager;
+
+	@Inject
+	public RequirementFactory(@NonNull ItemManager itemManager) {
+		this.itemManager = itemManager;
+	}
+
+	/**
+	 * Create a new {@link ItemRequirement} with a game-provided name.
+	 */
+	public ItemRequirement newItem(int itemId) {
+		String name = itemManager.getItemComposition(itemId).getMembersName();
+		return new ItemRequirement(name, itemId);
+	}
+}


### PR DESCRIPTION
Fixes #2555.

Instead of just fixing the typo, I introduced a new factory for constructing `ItemRequirement`s. Now helpers can construct `ItemRequirement`s with just an item ID and the plugin will default to using the in-game name for the item, instead of needing to supply a redundant item name. This will make issues like this less likely going forward.

Although the factory is quite small, I can imagine adding similarly helpful construction functions to it in the future for other kinds of duplication (such as common requirements like "Any pickaxe").