### PR TITLE
polish: A Porcine of Interest

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
@@ -36,62 +36,60 @@ import com.questhelper.rewards.ExperienceReward;
 import com.questhelper.rewards.ItemReward;
 import com.questhelper.rewards.QuestPointReward;
 import com.questhelper.rewards.UnlockReward;
-import com.questhelper.steps.*;
+import com.questhelper.steps.ConditionalStep;
+import com.questhelper.steps.NpcStep;
+import com.questhelper.steps.ObjectStep;
+import com.questhelper.steps.QuestStep;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.ObjectID;
 
-import java.util.*;
-
 public class APorcineOfInterest extends BasicQuestHelper
 {
-	//Items Required
-	ItemRequirement rope, slashItem, reinforcedGoggles, combatGear, hoof;
+	// Required items
+	ItemRequirement rope;
+	ItemRequirement slashItem;
+	ItemRequirement combatGear;
 
-	//Items Recommended
-	ItemRequirement draynorTeleport, faladorFarmTeleport;
+	// Recommended items
+	ItemRequirement draynorTeleport;
+	ItemRequirement faladorFarmTeleport;
 
-	Requirement inCave;
+	// Mid-quest item requirements
+	ItemRequirement reinforcedGoggles;
+	ItemRequirement hoof;
 
-	DetailedQuestStep readNotice, talkToSarah, useRopeOnHole, enterHole, investigateSkeleton, talkToSpria, enterHoleAgain, killSourhog,
-		enterHoleForFoot, cutOffFoot, returnToSarah, returnToSpria;
-
-	//Zones
+	// Zones
 	Zone cave;
 
+	// Miscellaneous requirements
+	Requirement inCave;
+
+	// Steps
+	ObjectStep readNotice;
+	NpcStep talkToSarah;
+	ObjectStep useRopeOnHole;
+	ObjectStep enterHole;
+	ObjectStep investigateSkeleton;
+	NpcStep talkToSpria;
+	ObjectStep enterHoleAgain;
+	NpcStep killSourhog;
+	ObjectStep enterHoleForFoot;
+	ObjectStep cutOffFoot;
+	NpcStep returnToSarah;
+	NpcStep returnToSpria;
+
+
 	@Override
-	public Map<Integer, QuestStep> loadSteps()
+	protected void setupZones()
 	{
-		initializeRequirements();
-		setupConditions();
-		setupSteps();
-		Map<Integer, QuestStep> steps = new HashMap<>();
-
-		steps.put(0, readNotice);
-		steps.put(5, talkToSarah);
-		steps.put(10, useRopeOnHole);
-
-		ConditionalStep investigateCave = new ConditionalStep(this, enterHole);
-		investigateCave.addStep(inCave, investigateSkeleton);
-
-		steps.put(15, investigateCave);
-
-		steps.put(20, talkToSpria);
-
-		ConditionalStep goKillSourhog = new ConditionalStep(this, enterHoleAgain);
-		goKillSourhog.addStep(inCave, killSourhog);
-
-		steps.put(25, goKillSourhog);
-
-		ConditionalStep getFootSteps = new ConditionalStep(this, enterHoleForFoot);
-		getFootSteps.addStep(hoof, returnToSarah);
-		getFootSteps.addStep(inCave, cutOffFoot);
-
-		steps.put(30, getFootSteps);
-		steps.put(35, returnToSpria);
-		return steps;
+		cave = new Zone(new WorldPoint(3152, 9669, 0), new WorldPoint(3181, 9720, 0));
 	}
 
 	@Override
@@ -116,16 +114,7 @@ public class APorcineOfInterest extends BasicQuestHelper
 		draynorTeleport = new ItemRequirement("Teleport to north Draynor", ItemID.TELETAB_DRAYNOR);
 		draynorTeleport.addAlternates(ItemCollections.AMULET_OF_GLORIES);
 		faladorFarmTeleport = new ItemRequirement("Teleport to Falador Farm", ItemCollections.EXPLORERS_RINGS);
-	}
 
-	@Override
-	protected void setupZones()
-	{
-		cave = new Zone(new WorldPoint(3152, 9669, 0), new WorldPoint(3181, 9720, 0));
-	}
-
-	public void setupConditions()
-	{
 		inCave = new ZoneRequirement(cave);
 	}
 
@@ -153,7 +142,7 @@ public class APorcineOfInterest extends BasicQuestHelper
 
 		enterHoleForFoot = new ObjectStep(this, ObjectID.PORCINE_HOLE, new WorldPoint(3151, 3348, 0), "Climb down into the Strange Hole east of Draynor Manor.", slashItem);
 		cutOffFoot = new ObjectStep(this, ObjectID.PORCINE_DEAD_SOURHOG, "Cut off Sourhog's foot.", slashItem);
