### PR TITLE
feat: rewrite the Steel key ring into a tracked container

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -256,6 +256,7 @@ public class QuestHelperPlugin extends Plugin
 	public void onGameTick(GameTick event)
 	{
 		questBankManager.loadInitialStateFromConfig(client);
+		playerStateManager.loadInitialStateFromConfig();
 		questManager.updateQuestState();
 	}
 
@@ -310,6 +311,7 @@ public class QuestHelperPlugin extends Plugin
 			questBankManager.saveBankToConfig();
 			SwingUtilities.invokeLater(() -> panel.refresh(Collections.emptyList(), true, new HashMap<>()));
 			questBankManager.emptyState();
+			playerStateManager.emptyState();
 			questManager.shutDownQuest(true);
 			profileChanged = true;
 		}
@@ -321,6 +323,7 @@ public class QuestHelperPlugin extends Plugin
 			GlobalFakeObjects.createNpcs(client, runeliteObjectManager, configManager, config);
 			newVersionManager.updateChatWithNotificationIfNewVersion();
 			questBankManager.setUnknownInitialState();
+			playerStateManager.setUnknownInitialState();
 			potionStorage.updateCachedPotions = true;
 			clientThread.invokeAtTickEnd(() -> {
 				questManager.setupRequirements();
@@ -447,6 +450,33 @@ public class QuestHelperPlugin extends Plugin
 				}
 			}
 			log.debug(String.valueOf(inv));
+		}
+		else if (developerMode && commandExecuted.getCommand().equals("qh"))
+		{
+			var args = commandExecuted.getArguments();
+			if (args.length == 0)
+			{
+				return;
+			}
+			var subCommand = args[0];
+			if (subCommand.equals("container"))
+			{
+				if (args.length < 2)
+				{
+					return;
+				}
+				var container = args[1];
+				switch (container)
+				{
+					case "keyring":
+						var keyringItems = QuestContainerManager.getKeyRingData().getItems();
+						for (var item : keyringItems)
+						{
+							log.debug("Key ring item: {}", item);
+						}
+						break;
+				}
+			}
 		}
 	}
 

--- a/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
+++ b/src/main/java/com/questhelper/bank/banktab/QuestHelperBankTagService.java
@@ -32,6 +32,7 @@ import com.questhelper.requirements.item.KeyringRequirement;
 import com.questhelper.requirements.util.LogicType;
 import net.runelite.api.Client;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.client.config.ConfigManager;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,6 +50,9 @@ public class QuestHelperBankTagService
 
 	@Inject
 	private Client client;
+
+	@Inject
+	private ConfigManager configManager;
 
 	ArrayList<Integer> taggedItems;
 
@@ -221,14 +225,18 @@ public class QuestHelperBankTagService
 		else if (itemRequirement instanceof KeyringRequirement)
 		{
 			KeyringRequirement keyringRequirement = (KeyringRequirement) itemRequirement;
-			KeyringRequirement fakeRequirement = new KeyringRequirement(keyringRequirement.getName(), plugin.getConfigManager(),
-					keyringRequirement.getKeyringCollection());
-			if (keyringRequirement.hasKeyOnKeyRing())
+			var keyringCollection = keyringRequirement.getKeyringCollection();
+			var fakeRequirement = keyringRequirement.copy();
+			if (keyringCollection.hasKeyOnKeyRing(configManager))
 			{
 				fakeRequirement.addAlternates(ItemID.FAVOUR_KEY_RING);
+				// NOTE: If the key is on your key ring _AND_ in your bank, we will still suggest using the key ring.
+				pluginItems.add(new BankTabItem(fakeRequirement, ItemID.FAVOUR_KEY_RING));
 			}
-			pluginItems.add(makeBankTabItem(fakeRequirement));
-
+			else
+			{
+				pluginItems.add(makeBankTabItem(fakeRequirement));
+			}
 		}
 		else
 		{

--- a/src/main/java/com/questhelper/collections/KeyringCollection.java
+++ b/src/main/java/com/questhelper/collections/KeyringCollection.java
@@ -24,15 +24,10 @@
  */
 package com.questhelper.collections;
 
-import com.questhelper.requirements.item.KeyringRequirement;
+import com.questhelper.QuestHelperConfig;
 import lombok.Getter;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.config.ConfigManager;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public enum KeyringCollection
 {
@@ -50,14 +45,18 @@ public enum KeyringCollection
 	ENCHANTED_KEY(ItemID.MAKINGHISTORY_KEY),
 	NEW_KEY(ItemID.MOURNING_EXCAVATION_KEY);
 
+	private final String CONFIG_GROUP = QuestHelperConfig.QUEST_BACKGROUND_GROUP;
+
 	@Getter
 	private final int itemID;
+
 	KeyringCollection(int itemID)
 	{
 		this.itemID = itemID;
 	}
 
-	public String toChatText()
+	/// The name of this key as seen in the chat box.
+	public String chatboxText()
 	{
 		return name().toLowerCase().replaceAll("_", " ");
 	}
@@ -67,19 +66,20 @@ public enum KeyringCollection
 		return name().toLowerCase().replaceAll("_", "");
 	}
 
-	public static List<KeyringRequirement> allKeyRequirements(ConfigManager configManager)
+	public boolean hasKeyOnKeyRing(ConfigManager configManager)
 	{
-		List<KeyringRequirement> keys = new ArrayList<>();
-		for (KeyringCollection keyringCollection : Collections.unmodifiableList(Arrays.asList(values())))
-		{
-			keys.add(new KeyringRequirement(configManager, keyringCollection));
-		}
+		var value = configManager.getRSProfileConfiguration(CONFIG_GROUP, runeliteName());
 
-		return keys;
+		return "true".equals(value);
 	}
 
-	public KeyringRequirement getRequirement(ConfigManager configManager)
+	public void setHasKeyOnKeyRing(ConfigManager configManager, boolean value)
 	{
-		return new KeyringRequirement(configManager, this);
+		if (configManager.getRSProfileKey() == null)
+		{
+			return;
+		}
+
+		configManager.setRSProfileConfiguration(CONFIG_GROUP, runeliteName(), value ? "true" : "false");
 	}
 }

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneHard.java
@@ -187,7 +187,7 @@ public class ArdougneHard extends ComplexStateQuestHelper
 
 		var hasCompletedSOTE = new QuestRequirement(QuestHelperQuest.SONG_OF_THE_ELVES, QuestState.FINISHED);
 
