### PR TITLE
polish(Desert Treasure II): Clarify Whisperer directions

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/WhispererSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/WhispererSteps.java
@@ -1371,7 +1371,7 @@ public class WhispererSteps extends ConditionalStep
 		fightWhispererSidebar.addText("Corrupted seeds: Activate the blackstone fragment in your inventory. Avoid the dark green seeds, and step on the light green ones.");
 		fightWhispererSidebar.addText("Screech: Pillars appear, which you must hide behind to avoid damage.");
 		fightWhispererSidebar.addText("After each special attack, the Whisperer fire out a binding spell if you are within 10 tiles of her, dealing Melee damage.");
-		fightWhispererSidebar.addText("When she hits 0 health, she will heal back to 100, and start attacking rapidly with random ranged and magic attacks. Finish her off.");
+		fightWhispererSidebar.addText("When she hits 0 health, she will heal back to 100, and start attacking rapidly, starting with ranged, and alternating every two attacks until the fight ends. Finish her off.");
 		fightWhispererSidebar.addSubSteps(enterTheCathedral, enterRuinsOfCamdozaalFight, descendDownRopeFight);
 
 		searchEntrails = new ObjectStep(getQuestHelper(), ObjectID.WHISPERER_MEDALLION_LOC, new WorldPoint(2656, 6370, 0),


### PR DESCRIPTION
Fixes #2562 

Reference the wiki, as well as some videos of the fight, and it consistently starts enrage phase with ranged, and alternates every two attacks. Updated the guidance in the sidebar to reflect this.