### PR TITLE
Update empty slot item requirements for Olaf's Task in TFT

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/thefremenniktrials/TheFremennikTrials.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefremenniktrials/TheFremennikTrials.java
@@ -302,7 +302,7 @@ public class TheFremennikTrials extends BasicQuestHelper
 		petRock = new ItemRequirement("Pet rock", ItemID.VT_USELESS_ROCK).isNotConsumed();
 		petRock.setTooltip("You can get another from Askeladden");
 
-		emptySlot4 = new ItemRequirement("4 empty inventory slots", -1, 4);
+		emptySlot4 = new ItemRequirement("Empty inventory slots for vegetables and a pet rock", -1, 4);
 
 		goldenWool = new ItemRequirement("Golden wool", ItemID.VIKING_GOLDEN_WOOL);
 		goldenFleece = new ItemRequirement("Golden fleece", ItemID.VIKING_GOLDEN_FLEECE);


### PR DESCRIPTION
The item requirements confusingly appear to indicate that you need 4x4 = 16 empty slots, not the actual 4 you need. This is now updated to properly show the 4 you need and indicates they are for the vegetables and pet rock acquired in the quest.

Resolves #2625 