-		newKey = new KeyringRequirement("New key", configManager, KeyringCollection.NEW_KEY).showConditioned(notDeathRune).isNotConsumed().hideConditioned(hasCompletedSOTE);
+		newKey = new KeyringRequirement("New key", KeyringCollection.NEW_KEY).showConditioned(notDeathRune).isNotConsumed().hideConditioned(hasCompletedSOTE);
 		newKey.setTooltip("Another can be found on the desk in the south-east room of the Mourner HQ basement.");
 
 		mournerBoots = new ItemRequirement("Mourner boots", ItemID.MOURNING_MOURNER_BOOTS).isNotConsumed().hideConditioned(hasCompletedSOTE);

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinEasy.java
@@ -176,7 +176,7 @@ public class KandarinEasy extends ComplexStateQuestHelper
         juteSeed = new ItemRequirement("Jute seeds", ItemID.JUTE_SEED).showConditioned(notPlantJute);
         rake = new ItemRequirement("Rake", ItemID.RAKE).showConditioned(notPlantJute).isNotConsumed();
         seedDibber = new ItemRequirement("Seed dibber", ItemID.DIBBER).showConditioned(notPlantJute).isNotConsumed();
-        batteredKey = new KeyringRequirement("Battered Key", configManager, KeyringCollection.BATTERED_KEY).showConditioned(notKillEle).isNotConsumed();
+        batteredKey = new KeyringRequirement("Battered Key", KeyringCollection.BATTERED_KEY).showConditioned(notKillEle).isNotConsumed();
         batteredKey.setTooltip("You can get another by searching the bookcase in the house south of the Elemental " +
 			"Workshop, then reading the book you get from it");
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
@@ -174,7 +174,7 @@ public class KandarinHard extends ComplexStateQuestHelper
 
 		Conditions not70Agility = new Conditions(LogicType.NOR, new SkillRequirement(Skill.AGILITY, 70, true));
 
