### PR TITLE
Small content fixes

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/gardenoftranquility/GardenOfTranquillity.java
+++ b/src/main/java/com/questhelper/helpers/quests/gardenoftranquility/GardenOfTranquillity.java
@@ -457,7 +457,7 @@ public class GardenOfTranquillity extends BasicQuestHelper
 			wateringCan.highlighted());
 
 		talkToAlthric = new NpcStep(this, NpcID.BROTHER_ALTHRIC, new WorldPoint(3052, 3502, 0),
-			"Talk to Brother Altheric in the Edgeville Monastery.", ringOfCharosA.equipped());
+			"Talk to Brother Althric in the Edgeville Monastery.", ringOfCharosA.equipped());
 		talkToAlthric.addDialogSteps("[Charm] These are the most beautiful rosebushes I've ever seen.");
 		useCharosOnWell = new ObjectStep(this, ObjectID.WELL, new WorldPoint(3085, 3503, 0),
 			"Use the Ring of charos(a) on the well in Edgeville.", ringOfCharosA.highlighted());

--- a/src/main/java/com/questhelper/helpers/quests/theidesofmilk/TheIdesOfMilk.java
+++ b/src/main/java/com/questhelper/helpers/quests/theidesofmilk/TheIdesOfMilk.java
@@ -124,7 +124,7 @@ public class TheIdesOfMilk extends BasicQuestHelper
 	{
 		talkToCassius = new NpcStep(this, NpcID.COWBOSS_FARMER,
 			new WorldPoint(3171, 3277, 0),
-			"Speak to Cassius by the lake north-west of Lumbridge to start the quest.", true);
+			"Speak to Cassius by the pond north-west of Lumbridge to start the quest.", true);
 		talkToCassius.addDialogStep("Yes.");
 
 		talkToGillie = new NpcStep(this, NpcID.GILLIE_THE_MILKMAID,

--- a/src/main/java/com/questhelper/helpers/quests/watchtower/Watchtower.java
+++ b/src/main/java/com/questhelper/helpers/quests/watchtower/Watchtower.java
@@ -471,7 +471,7 @@ public class Watchtower extends BasicQuestHelper
 
 		stealRockCake = new ObjectStep(this, ObjectID.ROCKCOUNTER_WITHCAKES, new WorldPoint(2514, 3036, 0), "Steal a rock cake from Gu'Tanoth's market.");
 
-		talkToGuardBattlement = new NpcStep(this, NpcID.OGRE_GUARD3, new WorldPoint(2503, 3012, 0), "Talk to an Ogre Guard next to the battelement.");
+		talkToGuardBattlement = new NpcStep(this, NpcID.OGRE_GUARD3, new WorldPoint(2503, 3012, 0), "Talk to an Ogre Guard next to the battlement.");
 		talkToGuardBattlement.addDialogStep("But I am a friend to ogres...");
 		talkToGuardWithRockCake = new ObjectStep(this, NpcID.OGRE_GUARD3, new WorldPoint(2507, 3012, 0),
 			"Attempt to cross the battlement again with a rock cake.", rockCake);


### PR DESCRIPTION
Addresses the following issues:

https://github.com/Zoinkwiz/quest-helper/issues/2657 - Changes name of body of water from lake -> pond ([seems accurate](https://mapgenie.io/old-school-runescape/maps/runescape-surface?x=-0.48238222486330073&y=0.6940610809263745&zoom=14))
https://github.com/Zoinkwiz/quest-helper/issues/2662 - Changes copy from Altheric -> Althric ([wiki](https://oldschool.runescape.wiki/w/Brother_Althric))

Then fixes a typo in Watchtower that doesn't have an issue associated with it (that which got me to open this PR :wink:)