-		((ObjectStep) cutOffFoot).addAlternateObjects(ObjectID.PORCINE_DEAD_SOURHOG_9);
+		cutOffFoot.addAlternateObjects(ObjectID.PORCINE_DEAD_SOURHOG_9);
 		cutOffFoot.addSubSteps(enterHoleForFoot);
 
 		returnToSarah = new NpcStep(this, NpcID.FARMING_SHOPKEEPER_1, new WorldPoint(3033, 3293, 0), "Return to Sarah in the South Falador Farm.", hoof);
@@ -163,21 +152,64 @@ public class APorcineOfInterest extends BasicQuestHelper
 	}
 
 	@Override
+	public Map<Integer, QuestStep> loadSteps()
+	{
+		initializeRequirements();
+		setupSteps();
+
+		var steps = new HashMap<Integer, QuestStep>();
+
+		steps.put(0, readNotice);
+		steps.put(5, talkToSarah);
+		steps.put(10, useRopeOnHole);
+
+		var investigateCave = new ConditionalStep(this, enterHole);
+		investigateCave.addStep(inCave, investigateSkeleton);
+
+		steps.put(15, investigateCave);
+
+		steps.put(20, talkToSpria);
+
+		var goKillSourhog = new ConditionalStep(this, enterHoleAgain);
+		goKillSourhog.addStep(inCave, killSourhog);
+
+		steps.put(25, goKillSourhog);
+
+		var getFootSteps = new ConditionalStep(this, enterHoleForFoot);
+		getFootSteps.addStep(hoof, returnToSarah);
+		getFootSteps.addStep(inCave, cutOffFoot);
+
+		steps.put(30, getFootSteps);
+		steps.put(35, returnToSpria);
+
+		return steps;
+	}
+
+	@Override
 	public List<ItemRequirement> getItemRequirements()
 	{
-		return Arrays.asList(rope, slashItem, combatGear);
+		return List.of(
+			rope,
+			slashItem,
+			combatGear
+		);
 	}
 
 	@Override
 	public List<ItemRequirement> getItemRecommended()
 	{
-		return Arrays.asList(draynorTeleport, faladorFarmTeleport);
+		return List.of(
+			draynorTeleport,
+			faladorFarmTeleport
+		);
 	}
 
 	@Override
 	public List<String> getCombatRequirements()
 	{
-		return Collections.singletonList("Sourhog (level 37)");
+		return List.of(
+			"Sourhog (level 37)"
+		);
 	}
 
 	@Override
@@ -189,28 +221,53 @@ public class APorcineOfInterest extends BasicQuestHelper
 	@Override
 	public List<ExperienceReward> getExperienceRewards()
 	{
-		return Collections.singletonList(new ExperienceReward(Skill.SLAYER, 1000));
+		return List.of(
+			new ExperienceReward(Skill.SLAYER, 1000)
+		);
 	}
 
 	@Override
 	public List<ItemReward> getItemRewards()
 	{
-		return Collections.singletonList(new ItemReward("Coins", ItemID.COINS, 5000));
+		return List.of(
+			new ItemReward("Coins", ItemID.COINS, 5000)
+		);
 	}
 
 	@Override
 	public List<UnlockReward> getUnlockRewards()
 	{
-		return Arrays.asList(new UnlockReward("30 Slayer Points"), new UnlockReward("Access to Sourhog Cave"), new UnlockReward("Sourhogs can be assigned as a slayer task by Spria"));
+		return List.of(
+			new UnlockReward("30 Slayer Points"),
+			new UnlockReward("Access to Sourhog Cave"),
+			new UnlockReward("Sourhogs can be assigned as a slayer task by Spria")
+		);
 	}
 
 	@Override
 	public List<PanelDetails> getPanels()
 	{
-		List<PanelDetails> allSteps = new ArrayList<>();
-		allSteps.add(new PanelDetails("Starting off", Arrays.asList(readNotice, talkToSarah, useRopeOnHole,
-			enterHole, investigateSkeleton, talkToSpria, enterHoleAgain, killSourhog, cutOffFoot, returnToSarah,
-			returnToSpria), rope, slashItem, combatGear));
-		return allSteps;
+		var sections = new ArrayList<PanelDetails>();
+
+		// TODO: Rename section since it's just a single section
+		sections.add(new PanelDetails("Starting off", List.of(
+			readNotice,
+			talkToSarah,
+			useRopeOnHole,
+			enterHole,
+			investigateSkeleton,
+			talkToSpria,
+			enterHoleAgain,
+			killSourhog,
+			cutOffFoot,
+			returnToSarah,
+			returnToSpria
+		), List.of(
+			rope,
+			slashItem,
+			combatGear
+		)));
+
+		return sections;
 	}
 }