-		dustyKey = new KeyringRequirement("Dusty Key", configManager, KeyringCollection.DUSTY_KEY).showConditioned(new Conditions(not70Agility,
+		dustyKey = new KeyringRequirement("Dusty Key", KeyringCollection.DUSTY_KEY).showConditioned(new Conditions(not70Agility,
 			notWaterOrb)).isNotConsumed();
 		dustyKey.setTooltip("You can get this by killing the Jailer in the Black Knights Base in Taverley Dungeon and" +
 			" using the key he drops to enter the jail cell there to talk to Velrak for the dusty key");

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinMedium.java
@@ -187,7 +187,7 @@ public class KandarinMedium extends ComplexStateQuestHelper
 		hornDust = new ItemRequirement("Horn Dust", ItemID.UNICORN_HORN_DUST, 1).showConditioned(notSuperAnti);
 		vialOfWater = new ItemRequirement("Vial of water", ItemID.VIAL_WATER, 1).showConditioned(notSuperAnti);
 		iritLeaf = new ItemRequirement("Irit leaf", ItemID.IRIT_LEAF, 1).showConditioned(notSuperAnti);
-		dustyKey = new KeyringRequirement("Dusty Key", configManager, KeyringCollection.DUSTY_KEY).showConditioned(new Conditions(not70Agility,
+		dustyKey = new KeyringRequirement("Dusty Key", KeyringCollection.DUSTY_KEY).showConditioned(new Conditions(not70Agility,
 			notGrapOb)).isNotConsumed();
 		dustyKey.setTooltip("You can get this by killing the Jailer in the Black Knights Base in Taverley Dungeon and" +
 			" using the key he drops to enter the jail cell there to talk to Velrak for the dusty key");
@@ -202,7 +202,7 @@ public class KandarinMedium extends ComplexStateQuestHelper
 		primedMind = new ItemRequirement("Mind bar", ItemID.ELEM_MIND_BAR).showConditioned(notMindHelm);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER).showConditioned(notMindHelm).isNotConsumed();
 		beatenBook = new ItemRequirement("Beaten Book", ItemID.ELEMENTAL_WORKSHOP_HELM_BOOK).showConditioned(notMindHelm);
-		batteredKey = new KeyringRequirement("Battered Key", configManager, KeyringCollection.BATTERED_KEY).showConditioned(notMindHelm);
+		batteredKey = new KeyringRequirement("Battered Key", KeyringCollection.BATTERED_KEY).showConditioned(notMindHelm);
 		batteredKey.setTooltip("You can get another by searching the bookcase in the house south of the Elemental " +
 			"Workshop, then reading the book you get from it");
 

--- a/src/main/java/com/questhelper/helpers/miniquests/enchantedkey/EnchantedKey.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/enchantedkey/EnchantedKey.java
@@ -70,7 +70,7 @@ public class EnchantedKey extends BasicQuestHelper
 	protected void setupRequirements()
 	{
 		spade = new ItemRequirement("Spade", ItemID.SPADE).isNotConsumed();
-		key = new KeyringRequirement("Enchanted key", configManager, KeyringCollection.ENCHANTED_KEY);
+		key = new KeyringRequirement("Enchanted key", KeyringCollection.ENCHANTED_KEY);
 		varrockTeleports = new ItemRequirement("Varrock teleports", ItemID.POH_TABLET_VARROCKTELEPORT);
 		ardougneTeleports = new ItemRequirement("Ardougne teleports", ItemID.POH_TABLET_ARDOUGNETELEPORT);
 		rellekkaTeleports = new ItemRequirement("Rellekka teleport", ItemID.NZONE_TELETAB_RELLEKKA);

--- a/src/main/java/com/questhelper/helpers/quests/bearyoursoul/BearYourSoul.java
+++ b/src/main/java/com/questhelper/helpers/quests/bearyoursoul/BearYourSoul.java
@@ -79,7 +79,7 @@ public class BearYourSoul extends BasicQuestHelper
 	{
 		dustyKeyOr70AgilOrKeyMasterTeleport =
 		new KeyringRequirement("Dusty key, or another way to get into the deep Taverley Dungeon",
-			configManager, KeyringCollection.DUSTY_KEY).isNotConsumed();
+			KeyringCollection.DUSTY_KEY).isNotConsumed();
 		spade = new ItemRequirement("Spade", ItemID.SPADE).isNotConsumed();
 		damagedSoulBearer = new ItemRequirement("Damaged soul bearer", ItemID.ARCEUUS_SOULBEARER_DAMAGED);
 	}

--- a/src/main/java/com/questhelper/helpers/quests/elementalworkshopi/ElementalWorkshopI.java
+++ b/src/main/java/com/questhelper/helpers/quests/elementalworkshopi/ElementalWorkshopI.java
@@ -154,7 +154,7 @@ public class ElementalWorkshopI extends ComplexStateQuestHelper
 		slashedBook = new ItemRequirement("Slashed book", ItemID.ELEMENTAL_WORKSHOP_SHIELD_BOOK_SLASHED);
 		slashedBook.setTooltip("If you've lost it you can get another by searching the bookcase in the building south of " +
 			"the odd wall");
-		batteredKey = new KeyringRequirement("Battered Key", configManager, KeyringCollection.BATTERED_KEY);
+		batteredKey = new KeyringRequirement("Battered Key", KeyringCollection.BATTERED_KEY);
 		batteredKey.setTooltip("If you've lost it you can get another by searching the bookcase in the building south of " +
 			"the odd wall");
 		elementalOre = new ItemRequirement("Elemental ore", ItemID.ELEMENTAL_WORKSHOP_ORE);

--- a/src/main/java/com/questhelper/helpers/quests/elementalworkshopii/ElementalWorkshopII.java
+++ b/src/main/java/com/questhelper/helpers/quests/elementalworkshopii/ElementalWorkshopII.java
@@ -256,7 +256,7 @@ public class ElementalWorkshopII extends BasicQuestHelper
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES).isNotConsumed();
 		hammer = new ItemRequirement("Hammer", ItemCollections.HAMMER).isNotConsumed();
 		coal = new ItemRequirement("Coal", ItemID.COAL, 8);
-		batteredKey = new KeyringRequirement("Battered Key", configManager, KeyringCollection.BATTERED_KEY);
+		batteredKey = new KeyringRequirement("Battered Key", KeyringCollection.BATTERED_KEY);
 		batteredKey.setTooltip("You can get another by searching the bookcase in the house south of the elemental " +
 			"workshop's entrance");
 

--- a/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
+++ b/src/main/java/com/questhelper/helpers/quests/heroesquest/HeroesQuest.java
@@ -198,8 +198,8 @@ public class HeroesQuest extends BasicQuestHelper
 		fishingRod.addAlternates(ItemID.OILY_FISHING_ROD);
 		fishingBait = new ItemRequirement("Fishing bait", ItemID.FISHING_BAIT);
 		jailKey = new ItemRequirement("Jail key", ItemID.JAIL_KEY).isNotConsumed();
-		dustyKey = new KeyringRequirement("Dusty Key", configManager, KeyringCollection.DUSTY_KEY).isNotConsumed();
-		dustyKeyHint = new KeyringRequirement("Dusty key (obtainable in quest)", configManager, KeyringCollection.DUSTY_KEY).isNotConsumed();
+		dustyKey = new KeyringRequirement("Dusty Key", KeyringCollection.DUSTY_KEY).isNotConsumed();
+		dustyKeyHint = new KeyringRequirement("Dusty key (obtainable in quest)", KeyringCollection.DUSTY_KEY).isNotConsumed();
 		harralanderUnf = new ItemRequirement("Harralander potion (unf)", ItemID.HARRALANDERVIAL);
 		pickaxe = new ItemRequirement("Any pickaxe", ItemID.BRONZE_PICKAXE).isNotConsumed();
 		pickaxe.addAlternates(ItemCollections.PICKAXES);

--- a/src/main/java/com/questhelper/helpers/quests/makinghistory/MakingHistory.java
+++ b/src/main/java/com/questhelper/helpers/quests/makinghistory/MakingHistory.java
@@ -150,7 +150,7 @@ public class MakingHistory extends BasicQuestHelper
 		portPhasmatysEntry.setTooltip(ectoTokens.getTooltip());
 
 		ringOfDueling = new ItemRequirement("Ring of Dueling", ItemCollections.RING_OF_DUELINGS);
-		enchantedKey = new KeyringRequirement("Enchanted key", configManager, KeyringCollection.ENCHANTED_KEY);
+		enchantedKey = new KeyringRequirement("Enchanted key", KeyringCollection.ENCHANTED_KEY);
 		enchantedKey.setTooltip("You can get another from the silver merchant in East Ardougne's market");
 
 		enchantedKeyHighlighted = new ItemRequirement("Enchanted key", ItemID.MAKINGHISTORY_KEY);

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -425,7 +425,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 			ItemCollections.PRAYER_POTIONS, -1);
 		food = new ItemRequirement("Food", ItemCollections.GOOD_EATING_FOOD, -1);
 
-		newKey = new KeyringRequirement("New Key", configManager, KeyringCollection.NEW_KEY);
+		newKey = new KeyringRequirement("New Key", KeyringCollection.NEW_KEY);
 		newKey.setTooltip("You can get another from Essyllt's desk");
 
 		edernsJournal = new ItemRequirement("Edern's journal", ItemID.MOURNING_EDERNS_JOURNAL);

--- a/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
+++ b/src/main/java/com/questhelper/helpers/quests/ragandboneman/RagAndBoneManII.java
@@ -215,7 +215,7 @@ public class RagAndBoneManII extends BasicQuestHelper
 		logs = new ItemRequirement("Logs", ItemID.LOGS);
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX).isNotConsumed();
 		lightSource = new ItemRequirement("Light source", ItemCollections.LIGHT_SOURCES).isNotConsumed();
