### PR TITLE
Add configurable font size for the sidebar panel

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -241,9 +241,9 @@ public interface QuestHelperConfig extends Config
 	enum FontSize
 	{
 		DEFAULT(0),
-		LARGE(2),
-		LARGER(4),
-		LARGEST(8);
+		LARGE(4),
+		LARGER(6),
+		LARGEST(10);
 
 		private final int offset;
 
@@ -373,7 +373,7 @@ public interface QuestHelperConfig extends Config
 	@ConfigItem(
 		keyName = "fontSize",
 		name = "Font size",
-		description = "Change the font size used in the sidebar panel and overlay",
+		description = "Change the font size used in the sidebar panel",
 		section = sidebarDetailsSection
 	)
 	default FontSize fontSize()

--- a/src/main/java/com/questhelper/QuestHelperConfig.java
+++ b/src/main/java/com/questhelper/QuestHelperConfig.java
@@ -27,6 +27,7 @@ package com.questhelper;
 import com.questhelper.panel.questorders.QuestOrders;
 import com.questhelper.questhelpers.QuestDetails;
 import com.questhelper.questhelpers.QuestHelper;
+import com.questhelper.util.Fonts;
 import lombok.Getter;
 import net.runelite.client.config.*;
 import net.runelite.client.util.Text;
@@ -237,6 +238,26 @@ public interface QuestHelperConfig extends Config
 		FILLED_OUTLINE
 	}
 
+	enum FontSize
+	{
+		DEFAULT(0),
+		LARGE(2),
+		LARGER(4),
+		LARGEST(8);
+
+		private final int offset;
+
+		FontSize(int offset)
+		{
+			this.offset = offset;
+		}
+
+		public int getSize()
+		{
+			return Math.round(Fonts.getDefaultSize()) + offset;
+		}
+	}
+
 	@ConfigItem(
 		keyName = "autostartQuests",
 		name = "Auto start helper",
@@ -348,6 +369,17 @@ public interface QuestHelperConfig extends Config
 		description = "Determines sidebar rendering"
 	)
 	String sidebarDetailsSection = "sidebarDetailsSection";
