### PR TITLE
Add alternate Surok NPC ID to WhatLiesBelow

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/whatliesbelow/WhatLiesBelow.java
+++ b/src/main/java/com/questhelper/helpers/quests/whatliesbelow/WhatLiesBelow.java
@@ -185,6 +185,7 @@ public class WhatLiesBelow extends BasicQuestHelper
 
 		talkToSurok = new NpcStep(this, NpcID.SUROK_SUROK, new WorldPoint(3211, 3493, 0), "Talk to Surok Magis in the Varrock Library.", letterToSurok);
 		talkToSurokNoLetter = new NpcStep(this, NpcID.WGS_SUROK_TRANSITION, new WorldPoint(3211, 3493, 0), "Talk to Surok Magis in the Varrock Library.");
+		((NpcStep) talkToSurokNoLetter).addAlternateNpcs(NpcID.SUROK_SUROK_TYPE1);
 		talkToSurokNoLetter.addDialogSteps("Go on, then!", "Go on then!");
 
 		talkToSurok.addSubSteps(talkToSurokNoLetter);


### PR DESCRIPTION
Added alternate Surok NPC ID to WhatLiesBelow quest, can see screenshot showing the alternate ID added.

### Testing
Tested in-game, after alternate ID added, Surok highlights properly. 

<img width="959" height="611" alt="Screenshot 2026-02-23 at 7 46 53 PM" src="https://github.com/user-attachments/assets/e54f0f3a-11a7-474f-b34b-d01d6b4111f0" />

