### PR TITLE
polish(Lost City): Account for Iron Axe drop

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/lostcity/LostCity.java
+++ b/src/main/java/com/questhelper/helpers/quests/lostcity/LostCity.java
@@ -29,6 +29,7 @@ import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.conditional.Conditions;
+import com.questhelper.requirements.util.LogicType;
 import com.questhelper.requirements.conditional.NpcCondition;
 import com.questhelper.requirements.item.ItemOnTileRequirement;
 import com.questhelper.requirements.item.ItemRequirement;


### PR DESCRIPTION
As a friend found out today, it is possible to get an Iron Axe from the zombies in the Entrana dungeon, albeit it significantly more rare than getting a bronze one. [See [https://oldschool.runescape.wiki/w/Zombie_(Entrana_Dungeon)](https://oldschool.runescape.wiki/w/Zombie_(Entrana_Dungeon))] 

This is for polishing the Lost City quest to account for this possibility.