--- a/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
@@ -100,6 +100,10 @@ public class APorcineOfInterest extends BasicQuestHelper
 
 		slashItem = new ItemRequirement("A knife or slash weapon", ItemID.KNIFE).isNotConsumed();
 		slashItem.setTooltip("Except abyssal whip, abyssal tentacle, noxious halberd, or dragon claws.");
+		// This is not intended to be a full list, but rather just a reasonable list of slash weapons a user might bring.
+		// This does not fit super well into an item collection since it's not reusable.
+		slashItem.addAlternates(ItemID.DRAGON_SCIMITAR, ItemID.RUNE_SCIMITAR, ItemID.ADAMANT_SCIMITAR, ItemID.MITHRIL_SCIMITAR, ItemID.STEEL_SCIMITAR, ItemID.IRON_SCIMITAR, ItemID.BRONZE_SCIMITAR);
+		slashItem.addAlternates(ItemID.DRAGON_LONGSWORD, ItemID.RUNE_LONGSWORD, ItemID.ADAMANT_LONGSWORD, ItemID.MITHRIL_LONGSWORD, ItemID.STEEL_LONGSWORD, ItemID.IRON_LONGSWORD, ItemID.BRONZE_LONGSWORD);
 
 		reinforcedGoggles = new ItemRequirement("Reinforced goggles", ItemID.SLAYER_REINFORCED_GOGGLES, 1, true).isNotConsumed();
 		reinforcedGoggles.setTooltip("You can get another pair from Spria");

--- a/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
@@ -108,7 +108,6 @@ public class APorcineOfInterest extends BasicQuestHelper
 		combatGear.setDisplayItemId(BankSlotIcons.getCombatGear());
 
 		hoof = new ItemRequirement("Sourhog foot", ItemID.PORCINE_SOURHOG_TROPHY);
-		hoof.setTooltip("You can get another from Sourhog's corpse in his cave");
 
 		// Recommended
 		draynorTeleport = new ItemRequirement("Teleport to north Draynor", ItemID.TELETAB_DRAYNOR);
@@ -176,7 +175,7 @@ public class APorcineOfInterest extends BasicQuestHelper
 		steps.put(25, goKillSourhog);
 
 		var getFootSteps = new ConditionalStep(this, enterHoleForFoot);
-		getFootSteps.addStep(hoof, returnToSarah);
+		getFootSteps.addStep(hoof.alsoCheckBank(), returnToSarah);
 		getFootSteps.addStep(inCave, cutOffFoot);
 
 		steps.put(30, getFootSteps);

--- a/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
+++ b/src/main/java/com/questhelper/helpers/quests/aporcineofinterest/APorcineOfInterest.java
@@ -249,8 +249,7 @@ public class APorcineOfInterest extends BasicQuestHelper
 	{
 		var sections = new ArrayList<PanelDetails>();
 
-		// TODO: Rename section since it's just a single section
-		sections.add(new PanelDetails("Starting off", List.of(
+		sections.add(new PanelDetails("Helping Sarah", List.of(
 			readNotice,
 			talkToSarah,
 			useRopeOnHole,

--- a/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
+++ b/src/test/java/com/questhelper/questhelpers/QuestHelperTest.java
@@ -317,6 +317,7 @@ public class QuestHelperTest extends MockedTest
 			QuestHelperQuest.DWARF_CANNON,
 			QuestHelperQuest.MERLINS_CRYSTAL,
 			QuestHelperQuest.X_MARKS_THE_SPOT,
+			QuestHelperQuest.A_PORCINE_OF_INTEREST,
 			QuestHelperQuest.SHADOW_OF_THE_STORM,
 			QuestHelperQuest.PANDEMONIUM,
 			QuestHelperQuest.OBSERVATORY_QUEST,


### PR DESCRIPTION
The standard modernizing, and in addition I have:
 - Renamed the sidebar section to "Helping Sarah" since we are only using one sidebar section. I don't think splitting this quest up into multiple sections is particularly helpful, so I just renamed it.
 - Check for the Sourhog Foot in the bank in case the player has banked it. With this change, I removed the tooltip since the tooltip should only ever be visible if the player has banked the foot. The steps to guide the player to re-retrieve the foot were already in place.
 - Added some likely slash weapons as alternatives to the knife. The Knife is still what we recommend in the bank, but all scimitars and longswords now also make the requirement green. Fixes #1393
