### PR TITLE
feat: quetzal destination highlight

### DIFF
--- a/src/main/java/com/questhelper/domain/QuetzalDestination.java
+++ b/src/main/java/com/questhelper/domain/QuetzalDestination.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, pajlada <https://github.com/pajlada>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.domain;
+
+import lombok.RequiredArgsConstructor;
+
+/// Mapping from quetzal destinations to the model ID used in the quetzal map widget.
+///
+/// See {@link com.questhelper.steps.widget.WidgetHighlight#createQuetzalHighlight}
+@RequiredArgsConstructor
+public enum QuetzalDestination
+{
+	CIVITAS_ILLA_FORTIS(51208),
+	THE_TEOMAT(51205),
+	SUNSET_COAST(51187),
+	HUNTER_GUILD(51185),
+	ALDARIN(54547),
+	QUETZACALLI_GORGE(54539),
+	TAL_TEKLAN(56665);
+
+	public final int modelID;
+}

--- a/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/TheHeartOfDarkness.java
+++ b/src/main/java/com/questhelper/helpers/quests/theheartofdarkness/TheHeartOfDarkness.java
@@ -27,6 +27,7 @@ package com.questhelper.helpers.quests.theheartofdarkness;
 import com.google.common.collect.Lists;
 import com.questhelper.bank.banktab.BankSlotIcons;
 import com.questhelper.collections.ItemCollections;
+import com.questhelper.domain.QuetzalDestination;
 import com.questhelper.helpers.quests.secretsofthenorth.ArrowChestPuzzleStep;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
@@ -542,15 +543,11 @@ public class TheHeartOfDarkness extends BasicQuestHelper
     {
         talkToItzlaAtTeomat = new NpcStep(this, NpcID.VMQ2_ITZLA_VIS, new WorldPoint(1454, 3173, 0), "Talk to Prince Itzla Arkan at the Teomat. You" +
                 " can travel here using Renu the quetzal.");
-        WidgetHighlight teomatWidget = new WidgetHighlight(874, 15, true);
-        teomatWidget.setModelIdRequirement(51205);
-        talkToItzlaAtTeomat.addWidgetHighlight(teomatWidget);
+        talkToItzlaAtTeomat.addWidgetHighlight(WidgetHighlight.createQuetzalHighlight(QuetzalDestination.THE_TEOMAT));
         talkToItzlaAtTeomat.addDialogStep("Yes.");
         travelToGorge = new NpcStep(this, NpcID.QUETZAL_CHILD_GREEN_NOOP, new WorldPoint(1437, 3169, 0), "Travel on Renu to the Quetzacalli Gorge.");
         ((NpcStep) travelToGorge).addAlternateNpcs(NpcID.QUETZAL_CHILD_GREEN_FEED, NpcID.QUETZAL_CHILD_GREEN, NpcID.QUETZAL_CHILD_ORANGE, NpcID.QUETZAL_CHILD_BLUE, NpcID.QUETZAL_CHILD_CYAN, NpcID.QUETZAL_CHILD_GREEN_ORANGE);
-        WidgetHighlight gorgeWidget = new WidgetHighlight(874, 15, true);
-        gorgeWidget.setModelIdRequirement(54539);
-        travelToGorge.addWidgetHighlight(gorgeWidget);
+        travelToGorge.addWidgetHighlight(WidgetHighlight.createQuetzalHighlight(QuetzalDestination.QUETZACALLI_GORGE));
         talkToBartender = new NpcStep(this, NpcID.QUETZACALLI_BARTENDER, new WorldPoint(1499, 3224, 0), "Talk to the Bartender in the pub in the Gorge.",
                 coins.quantity(30));
         // Told about ground room, 11123 1->0

--- a/src/main/java/com/questhelper/steps/widget/WidgetHighlight.java
+++ b/src/main/java/com/questhelper/steps/widget/WidgetHighlight.java
@@ -25,6 +25,7 @@
 package com.questhelper.steps.widget;
 
 import com.questhelper.QuestHelperPlugin;
+import com.questhelper.domain.QuetzalDestination;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
@@ -137,6 +138,18 @@ public class WidgetHighlight extends AbstractWidgetHighlight
 		return w;
 	}
 
+	/**
+	 * Create a widget highlight that highlights the given destination in the quetzal interface
+	 * @param quetzalDestination The quetzal destination to highlight
+	 * @return a fully built WidgetHighlight
+	 */
+	public static WidgetHighlight createQuetzalHighlight(QuetzalDestination quetzalDestination)
+	{
+		var w = new WidgetHighlight(InterfaceID.QuetzalMenu.ICONS, true);
+		w.modelIdRequirement = quetzalDestination.modelID;
+		return w;
+	}
+
 	@Override
 	public void highlightChoices(Graphics2D graphics, Client client, QuestHelperPlugin questHelper)
 	{
@@ -153,6 +166,7 @@ public class WidgetHighlight extends AbstractWidgetHighlight
 
 		Widget[] widgets = parentWidget.getChildren();
 		Widget[] staticWidgets = parentWidget.getStaticChildren();
+		var dynamicWidgets = parentWidget.getDynamicChildren();
 
 		if (childChildId != -1 && widgets != null)
 		{
@@ -167,6 +181,10 @@ public class WidgetHighlight extends AbstractWidgetHighlight
 				highlightChoices(widget, graphics, questHelper);
 			}
 			for (Widget widget : staticWidgets)
+			{
+				highlightChoices(widget, graphics, questHelper);
+			}
+			for (var widget : dynamicWidgets)
 			{
 				highlightChoices(widget, graphics, questHelper);
 			}


### PR DESCRIPTION
This adds dynamic widgets to our widget iterations. This is currently enabled for all WidgetHighlights that have `checkChildren` enabled. Should "check dynamic children" be opt-in?