-		dustyKey = new KeyringRequirement("Dusty Key", configManager, KeyringCollection.DUSTY_KEY).isNotConsumed();
+		dustyKey = new KeyringRequirement("Dusty Key", KeyringCollection.DUSTY_KEY).isNotConsumed();
 		dustyKey.canBeObtainedDuringQuest();
 		mirrorShield = new ItemRequirement("Mirror shield", ItemID.SLAYER_MIRROR_SHIELD).isNotConsumed();
 		mirrorShield.addAlternates(ItemID.VIKINGEXILE_V_SHIELD, ItemID.V_SHIELD);

--- a/src/main/java/com/questhelper/helpers/quests/scorpioncatcher/ScorpionCatcher.java
+++ b/src/main/java/com/questhelper/helpers/quests/scorpioncatcher/ScorpionCatcher.java
@@ -114,7 +114,7 @@ public class ScorpionCatcher extends BasicQuestHelper
 	@Override
 	protected void setupRequirements()
 	{
-		dustyKey = new KeyringRequirement("Dusty Key", configManager, KeyringCollection.DUSTY_KEY).isNotConsumed();
+		dustyKey = new KeyringRequirement("Dusty Key", KeyringCollection.DUSTY_KEY).isNotConsumed();
 		dustyKey.setTooltip("Not needed if you have level 70 Agility, can be obtained during the quest");
 		jailKey = new ItemRequirement("Jail Key", ItemID.JAIL_KEY);
 

--- a/src/main/java/com/questhelper/helpers/quests/thetouristtrap/TheTouristTrap.java
+++ b/src/main/java/com/questhelper/helpers/quests/thetouristtrap/TheTouristTrap.java
@@ -191,7 +191,7 @@ public class TheTouristTrap extends BasicQuestHelper
 		bronzeBar3 = new ItemRequirement("Bronze bars", ItemID.BRONZE_BAR, 3);
 		hammer = new ItemRequirement("Hammer", ItemCollections.HAMMER).isNotConsumed();
 
-		metalKey = new KeyringRequirement("Metal key", configManager, KeyringCollection.METAL_KEY);
+		metalKey = new KeyringRequirement("Metal key", KeyringCollection.METAL_KEY);
 		metalKey.setTooltip("You can get another by killing the Mercenary Guard outside the Desert Mining Camp");
 		slaveTop = new ItemRequirement("Slave shirt", ItemID.SLAVE_SHIRT);
 		slaveTop.setTooltip("You can trade in a desert robe set for slave clothes with the Male Slave");

--- a/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
+++ b/src/main/java/com/questhelper/managers/ItemAndLastUpdated.java
@@ -31,7 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Item;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 @Slf4j
@@ -53,11 +55,35 @@ public class ItemAndLastUpdated
         this.containerType = containerType;
     }
 
