### PR TITLE
fix: RuneLite 1.12.23 release

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendMedium.java
@@ -256,7 +256,7 @@ public class KourendMedium extends ComplexStateQuestHelper
 	public void setupSteps()
 	{
 		// Travel to Fairy Ring
-		travelFairyRing = new ObjectStep(this, ObjectID.POH_FAIRY_RING_LAST_AIP, new WorldPoint(2658, 3230, 0),
+		travelFairyRing = new ObjectStep(this, ObjectID.FAIRYRING_MINORHUB, new WorldPoint(2658, 3230, 0),
 			"Travel from any fairy ring to south of Mount Karuulm (CIR).", dramenStaff.highlighted());
 
 		// Kill a lizardman


### PR DESCRIPTION
fairy ring object ID changed with jagex update

<img width="1360" height="851" alt="image" src="https://github.com/user-attachments/assets/8dc862a0-6513-43e9-8394-2fd659039c1b" />

Being released as https://github.com/Zoinkwiz/quest-helper/tree/release/4.13.0.2