### PR TITLE
Mage Arena 2 Demonic Ruins Fix

### DIFF
--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MageArenaSpawnLocation.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MageArenaSpawnLocation.java
@@ -48,7 +48,7 @@ public enum MageArenaSpawnLocation
 	NORTH_EAST_LAVA_DRAGON_4(new WorldPoint(3247, 3862, 0), "North east of the Lava Dragon Isle."),
 	WEST_LAVA_DRAGON(new WorldPoint(3146, 3895, 0), "West of the Lava Dragon Isle."),
 	WEST_LAVA_DRAGON_2(new WorldPoint(3163, 3833, 0), "West of the Lava Dragon Isle."),
-	WEST_DEMONIC_RUINS(new WorldPoint(3314, 3876, 0), "West of the Demonic Ruins."),
+	EAST_DEMONIC_RUINS(new WorldPoint(3314, 3876, 0), "East of the Demonic Ruins."),
 	EAST_LAVA_DRAGON_ISLE(new WorldPoint(3246, 3834, 0), "East of the Lava Dragon Isle."),
 	EAST_LAVA_DRAGON_ISLE_2(new WorldPoint(3279, 3823, 0), "East of the Lava Dragon Isle."),
 	SOUTH_EAST_LAVA_DRAGON_ISLE(new WorldPoint(3266, 3814, 0), "South east of the Lava Dragon Isle."),


### PR DESCRIPTION
Updated the enumerator for the Mage Arena 2 quest, Demonic Ruins location. I was going to open an issue but I found one that already exists https://github.com/Zoinkwiz/quest-helper/issues/1905 and it's an easy fix.