+
+	@ConfigItem(
+		keyName = "fontSize",
+		name = "Font size",
+		description = "Change the font size used in the sidebar panel and overlay",
+		section = sidebarDetailsSection
+	)
+	default FontSize fontSize()
+	{
+		return FontSize.DEFAULT;
+	}
 
 	@ConfigItem(
 		keyName = "showFullRequirements",

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -43,6 +43,7 @@ import com.questhelper.runeliteobjects.RuneliteConfigSetter;
 import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectManager;
 import com.questhelper.statemanagement.PlayerStateManager;
 import com.questhelper.tools.Icon;
+import com.questhelper.util.Fonts;
 import com.questhelper.util.worldmap.WorldMapAreaManager;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -189,6 +190,7 @@ public class QuestHelperPlugin extends Plugin
 	@Override
 	protected void startUp() throws IOException
 	{
+		Fonts.setSize(config.fontSize().getSize());
 		questBankManager.startUp(injector, eventBus);
 		QuestContainerManager.getBankData().setSpecialMethodToObtainItems(() -> questBankManager.getBankItems().toArray(new Item[0]));
 		QuestContainerManager.getGroupStorageData().setSpecialMethodToObtainItems(() -> questBankManager.getGroupBankItems().toArray(new Item[0]));
@@ -390,6 +392,15 @@ public class QuestHelperPlugin extends Plugin
 		{
 			boolean isLeague = client.getWorldType().contains(WorldType.SEASONAL);
 			SwingUtilities.invokeLater(() -> panel.updateRegionFilterVisibility(isLeague));
+		}
+
+		if ("fontSize".equals(event.getKey()))
+		{
+			Fonts.setSize(config.fontSize().getSize());
+			if (questManager.getSelectedQuest() != null)
+			{
+				questManager.startUpQuest(questManager.getSelectedQuest(), false);
+			}
 		}
 
 		if (configEvents.contains(event.getKey()) || event.getKey().contains("skillfilter"))

--- a/src/main/java/com/questhelper/overlays/QuestHelperOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperOverlay.java
@@ -29,6 +29,7 @@ package com.questhelper.overlays;
 
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -54,6 +55,10 @@ public class QuestHelperOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		int fontSize = plugin.getConfig().fontSize().getSize();
+		Font overlayFont = FontManager.getRunescapeFont().deriveFont(Font.PLAIN, fontSize);
+		graphics.setFont(overlayFont);
+
 		if (!plugin.getConfig().showOverlay())
 		{
 			return super.render(graphics);

--- a/src/main/java/com/questhelper/overlays/QuestHelperOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperOverlay.java
@@ -29,10 +29,8 @@ package com.questhelper.overlays;
 
 import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
-import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
-import net.runelite.client.ui.overlay.OverlayPriority;
 
 import javax.inject.Inject;
 import java.awt.*;
@@ -55,10 +53,6 @@ public class QuestHelperOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		int fontSize = plugin.getConfig().fontSize().getSize();
-		Font overlayFont = FontManager.getRunescapeFont().deriveFont(Font.PLAIN, fontSize);
-		graphics.setFont(overlayFont);
-
 		if (!plugin.getConfig().showOverlay())
 		{
 			return super.render(graphics);

--- a/src/main/java/com/questhelper/overlays/QuestHelperTooltipOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperTooltipOverlay.java
@@ -26,6 +26,7 @@ package com.questhelper.overlays;
 
 import com.questhelper.QuestHelperPlugin;
 import net.runelite.api.Client;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -53,6 +54,10 @@ public class QuestHelperTooltipOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		int fontSize = questHelperPlugin.getConfig().fontSize().getSize();
+		Font overlayFont = FontManager.getRunescapeFont().deriveFont(Font.PLAIN, fontSize);
+		graphics.setFont(overlayFont);
+
 		if (questHelperPlugin.getSelectedQuest() != null && questHelperPlugin.getSelectedQuest().getCurrentStep() != null)
 		{
 			questHelperPlugin.getSelectedQuest().getCurrentStep().renderQuestStepTooltip(panelComponent, !client.isMenuOpen(), false);

--- a/src/main/java/com/questhelper/overlays/QuestHelperTooltipOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperTooltipOverlay.java
@@ -26,7 +26,6 @@ package com.questhelper.overlays;
 
 import com.questhelper.QuestHelperPlugin;
 import net.runelite.api.Client;
-import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -54,10 +53,6 @@ public class QuestHelperTooltipOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		int fontSize = questHelperPlugin.getConfig().fontSize().getSize();
-		Font overlayFont = FontManager.getRunescapeFont().deriveFont(Font.PLAIN, fontSize);
-		graphics.setFont(overlayFont);
-
 		if (questHelperPlugin.getSelectedQuest() != null && questHelperPlugin.getSelectedQuest().getCurrentStep() != null)
 		{
 			questHelperPlugin.getSelectedQuest().getCurrentStep().renderQuestStepTooltip(panelComponent, !client.isMenuOpen(), false);

--- a/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestOverviewPanel.java
@@ -76,10 +76,13 @@ public class QuestOverviewPanel extends JPanel
 	private final QuestRequirementsPanel questItemRequirementsPanel;
 	private final QuestRequirementsPanel questItemRecommendedPanel;
 	private final JPanel questCombatRequirementsListPanel;
+	private final JTextArea questCombatRequirementsHeader;
 	private final JPanel questNotesPanel;
 	private final JPanel questNotesList;
+	private final JTextArea questNotesHeader;
 	private final QuestRewardsPanel questRewardsPanel;
 	private final JPanel questExternalResourcesList;
+	private final JTextArea questExternalResourcesHeader;
 
 	private JPanel questStepsContainer;
 	private final CardLayout questStepsLayout = new CardLayout();
@@ -184,19 +187,22 @@ public class QuestOverviewPanel extends JPanel
 		overviewPanel.add(questItemRecommendedPanel);
 
 		var combatRequirements = QuestRequirementsPanel.createGenericGroup("Enemies to defeat:");
-		questCombatRequirementsListPanel = combatRequirements.getRight();
+		questCombatRequirementsListPanel = combatRequirements.getMiddle();
+		questCombatRequirementsHeader = combatRequirements.getRight();
 		overviewPanel.add(combatRequirements.getLeft());
 
 		var notes = QuestRequirementsPanel.createGenericGroup("Notes:");
 		questNotesPanel = notes.getLeft();
-		questNotesList = notes.getRight();
+		questNotesList = notes.getMiddle();
+		questNotesHeader = notes.getRight();
 		overviewPanel.add(questNotesPanel);
 
 		questRewardsPanel = new QuestRewardsPanel();
 		overviewPanel.add(questRewardsPanel);
 
 		var externalResources = QuestRequirementsPanel.createGenericGroup("External Resources:");
-		questExternalResourcesList = externalResources.getRight();
+		questExternalResourcesList = externalResources.getMiddle();
+		questExternalResourcesHeader = externalResources.getRight();
 		overviewPanel.add(externalResources.getLeft());
 
 		introPanel.add(overviewPanel, BorderLayout.NORTH);
@@ -279,6 +285,7 @@ public class QuestOverviewPanel extends JPanel
 		if (quest.getCurrentStep() != null)
 		{
 			questNameLabel.setText(quest.getQuest().getName());
+			questNameLabel.setFont(Fonts.getOriginalFont());
 			actionsContainer.setVisible(true);
 
 			if (quest.getConfigs() != null)
@@ -371,8 +378,27 @@ public class QuestOverviewPanel extends JPanel
 			.count() == allQuestStepPanelList.size();
 	}
 
+	private void refreshGenericHeaderFonts()
+	{
+		Font font = Fonts.getOriginalFont();
+		if (questCombatRequirementsHeader != null)
+		{
+			questCombatRequirementsHeader.setFont(font);
+		}
+		if (questNotesHeader != null)
+		{
+			questNotesHeader.setFont(font);
+		}
+		if (questExternalResourcesHeader != null)
+		{
+			questExternalResourcesHeader.setFont(font);
+		}
+	}
+
 	public void setupQuestRequirements(QuestHelper quest)
 	{
+		refreshGenericHeaderFonts();
+
 		/* Config setup */
 		if (quest.getConfigs() != null)
 		{
@@ -522,6 +548,7 @@ public class QuestOverviewPanel extends JPanel
 	private void updateCombatRequirementsPanels(List<String> combatRequirementList)
 	{
 		JTextArea combatLabel = JGenerator.makeJTextArea();
+		combatLabel.setFont(Fonts.getOriginalFont());
 		combatLabel.setForeground(Color.GRAY);
 		StringBuilder textCombat = new StringBuilder();
 		if (combatRequirementList == null)
@@ -615,6 +642,7 @@ public class QuestOverviewPanel extends JPanel
 				first = false;
 			}
 			var overviewLabel = JGenerator.makeJTextArea();
+			overviewLabel.setFont(Fonts.getOriginalFont());
 			overviewLabel.setForeground(Color.GRAY);
 			overviewLabel.setText(textNote.toString());
 

--- a/src/main/java/com/questhelper/panel/QuestRequirementsPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRequirementsPanel.java
@@ -42,6 +42,7 @@ import net.runelite.client.events.PluginMessage;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.LinkBrowser;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 
 import javax.annotation.Nullable;
 import javax.swing.*;
@@ -68,6 +69,7 @@ public class QuestRequirementsPanel extends JPanel
 	private final QuestManager questManager;
 	private final boolean showEvenIfEmpty;
 	private final JPanel requirementsPanel = new JPanel();
+	private final JTextArea headerLabel;
 
 	public QuestRequirementsPanel(@NonNull String header, Collection<Requirement> requirements, @NonNull QuestManager questManager, boolean showEvenIfEmpty)
 	{
@@ -78,9 +80,10 @@ public class QuestRequirementsPanel extends JPanel
 		setLayout(new BorderLayout());
 		setBorder(new EmptyBorder(0, 0, 10, 0));
 
-		var headerPanel = createHeader(header);
+		var headerResult = createHeader(header);
+		headerLabel = headerResult.getRight();
 
-		add(headerPanel, BorderLayout.NORTH);
+		add(headerResult.getLeft(), BorderLayout.NORTH);
 
 		requirementsPanel.setLayout(new DynamicPaddedGridLayout(0, 1, 0, 1));
 		requirementsPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
@@ -90,7 +93,7 @@ public class QuestRequirementsPanel extends JPanel
 		setRequirements(requirements);
 	}
 
-	public static JPanel createHeader(@NonNull String header)
+	public static Pair<JPanel, JTextArea> createHeader(@NonNull String header)
 	{
 		var headerPanel = new JPanel();
 		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -98,34 +101,36 @@ public class QuestRequirementsPanel extends JPanel
 		headerPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
 
 		var headerLabel = JGenerator.makeJTextArea(header);
+		headerLabel.setFont(Fonts.getOriginalFont());
 		headerLabel.setForeground(Color.WHITE);
 		headerLabel.setMinimumSize(new Dimension(1, headerPanel.getPreferredSize().height));
 		headerPanel.add(headerLabel, BorderLayout.NORTH);
 
-		return headerPanel;
+		return Pair.of(headerPanel, headerLabel);
 	}
 
-	public static Pair<JPanel, JPanel> createGenericGroup(@NonNull String header)
+	public static Triple<JPanel, JPanel, JTextArea> createGenericGroup(@NonNull String header)
 	{
 		var group = new JPanel();
 		group.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		group.setLayout(new BorderLayout());
 		group.setBorder(new EmptyBorder(0, 0, 0, 0));
 
-		var headerPanel = createHeader(header);
+		var headerResult = createHeader(header);
 
 		var listPanel = new JPanel();
 		listPanel.setLayout(new DynamicPaddedGridLayout(0, 1, 0, 1));
 		listPanel.setBorder(new EmptyBorder(10, 5, 10, 5));
 
-		group.add(headerPanel, BorderLayout.NORTH);
+		group.add(headerResult.getLeft(), BorderLayout.NORTH);
 		group.add(listPanel, BorderLayout.CENTER);
 
-		return Pair.of(group, listPanel);
+		return Triple.of(group, listPanel, headerResult.getRight());
 	}
 
 	public void setRequirements(@Nullable Collection<? extends Requirement> requirements)
 	{
+		headerLabel.setFont(Fonts.getOriginalFont());
 		requirementList.clear();
 		requirementsPanel.removeAll();
 

--- a/src/main/java/com/questhelper/panel/QuestRewardsPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRewardsPanel.java
@@ -61,7 +61,6 @@ public class QuestRewardsPanel extends JPanel
 		rewardsText.setEditable(false);
 		rewardsText.setFocusable(false);
 		rewardsText.setBackground(javax.swing.UIManager.getColor("Label.background"));
-		rewardsText.setFont(Fonts.getOriginalFont());
 		rewardsText.setBorder(new EmptyBorder(0, 0, 0, 0));
 
 		add(rewardsPanel, BorderLayout.CENTER);

--- a/src/main/java/com/questhelper/panel/QuestRewardsPanel.java
+++ b/src/main/java/com/questhelper/panel/QuestRewardsPanel.java
@@ -38,6 +38,7 @@ import java.util.List;
 public class QuestRewardsPanel extends JPanel
 {
 	private final JTextArea rewardsText = new JTextArea();
+	private final JTextArea headerLabel;
 
 	public QuestRewardsPanel()
 	{
@@ -45,9 +46,10 @@ public class QuestRewardsPanel extends JPanel
 		setLayout(new BorderLayout());
 		setBorder(new EmptyBorder(0, 0, 10, 0));
 
-		var headerPanel = QuestRequirementsPanel.createHeader("Rewards:");
+		var headerResult = QuestRequirementsPanel.createHeader("Rewards:");
+		headerLabel = headerResult.getRight();
 
-		add(headerPanel, BorderLayout.NORTH);
+		add(headerResult.getLeft(), BorderLayout.NORTH);
 
 		var rewardsPanel = new JPanel();
 		rewardsPanel.setLayout(new DynamicPaddedGridLayout(0, 1, 0, 1));
@@ -69,6 +71,8 @@ public class QuestRewardsPanel extends JPanel
 
 	public void setRewards(@Nullable List<Reward> rewards)
 	{
+		rewardsText.setFont(Fonts.getOriginalFont());
+		headerLabel.setFont(Fonts.getOriginalFont());
 		Reward lastReward = null;
 		if (rewards != null && !rewards.isEmpty())
 		{
@@ -104,6 +108,8 @@ public class QuestRewardsPanel extends JPanel
 
 	public void hideRewards()
 	{
+		rewardsText.setFont(Fonts.getOriginalFont());
+		headerLabel.setFont(Fonts.getOriginalFont());
 		rewardsText.setText("Hidden by the \"Hide quest rewards\" config");
 		rewardsText.setForeground(Color.GRAY);
 

--- a/src/main/java/com/questhelper/panel/queststepsection/QuestSectionSection.java
+++ b/src/main/java/com/questhelper/panel/queststepsection/QuestSectionSection.java
@@ -31,6 +31,7 @@ import com.questhelper.panel.QuestOverviewPanel;
 import com.questhelper.panel.TopLevelPanelDetails;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.steps.QuestStep;
+import com.questhelper.util.Fonts;
 import net.runelite.api.Client;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -85,7 +86,7 @@ public class QuestSectionSection extends AbstractQuestSection implements MouseLi
 		addMouseListener(this);
 
 		headerLabel.setText(panelDetails.getHeader());
-		headerLabel.setFont(FontManager.getRunescapeBoldFont());
+		headerLabel.setFont(FontManager.getRunescapeBoldFont().deriveFont((float) Fonts.getOriginalFont().getSize()));
 
 		headerLabel.setMinimumSize(new Dimension(1, headerLabel.getPreferredSize().height));
 

--- a/src/main/java/com/questhelper/panel/queststepsection/QuestStepPanel.java
+++ b/src/main/java/com/questhelper/panel/queststepsection/QuestStepPanel.java
@@ -35,6 +35,7 @@ import com.questhelper.requirements.ManualRequirement;
 import com.questhelper.steps.BoardShipStep;
 import com.questhelper.steps.PortTaskStep;
 import com.questhelper.steps.QuestStep;
+import com.questhelper.util.Fonts;
 import net.runelite.api.Client;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -97,7 +98,7 @@ public class QuestStepPanel extends AbstractQuestSection implements MouseListene
 		addMouseListener(this);
 
 		headerLabel.setText(panelDetails.getHeader());
-		headerLabel.setFont(FontManager.getRunescapeBoldFont());
+		headerLabel.setFont(FontManager.getRunescapeBoldFont().deriveFont((float) Fonts.getOriginalFont().getSize()));
 
 		headerLabel.setMinimumSize(new Dimension(1, headerLabel.getPreferredSize().height));
 
@@ -374,6 +375,7 @@ public class QuestStepPanel extends AbstractQuestSection implements MouseListene
 			BorderFactory.createEmptyBorder(5, 5, 10, 0)
 		));
 		questStepLabel.setText(generateText(step));
+		questStepLabel.setFont(Fonts.getOriginalFont());
 		questStepLabel.setOpaque(true);
 		questStepLabel.setVisible(true);
 		return questStepLabel;

--- a/src/main/java/com/questhelper/util/Fonts.java
+++ b/src/main/java/com/questhelper/util/Fonts.java
@@ -33,7 +33,9 @@ import java.util.HashMap;
 
 public class Fonts
 {
+	// Note: offset 3 is skipped for LARGE as it produces a glyph-hinting artifact on the system font (e.g. "0" renders poorly at that size).
 	private static final Font baseFont;
+
 	@Getter
 	private static final float defaultSize;
 
@@ -59,9 +61,13 @@ public class Fonts
 	 */
 	public static void setSize(int size)
 	{
-		originalFont = baseFont.deriveFont((float) size);
-		var attributes = new HashMap<TextAttribute, Object>(originalFont.getAttributes());
-		attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
-		underlinedFont = originalFont.deriveFont(attributes);
+		var baseAttributes = new HashMap<TextAttribute, Object>(baseFont.getAttributes());
+		baseAttributes.put(TextAttribute.SIZE, (float) size);
+		baseAttributes.put(TextAttribute.KERNING, TextAttribute.KERNING_ON);
+		originalFont = baseFont.deriveFont(baseAttributes);
+
+		var underlineAttributes = new HashMap<TextAttribute, Object>(originalFont.getAttributes());
+		underlineAttributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
+		underlinedFont = originalFont.deriveFont(underlineAttributes);
 	}
 }

--- a/src/main/java/com/questhelper/util/Fonts.java
+++ b/src/main/java/com/questhelper/util/Fonts.java
@@ -33,15 +33,33 @@ import java.util.HashMap;
 
 public class Fonts
 {
+	private static final Font baseFont;
 	@Getter
-	private static final Font originalFont;
+	private static final float defaultSize;
+
 	@Getter
-	private static final Font underlinedFont;
+	private static Font originalFont;
+	@Getter
+	private static Font underlinedFont;
 
 	static
 	{
 		var label = JGenerator.makeJTextArea();
-		originalFont = label.getFont();
+		baseFont = label.getFont();
+		defaultSize = baseFont.getSize2D();
+		originalFont = baseFont;
+		var attributes = new HashMap<TextAttribute, Object>(baseFont.getAttributes());
+		attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
+		underlinedFont = baseFont.deriveFont(attributes);
+	}
+
+	/**
+	 * Update the global font size used by the sidebar panel.
+	 * Call this when the config changes.
+	 */
+	public static void setSize(int size)
+	{
+		originalFont = baseFont.deriveFont((float) size);
 		var attributes = new HashMap<TextAttribute, Object>(originalFont.getAttributes());
 		attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
 		underlinedFont = originalFont.deriveFont(attributes);


### PR DESCRIPTION
### Description 
Adds a "Font size" option to the sidebar details config section, allowing users to increase the text size in the quest helper sidebar panel. 

### Changes

1. Added FontSize enum (DEFAULT, LARGE, LARGER, LARGEST) with size offsets relative to the system default font size so they scale correctly across different OSes.
2. Added fontSize() config item under the "Sidebar details" section.
3. Added Fonts class to manage the current sidebar font and its underlined variant.
4. Font size change takes effect immediately by restarting the active quest helper.
5. Refactored QuestRequirementsPanel.createHeader() to return a Pair<JPanel, JTextArea> and createGenericGroup() to return a Triple<JPanel, JPanel, JTextArea>, removing the need to do component-tree walking.

### Notes

1. Size offset +3pt is intentionally skipped for LARGE as it produces a glyph rendering artifact on the system font at that specific pixel size.
2. Originally this was going to include increasing the overlay size/overlay font size but I decided that it wasn't really needed during testing. 