+	/// Updates the full list of items in this container
     public void update(int updateTick, Item[] items)
     {
         this.lastUpdated = updateTick;
         this.items = items;
     }
+
+	/// Helper function to add a single item into the container.
+	///
+	/// Prefer using the update method if possible.
+	public void add(int updateTick, int itemID, int itemQuantity)
+	{
+		this.lastUpdated = updateTick;
+
+		var newItems = new ArrayList<>(List.of(this.items));
+		newItems.add(new Item(itemID, itemQuantity));
+
+		this.items = newItems.toArray(new Item[0]);
+	}
+
+	/// Helper function to remove items with a given item ID from the container.
+	///
+	/// Prefer using the update method if possible.
+	public void removeByItemID(int updateTick, int itemID)
+	{
+		this.lastUpdated = updateTick;
+
+		this.items = Arrays.stream(this.items).filter((item) -> item.getId() != itemID).toArray(Item[]::new);
+	}
 
     /**
      * Get the Items contained within the Tracked Container.

--- a/src/main/java/com/questhelper/managers/QuestContainerManager.java
+++ b/src/main/java/com/questhelper/managers/QuestContainerManager.java
@@ -56,8 +56,11 @@ public class QuestContainerManager
     @Getter
     private final static ItemAndLastUpdated runePouchData = new ItemAndLastUpdated(TrackedContainers.RUNE_POUCH);
 
+	@Getter
+	private final static ItemAndLastUpdated keyRingData = new ItemAndLastUpdated(TrackedContainers.KEY_RING);
+
     @Getter
-    private final static List<ItemAndLastUpdated> orderedListOfContainers = List.of(equippedData, inventoryData, bankData, runePouchData, potionData, groupStorageData);
+    private final static List<ItemAndLastUpdated> orderedListOfContainers = List.of(equippedData, inventoryData, bankData, runePouchData, potionData, groupStorageData, keyRingData);
 
     static Set<Integer> RUNE_POUCHES = Set.of(ItemID.BH_RUNE_POUCH, ItemID.BH_RUNE_POUCH_TROUVER, ItemID.DIVINE_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH_TROUVER);
     private static final int NUM_SLOTS = 6;

--- a/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
+++ b/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
@@ -26,11 +26,13 @@ package com.questhelper.playerquests.bikeshedder;
 
 import com.google.common.collect.ImmutableMap;
 import com.questhelper.collections.ItemCollections;
+import com.questhelper.collections.KeyringCollection;
 import com.questhelper.collections.TeleportCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
+import com.questhelper.requirements.item.KeyringRequirement;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.player.SpellbookRequirement;
 import com.questhelper.requirements.util.LogicType;
@@ -101,9 +103,16 @@ public class BikeShedder extends BasicQuestHelper
 	private ZoneRequirement onBoat3;
 	private ZoneRequirement onBoat4;
 
+	// Keyring
+	private ItemRequirement dustyKeyItem;
+	private KeyringRequirement dustyKeyKeyRing;
+	private DetailedQuestStep keyringStep;
+
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
 	{
+		setupRequirements();
+
 		var lumbridge = new Zone(new WorldPoint(3217, 3210, 0), new WorldPoint(3226, 3228, 0));
 		var outsideLumbridge = new ZoneRequirement(false, lumbridge);
 		moveToLumbridge.setHighlightZone(lumbridge);
@@ -170,6 +179,8 @@ public class BikeShedder extends BasicQuestHelper
 		steps.addStep(onBoat2, talkToKlarenceFromShip);
 		steps.addStep(onBoat3, useSalvagingHook);
 		steps.addStep(onBoat4, useObjectOffBoat);
+
+		steps.addStep(new ZoneRequirement(new WorldPoint(2655, 3286, 0)), keyringStep);
 
 		steps.addStep(byStaircaseInSunrisePalace, goDownstairsInSunrisePalace);
 		steps.addStep(outsideLumbridge, moveToLumbridge);
@@ -324,6 +335,10 @@ public class BikeShedder extends BasicQuestHelper
 		useObjectOffBoat = new ObjectStep(this, ObjectID.DRAGONSHIPGANGPLANK_ON, new WorldPoint(3047, 3205, 0), "Click Klarense's gangplank.");
 		useObjectOffBoat.setHighlightZone(new Zone(new WorldPoint(3044, 3202, 0), new WorldPoint(3050, 3205, 0)));
 		useObjectOffBoat.addHighlightZones(zones4);
+
+		dustyKeyItem = new ItemRequirement("Dusty key (ItemReq)", ItemID.DUSTY_KEY);
+		dustyKeyKeyRing = new KeyringRequirement("Dusty key (KeyRingReq)", KeyringCollection.DUSTY_KEY);
+		keyringStep = new DetailedQuestStep(this, "We need the dusty key", dustyKeyItem, dustyKeyKeyRing);
 	}
 
 	@Override
@@ -346,6 +361,7 @@ public class BikeShedder extends BasicQuestHelper
 		panels.add(new PanelDetails("Quest state", List.of(lookAtCooksAssistant), List.of(lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement)));
 		panels.add(new PanelDetails("Ensure staircase upstairs in Sunrise Palace is highlighted", List.of(goDownstairsInSunrisePalace), List.of()));
 		panels.add(new PanelDetails("Sailing", List.of(talkToNpcOnBoat, talkToKlarenceFromShip, useSalvagingHook, useObjectOffBoat), List.of()));
+		panels.add(new PanelDetails("Key ring", List.of(keyringStep), List.of(dustyKeyItem, dustyKeyKeyRing)));
 
 		return panels;
 	}

--- a/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
+++ b/src/main/java/com/questhelper/requirements/item/KeyringRequirement.java
@@ -24,117 +24,26 @@
  */
 package com.questhelper.requirements.item;
 
