### PR TITLE
fix: shortest-path localplayer null

### DIFF
--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -881,7 +881,14 @@ public class DetailedQuestStep extends QuestStep
 		{
 			return;
 		}
-		var playerWp = client.getLocalPlayer().getWorldLocation();
+
+		var localPlayer = client.getLocalPlayer();
+		if (localPlayer == null)
+		{
+			return;
+		}
+
+		var playerWp = localPlayer.getWorldLocation();
 		if (playerWp == null)
 		{
 			return;


### PR DESCRIPTION
When the user already has a quest started _and_ the shortest path integration activate and then performs a world hop, the step will attempt to start before `localPlayer` is initialized.

This ensures code execution continues, but that already-started step won't re-attempt to set the shortest path. There might be better solutions we can do to ensure local player is always initialized when startUp is called, but that would require a lot more testing than I've performed here.
