### PR TITLE
polish Kandarin Easy

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinEasy.java
@@ -40,6 +40,7 @@ import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
 import com.questhelper.requirements.runelite.RuneliteRequirement;
 import com.questhelper.requirements.util.LogicType;
+import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.rewards.ItemReward;
@@ -53,11 +54,14 @@ import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import static com.questhelper.requirements.util.LogicHelper.and;
+import static com.questhelper.requirements.util.LogicHelper.not;
 
 public class KandarinEasy extends ComplexStateQuestHelper
 {
@@ -174,7 +178,8 @@ public class KandarinEasy extends ComplexStateQuestHelper
         seaweed = new ItemRequirement("Seaweed", ItemID.SEAWEED).showConditioned(notPetFish);
         juteSeed = new ItemRequirement("Jute seeds", ItemID.JUTE_SEED).showConditioned(notPlantJute);
         rake = new ItemRequirement("Rake", ItemID.RAKE).showConditioned(notPlantJute).isNotConsumed();
-        seedDibber = new ItemRequirement("Seed dibber", ItemID.DIBBER).showConditioned(notPlantJute).isNotConsumed();
+        var needSeedDibber = not(new VarbitRequirement(VarbitID.BRUT_FARMING_PLANTING, 3));
+        seedDibber = new ItemRequirement("Seed dibber", ItemID.DIBBER).showConditioned(and(notPlantJute, needSeedDibber)).isNotConsumed();
         spade = new ItemRequirement("Spade (if existing plant in hops patch)", ItemID.SPADE).showConditioned(notPlantJute).isNotConsumed();
 
 		batteredKey = new KeyringRequirement("Battered Key", KeyringCollection.BATTERED_KEY).showConditioned(notKillEle).isNotConsumed();

--- a/src/main/java/com/questhelper/requirements/zone/ZoneRequirement.java
+++ b/src/main/java/com/questhelper/requirements/zone/ZoneRequirement.java
@@ -48,6 +48,13 @@ public class ZoneRequirement extends AbstractRequirement
 	private final boolean checkInZone;
 	private String displayText;
 
+	/// Contains the value of the most recent successful zone check.
+	/// null = no check has succeeded
+	/// true = the last check was deemed a success (check returned true)
+	/// false = the last check was deemed a failure (check returned false)
+	@Getter
+	private Boolean matchedZoneLastCheck = null;
+
 	/**
 	 * Check if the player is either in the specified zone.
 	 *
@@ -109,7 +116,8 @@ public class ZoneRequirement extends AbstractRequirement
 		if (player != null && zones != null)
 		{
 			boolean inZone = zones.stream().anyMatch(z -> z.contains(client, player.getLocalLocation()));
-			return inZone == checkInZone;
+			matchedZoneLastCheck = inZone == checkInZone;
+			return matchedZoneLastCheck;
 		}
 		return false;
 	}

--- a/src/main/java/com/questhelper/statemanagement/AchievementDiaryStepManager.java
+++ b/src/main/java/com/questhelper/statemanagement/AchievementDiaryStepManager.java
@@ -36,6 +36,7 @@ import net.runelite.api.gameval.NpcID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
+import net.runelite.client.events.ServerNpcLoot;
 
 import javax.inject.Singleton;
 
@@ -46,7 +47,7 @@ public class AchievementDiaryStepManager
 	static Zone workshop;
 
 	@Getter
-	static Requirement inWorkshop;
+	static ZoneRequirement inWorkshop;
 
 	@Getter
 	static RuneliteRequirement killedFire, killedEarth, killedWater, killedAir;
@@ -68,7 +69,7 @@ public class AchievementDiaryStepManager
 
 	public static void check(Client client)
 	{
-		if (!inWorkshop.check(client))
+		if (inWorkshop.getMatchedZoneLastCheck() != false && !inWorkshop.check(client))
 		{
 			killedFire.setConfigValue("false");
 			killedEarth.setConfigValue("false");
@@ -78,14 +79,27 @@ public class AchievementDiaryStepManager
 	}
 
 	@Subscribe
-	public void onNpcLootReceived(final NpcLootReceived npcLootReceived)
+	public static void onServerNpcLoot(final ServerNpcLoot npcLootReceived)
 	{
-		final NPC npc = npcLootReceived.getNpc();
+		final var npc = npcLootReceived.getComposition();
 
-		final int id = npc.getId();
-		if (id == NpcID.ELEMENTAL_FIRE) killedFire.setConfigValue("true");
-		if (id == NpcID.ELEMENTAL_EARTH) killedEarth.setConfigValue("true");
-		if (id == NpcID.ELEMENTAL_WATER) killedWater.setConfigValue("true");
-		if (id == NpcID.ELEMENTAL_AIR) killedAir.setConfigValue("true");
+		switch (npc.getId())
+		{
+			case NpcID.ELEMENTAL_FIRE:
+				killedFire.setConfigValue("true");
+				break;
+
+			case NpcID.ELEMENTAL_EARTH:
+				killedEarth.setConfigValue("true");
+				break;
+
+			case NpcID.ELEMENTAL_WATER:
+				killedWater.setConfigValue("true");
+				break;
+
+			case NpcID.ELEMENTAL_AIR:
+				killedAir.setConfigValue("true");
+				break;
+		}
 	}
 }

--- a/src/main/java/com/questhelper/statemanagement/PlayerStateManager.java
+++ b/src/main/java/com/questhelper/statemanagement/PlayerStateManager.java
@@ -43,6 +43,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneScapeProfileType;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ServerNpcLoot;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -142,6 +143,8 @@ public class PlayerStateManager
 				}
 			}
 			lastPlayerPos = newPos;
+
+			AchievementDiaryStepManager.check(client);
 		}
 	}
 
@@ -217,5 +220,11 @@ public class PlayerStateManager
 	public void setUnknownInitialState()
 	{
 		loggedInStateKnown = false;
+	}
+
+	@Subscribe
+	public void onServerNpcLoot(ServerNpcLoot event)
+	{
+		AchievementDiaryStepManager.onServerNpcLoot(event);
 	}
 }


### PR DESCRIPTION
- **kandarin easy: hide seed dibber if finished barb farming**
- **kandarin easy: fix "kill elementals" step**
  There are multiple fixes involved with this:
    1) Switch to the new `ServerLootEvent` event (and actually subscribe to it). The AchievementDiaryStepManager, as a
       static class, never actually subscribed.
       I have moved the subscription to PlayerStateManager which forwards loot events to AchievementDiaryStepManager.
    2) Reset the known kills more often. Depending on the player's position, they can have their progress reset. It doesn't
       _exactly_ reset when leaving, but it's the most reliable check we can make. To combat this location check every game
       tick I cache the most recent check made in a ZoneRequirement and only ever check to reset it on game tick if it
       wasn't previously set to false.
