### PR TITLE
more carefully attach listener

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MA2Locator.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MA2Locator.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.helpers.miniquests.themagearenaii;
 
+import com.questhelper.QuestHelperPlugin;
 import com.questhelper.bank.banktab.BankSlotIcons;
 import com.questhelper.collections.ItemCollections;
 import com.questhelper.panel.PanelDetails;
@@ -38,7 +39,9 @@ import com.questhelper.steps.QuestStep;
 import net.runelite.api.QuestState;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -154,5 +157,18 @@ public class MA2Locator extends ComplexStateQuestHelper
 		allSteps.add(new PanelDetails("Upgrading the God Cape", Collections.singletonList(locateFollowers),
 			knife, saradominStaff, guthixStaff, zamorakStaff, runesForCasts));
 		return allSteps;
+	}
+
+	@Override
+	public void renderDebugOverlay(Graphics graphics, QuestHelperPlugin plugin, PanelComponent panelComponent)
+	{
+		super.renderDebugOverlay(graphics, plugin, panelComponent);
+
+		var currentStep = this.getCurrentStep();
+		if (currentStep instanceof MageArenaBossStep)
+		{
+			var bossStep = (MageArenaBossStep) currentStep;
+			bossStep.renderDebugOverlay(graphics, plugin, panelComponent);
+		}
 	}
 }

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MageArenaBossStep.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MageArenaBossStep.java
@@ -50,6 +50,7 @@ import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -425,6 +426,33 @@ public class MageArenaBossStep extends DetailedQuestStep
 	private BufferedImage getSymbolLocation()
 	{
 		return itemManager.getImage(ItemID.MA2_SYMBOL);
+	}
+
+	public void renderDebugOverlay(Graphics graphics, QuestHelperPlugin plugin, PanelComponent panelComponent)
+	{
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("God name")
+			.leftColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.right(this.bossName)
+			.rightColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.build()
+		);
+
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("God to find")
+			.leftColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.right(this.godToFind.name)
+			.rightColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.build()
+		);
+
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Pending")
+			.leftColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.right(clickedActivateOnSymbol ? "y" : "n")
+			.rightColor(ColorScheme.BRAND_ORANGE_TRANSPARENT)
+			.build()
+		);
 	}
 
 	enum God


### PR DESCRIPTION
This attempts to only add the listener to the CHATMENU widget if the user just clicked "Activate" on the MA2 Enchanted symbol

Additionally / unrelatedly, this adds the god we're looking to find to the debug overlay

<img width="147" height="125" alt="image" src="https://github.com/user-attachments/assets/b5cb0dee-cf2b-4cf5-b086-fabaebf67e2a" />