-import com.questhelper.QuestHelperConfig;
 import com.questhelper.collections.KeyringCollection;
-import com.questhelper.requirements.runelite.RuneliteRequirement;
 import lombok.Getter;
-import net.runelite.api.Client;
-import net.runelite.api.gameval.ItemID;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.util.Text;
 
-import java.awt.*;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-// TODO: Convert this to be a TrackedContainer instead?
+/// A requirement of a key that can be found on a key ring.
+///
+/// This requirement helps the bank tag service show the keyring if the key can be found in the player's key ring.
 public class KeyringRequirement extends ItemRequirement
 {
-	RuneliteRequirement runeliteRequirement;
-
 	@Getter
 	KeyringCollection keyringCollection;
 
-	ConfigManager configManager;
-
-	ItemRequirement keyring;
-
-	public KeyringRequirement(String name, ConfigManager configManager, KeyringCollection key)
+	public KeyringRequirement(String name, KeyringCollection key)
 	{
 		super(name, key.getItemID());
-		keyring = new ItemRequirement("Steel key ring", ItemID.FAVOUR_KEY_RING);
-		runeliteRequirement = new RuneliteRequirement(configManager, key.runeliteName(),
-			"true", key.toChatText());
 		this.keyringCollection = key;
-		this.configManager = configManager;
-	}
-
-	public KeyringRequirement(ConfigManager configManager, KeyringCollection key)
-	{
-		super(key.toChatText(), key.getItemID());
-		keyring = new ItemRequirement("Steel key ring", ItemID.FAVOUR_KEY_RING);
-		runeliteRequirement = new RuneliteRequirement(configManager, key.runeliteName(),
-			"true", key.toChatText());
-		this.keyringCollection = key;
-		this.configManager = configManager;
-	}
-
-	public String chatboxText()
-	{
-		return keyringCollection.toChatText();
-	}
-
-	public void setConfigValue(String value)
-	{
-		runeliteRequirement.setConfigValue(value);
-	}
-
-	@Override
-	public ItemRequirement copy()
-	{
-		KeyringRequirement newItem = new KeyringRequirement(getName(), configManager, keyringCollection);
-		newItem.addAlternates(alternateItems);
-		newItem.setDisplayItemId(getDisplayItemId());
-		newItem.setHighlightInInventory(highlightInInventory);
-		newItem.setDisplayMatchedItemName(isDisplayMatchedItemName());
-		newItem.setConditionToHide(getConditionToHide());
-		newItem.setShouldCheckBank(isShouldCheckBank());
-		newItem.setTooltip(getTooltip());
-		newItem.setUrlSuffix(getUrlSuffix());
-
-		return newItem;
-	}
-
-	@Override
-	public boolean check(Client client)
-	{;
-		if (hasKeyOnKeyRing() && keyring.check(client))
-		{
-			return true;
-		}
-
-		return super.check(client);
-	}
-
-	public boolean hasKeyOnKeyRing()
-	{
-		return runeliteRequirement.check();
-	}
-
-	@Override
-	public Color getColor(Client client, QuestHelperConfig config)
-	{
-		if (hasKeyOnKeyRing())
-		{
-			return keyring.getColor(client, config);
-		}
-
-		return this.check(client) ? config.passColour() : config.failColour();
-	}
-
-	protected String getTooltipFromEnumSet(Set<TrackedContainers> containers)
-	{
-		String basicTooltip = super.getTooltipFromEnumSet(containers);
-		if (hasKeyOnKeyRing())
-		{
-			return basicTooltip + " on your key ring.";
-		}
-		return basicTooltip;
 	}
 
 	@Override
 	protected KeyringRequirement copyOfClass()
 	{
-		return new KeyringRequirement(getName(), configManager, keyringCollection);
+		return new KeyringRequirement(getName(), keyringCollection);
 	}
 }

--- a/src/main/java/com/questhelper/requirements/item/TrackedContainers.java
+++ b/src/main/java/com/questhelper/requirements/item/TrackedContainers.java
@@ -32,5 +32,6 @@ public enum TrackedContainers
     POTION_STORAGE,
     GROUP_STORAGE,
     RUNE_POUCH,
+	KEY_RING,
     UNDEFINED
 }

--- a/src/main/java/com/questhelper/statemanagement/PlayerStateManager.java
+++ b/src/main/java/com/questhelper/statemanagement/PlayerStateManager.java
@@ -26,12 +26,13 @@ package com.questhelper.statemanagement;
 
 import com.questhelper.collections.KeyringCollection;
 import com.questhelper.domain.AccountType;
-import com.questhelper.requirements.item.KeyringRequirement;
+import com.questhelper.managers.QuestContainerManager;
 import com.questhelper.runeliteobjects.extendedruneliteobjects.QuestCompletedWidget;
 import lombok.Getter;
 import lombok.NonNull;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Item;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
@@ -39,16 +40,19 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneScapeProfileType;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.List;
+import java.util.ArrayList;
 
 @Singleton
 public class PlayerStateManager
 {
+	private final KeyringCollection[] keyringKeys = KeyringCollection.values();
+
 	@Inject
 	Client client;
 
@@ -64,9 +68,10 @@ public class PlayerStateManager
 	@Inject
 	BarbarianTrainingStateTracker barbarianTrainingStateTracker;
 
-	List<KeyringRequirement> keyringKeys;
-
 	WorldPoint lastPlayerPos = null;
+
+	private boolean loggedInStateKnown = false;
+	private RuneScapeProfileType worldType;
 
 	/**
 	 * The type of the logged in account (e.g. ironman, hardcore ironman)
@@ -77,7 +82,6 @@ public class PlayerStateManager
 
 	public void startUp()
 	{
-		keyringKeys = KeyringCollection.allKeyRequirements(configManager);
 		AchievementDiaryStepManager.setup(configManager);
 		barbarianTrainingStateTracker.startUp(configManager, eventBus);
 	}
@@ -90,29 +94,34 @@ public class PlayerStateManager
 	@Subscribe
 	public void onChatMessage(ChatMessage chatMessage)
 	{
-		if (keyringKeys == null || chatMessage.getType() != ChatMessageType.GAMEMESSAGE) return;
+		if (chatMessage.getType() != ChatMessageType.GAMEMESSAGE) return;
 		if (chatMessage.getMessage().contains("to your key ring."))
 		{
-			for (KeyringRequirement keyringKey : keyringKeys)
+			for (var keyringKey : keyringKeys)
 			{
 				if (chatMessage.getMessage().contains("You add the " + keyringKey.chatboxText()))
 				{
-					keyringKey.setConfigValue("true");
+					keyringKey.setHasKeyOnKeyRing(configManager, true);
+
+					QuestContainerManager.getKeyRingData().add(client.getTickCount(), keyringKey.getItemID(), 1);
+					break;
 				}
 			}
 		}
-		if (chatMessage.getMessage().contains("from your key ring."))
+		else if (chatMessage.getMessage().contains("from your key ring."))
 		{
-			for (KeyringRequirement keyringKey : keyringKeys)
+			for (var keyringKey : keyringKeys)
 			{
 				if (chatMessage.getMessage().contains("You remove the " + keyringKey.chatboxText()))
 				{
-					keyringKey.setConfigValue("false");
+					keyringKey.setHasKeyOnKeyRing(configManager, false);
+
+					QuestContainerManager.getKeyRingData().removeByItemID(client.getTickCount(), keyringKey.getItemID());
+					break;
 				}
 			}
 		}
-
-		if (chatMessage.getMessage().contains("Achievement Diary Stage Task - "))
+		else if (chatMessage.getMessage().contains("Achievement Diary Stage Task - "))
 		{
 			AchievementDiaryStepManager.check(client);
 		}
@@ -158,5 +167,55 @@ public class PlayerStateManager
 			return null;
 		}
 		return client.getLocalPlayer().getName();
+	}
+
+	public void loadInitialStateFromConfig()
+	{
+		if (loggedInStateKnown)
+		{
+			return;
+		}
+
+		var localPlayer = client.getLocalPlayer();
+		if (localPlayer != null && localPlayer.getName() != null)
+		{
+			loggedInStateKnown = true;
+			loadState();
+		}
+	}
+
+	private void loadState()
+	{
+		// Only re-load from config if loading from a new profile
+		if (!RuneScapeProfileType.getCurrent(client).equals(worldType))
+		{
+			// Load key ring state from config
+			loadKeyRingFromConfig();
+		}
+	}
+
+	private void loadKeyRingFromConfig()
+	{
+		var keys = new ArrayList<Item>();
+
+		for (var keyringKey : keyringKeys)
+		{
+			if (keyringKey.hasKeyOnKeyRing(configManager))
+			{
+				keys.add(new Item(keyringKey.getItemID(), 1));
+			}
+		}
+
+		QuestContainerManager.getKeyRingData().update(client.getTickCount(), keys.toArray(new Item[0]));
+	}
+
+	public void emptyState()
+	{
+		worldType = null;
+	}
+
+	public void setUnknownInitialState()
+	{
+		loggedInStateKnown = false;
 	}
 }


### PR DESCRIPTION
I have kept `KeyringRequirement` because it's still handy for the bank tab service to automatically add the Steel key ring to the requirement if the key is on there.

The `loggedInStateKnown` logic was mostly borrowed from the bank state

Unrelatedly, I added a command to print the contents of a quest helper tracked container. Only supports keyring at the moment.
Usage: `::qh container keyring`