### PR TITLE
polish: Mage Arena I & Mage Arena II

### DIFF
--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -2244,6 +2244,15 @@ public enum ItemCollections
 		ItemID.WILDBLOOD_HOP_SEED
 	)),
 
+	/// Things you can slash webs with that are safe to bring to wildy
+	SLASH_WEB_KNIFE(ImmutableList.of(
+		ItemID.KNIFE,
+		ItemID.WILDERNESS_SWORD_ELITE,
+		ItemID.WILDERNESS_SWORD_HARD,
+		ItemID.WILDERNESS_SWORD_MEDIUM,
+		ItemID.WILDERNESS_SWORD_EASY
+	)),
+
 	BUSH_SEEDS(ImmutableList.of(
 		ItemID.REDBERRY_BUSH_SEED,
 		ItemID.CADAVABERRY_BUSH_SEED,

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenai/TheMageArenaI.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenai/TheMageArenaI.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.helpers.miniquests.themagearenai;
 
+import com.questhelper.collections.ItemCollections;
 import com.questhelper.panel.PanelDetails;
 import com.questhelper.questhelpers.BasicQuestHelper;
 import com.questhelper.requirements.Requirement;
@@ -86,7 +87,7 @@ public class TheMageArenaI extends BasicQuestHelper
 	{
 		runesForCasts = new ItemRequirement("Runes for fighting Kolodion", -1, -1);
 		runesForCasts.setDisplayItemId(ItemID.DEATHRUNE);
-		knife = new ItemRequirement("Knife or sharp weapon to cut through a web", ItemID.KNIFE).isNotConsumed();
+		knife = new ItemRequirement("Knife or sharp weapon to cut through a web", ItemCollections.SLASH_WEB_KNIFE).isNotConsumed();
 		godCape = new ItemRequirement("God cape", ItemID.ZAMORAK_CAPE).isNotConsumed();
 		godCape.addAlternates(ItemID.GUTHIX_CAPE, ItemID.SARADOMIN_CAPE);
 	}

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MageArenaBossStep.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/MageArenaBossStep.java
@@ -31,6 +31,7 @@ import com.questhelper.QuestHelperPlugin;
 import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.requirements.Requirement;
 import com.questhelper.requirements.item.ItemRequirement;
+import com.questhelper.requirements.var.VarbitRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.steps.DetailedQuestStep;
 import com.questhelper.steps.tools.DefinedPoint;
@@ -55,6 +56,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
+import javax.annotation.Nullable;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
@@ -63,6 +65,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class MageArenaBossStep extends DetailedQuestStep
@@ -105,8 +108,21 @@ public class MageArenaBossStep extends DetailedQuestStep
 	// We need this as a player can press multiple keys in the options dialog, but only the first press counts
 	boolean keyPressedOnce;
 
+	/// If set, will be used when "Activate" is clicked to figure out whether it's the last option available (only a thing during MA2)
+	private final @Nullable VarbitRequirement finishedSaradomin;
+
+	/// If set, will be used when "Activate" is clicked to figure out whether it's the last option available (only a thing during MA2)
+	private final @Nullable VarbitRequirement finishedGuthix;
+
+	/// If set, will be used when "Activate" is clicked to figure out whether it's the last option available (only a thing during MA2)
+	private final @Nullable VarbitRequirement finishedZamorak;
+
 	public MageArenaBossStep(QuestHelper questHelper, ItemRequirement staff, String bossName,
-							 String abilityDetail, ItemRequirement... requirements)
+							 String abilityDetail,
+							 VarbitRequirement finishedSaradomin,
+							 VarbitRequirement finishedGuthix,
+							 VarbitRequirement finishedZamorak,
+							 ItemRequirement... requirements)
 	{
 		super(questHelper, originalTextStart + bossName + originalTextEnd, requirements);
 		this.bossName = bossName;
@@ -114,6 +130,10 @@ public class MageArenaBossStep extends DetailedQuestStep
 		this.staff = staff;
 		this.baseRequirements = requirements;
 		this.godToFind = God.getByName(bossName);
+
+		this.finishedSaradomin = finishedSaradomin;
+		this.finishedGuthix = finishedGuthix;
+		this.finishedZamorak = finishedZamorak;
 	}
 
 	public MageArenaBossStep(QuestHelper questHelper, ItemRequirement staff,
@@ -126,6 +146,10 @@ public class MageArenaBossStep extends DetailedQuestStep
 		this.baseRequirements = requirements;
 		this.allowChangingBoss = true;
 		this.godToFind = God.SARADOMIN;
+
+		this.finishedSaradomin = null;
+		this.finishedGuthix = null;
+		this.finishedZamorak = null;
 	}
 
 	@Override
@@ -279,20 +303,44 @@ public class MageArenaBossStep extends DetailedQuestStep
 
 	public void addListeners()
 	{
-		final var SARADOMIN_POS = 1;
-		final var GUTHIX_POS = 2;
-		final var ZAMORAK_POS = 3;
+		final AtomicInteger SARADOMIN_KC = new AtomicInteger(-1);
+		final AtomicInteger GUTHIX_KC = new AtomicInteger(-1);
+		final AtomicInteger ZAMORAK_KC = new AtomicInteger(-1);
 		var chatMenu = client.getWidget(InterfaceID.Chatmenu.OPTIONS);
 		if (chatMenu == null || chatMenu.isHidden()) return;
 		if (chatMenu.getChildren() == null || chatMenu.getChildren().length < 4) return;
 
-		var saradominButton = chatMenu.getChildren()[SARADOMIN_POS];
-		var guthixButton = chatMenu.getChildren()[GUTHIX_POS];
-		var zamorakButton = chatMenu.getChildren()[ZAMORAK_POS];
-		if (saradominButton == null || guthixButton == null || zamorakButton == null) return;
-		saradominButton.setOnClickListener((JavaScriptCallback) ev -> { handleBossButtonClick(God.SARADOMIN); });
-		guthixButton.setOnClickListener((JavaScriptCallback) ev -> {handleBossButtonClick(God.GUTHIX);});
-		zamorakButton.setOnClickListener((JavaScriptCallback) ev -> { handleBossButtonClick(God.ZAMORAK); });
+		for (var i = 1; i < 4; ++i)
+		{
+			var button = chatMenu.getChild(i);
+			if (button == null)
+			{
+				return;
+			}
+			var buttonText = button.getText();
+			var buttonIndex = button.getIndex();
+			if ("Saradomin".equals(buttonText))
+			{
+				button.setOnClickListener((JavaScriptCallback) ev -> { handleBossButtonClick(God.SARADOMIN); });
+				if (buttonIndex == 1) SARADOMIN_KC.set(KeyCode.KC_1);
+				else if (buttonIndex == 2) SARADOMIN_KC.set(KeyCode.KC_2);
+				else if (buttonIndex == 3) SARADOMIN_KC.set(KeyCode.KC_3);
+			}
+			else if ("Guthix".equals(buttonText))
+			{
+				button.setOnClickListener((JavaScriptCallback) ev -> {handleBossButtonClick(God.GUTHIX);});
+				if (buttonIndex == 1) GUTHIX_KC.set(KeyCode.KC_1);
+				else if (buttonIndex == 2) GUTHIX_KC.set(KeyCode.KC_2);
+				else if (buttonIndex == 3) GUTHIX_KC.set(KeyCode.KC_3);
+			}
+			else if ("Zamorak".equals(buttonText))
+			{
+				button.setOnClickListener((JavaScriptCallback) ev -> { handleBossButtonClick(God.ZAMORAK); });
+				if (buttonIndex == 1) ZAMORAK_KC.set(KeyCode.KC_1);
+				else if (buttonIndex == 2) ZAMORAK_KC.set(KeyCode.KC_2);
+				else if (buttonIndex == 3) ZAMORAK_KC.set(KeyCode.KC_3);
+			}
+		}
 
 		keyPressedOnce = false;
 
@@ -300,9 +348,12 @@ public class MageArenaBossStep extends DetailedQuestStep
 		chatMenu.setOnKeyListener((JavaScriptCallback) ev -> {
 			if (keyPressedOnce) return;
 			keyPressedOnce = true;
-			if (ev.getTypedKeyCode() == KeyCode.KC_1) handleBossButtonClick(God.SARADOMIN);
-			if (ev.getTypedKeyCode() == KeyCode.KC_2) handleBossButtonClick(God.GUTHIX);
-			if (ev.getTypedKeyCode() == KeyCode.KC_3) handleBossButtonClick(God.ZAMORAK);
+			var saradominKc = SARADOMIN_KC.get();
+			var guthixKc = GUTHIX_KC.get();
+			var zamorakKc = ZAMORAK_KC.get();
+			if (saradominKc != -1 && ev.getTypedKeyCode() == saradominKc) handleBossButtonClick(God.SARADOMIN);
+			if (guthixKc != -1 && ev.getTypedKeyCode() == guthixKc) handleBossButtonClick(God.GUTHIX);
+			if (zamorakKc != -1 && ev.getTypedKeyCode() == zamorakKc) handleBossButtonClick(God.ZAMORAK);
 		});
 		chatMenu.revalidate();
 	}
@@ -312,6 +363,33 @@ public class MageArenaBossStep extends DetailedQuestStep
 	{
 		if (e.getItemId() == ItemID.MA2_SYMBOL && "Activate".equals(e.getMenuOption()))
 		{
+			if (finishedSaradomin != null && finishedGuthix != null && finishedZamorak != null) {
+				var finishedSaradomin = this.finishedSaradomin.check(client);
+				var finishedGuthix = this.finishedGuthix.check(client);
+				var finishedZamorak = this.finishedZamorak.check(client);
+
+				if (finishedSaradomin && finishedGuthix && !finishedZamorak)
+				{
+					// User only has Zamorak left
+					handleBossButtonClick(God.ZAMORAK);
+					return;
+				}
+
+				if (finishedSaradomin && !finishedGuthix && finishedZamorak)
+				{
+					// User only has Guthix left
+					handleBossButtonClick(God.GUTHIX);
+					return;
+				}
+
+				if (!finishedSaradomin && finishedGuthix && finishedZamorak)
+				{
+					// User only has Saradomin left
+					handleBossButtonClick(God.SARADOMIN);
+					return;
+				}
+			}
+
 			clickedActivateOnSymbol = true;
 		}
 	}

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
@@ -115,7 +115,7 @@ public class TheMageArenaII extends BasicQuestHelper
 			new ItemRequirement("Fire runes", ItemID.FIRERUNE, -1));
 		magicCombatGear = new ItemRequirement("Magic combat gear", -1, 1).isNotConsumed();
 		magicCombatGear.setDisplayItemId(BankSlotIcons.getMagicCombatGear());
-		knife = new ItemRequirement("Knife or sharp weapon to cut through a web", ItemID.KNIFE).isNotConsumed();
+		knife = new ItemRequirement("Knife or sharp weapon to cut through a web", ItemCollections.SLASH_WEB_KNIFE).isNotConsumed();
 		brews =  new ItemRequirement("Saradomin brews", ItemCollections.SARADOMIN_BREWS, -1);
 		restores = new ItemRequirement("Super restores", ItemCollections.SUPER_RESTORE_POTIONS, -1);
 		food = new ItemRequirement("Food", ItemCollections.GOOD_EATING_FOOD, -1);

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
@@ -35,7 +35,9 @@ import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.requirements.item.ItemRequirements;
 import com.questhelper.requirements.player.SkillRequirement;
 import com.questhelper.requirements.quest.QuestRequirement;
+import com.questhelper.requirements.util.Operation;
 import com.questhelper.requirements.var.VarbitRequirement;
+import com.questhelper.requirements.var.VarplayerRequirement;
 import com.questhelper.requirements.zone.Zone;
 import com.questhelper.requirements.zone.ZoneRequirement;
 import com.questhelper.rewards.UnlockReward;
@@ -46,6 +48,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.NpcID;
 import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
 
 import java.util.*;
@@ -56,6 +59,10 @@ public class TheMageArenaII extends BasicQuestHelper
 		, food, recoils, enchantedSymbol, justicarsHand, demonsHeart, entRoots, godCape;
 
 	Requirement inCavern, givenHand, givenHeart, givenRoots;
+
+	VarplayerRequirement unlockedSaradominStrike;
+	VarplayerRequirement unlockedClawsOfGuthix;
+	VarplayerRequirement unlockedFlamesOfZamorak;
 
 	QuestStep enterCavern, talkToKolodion, locateFollowerSara, locateFollowerGuthix, locateFollowerZammy,
 		enterCavernWithHand, enterCavernWithHeart, enterCavernWithRoots, giveKolodionHeart, giveKolodionHand,
@@ -130,6 +137,13 @@ public class TheMageArenaII extends BasicQuestHelper
 		godCape = new ItemRequirement("God cape", ItemID.ZAMORAK_CAPE).isNotConsumed();
 		godCape.addAlternates(ItemID.GUTHIX_CAPE, ItemID.SARADOMIN_CAPE);
 		godCape.setHighlightInInventory(true);
+
+		unlockedSaradominStrike = new VarplayerRequirement(VarPlayerID.SARAMAGE, 100, Operation.GREATER_EQUAL, "Unlocked Saradomin Strike");
+		unlockedSaradominStrike.setTooltip("Unlocked by casting the Saradomin Strike 100 times within the mage arena");
+		unlockedClawsOfGuthix = new VarplayerRequirement(VarPlayerID.GUTHMAGE, 100, Operation.GREATER_EQUAL, "Unlocked Claws of Guthix");
+		unlockedClawsOfGuthix.setTooltip("Unlocked by casting the Claws of Guthix 100 times within the mage arena");
+		unlockedFlamesOfZamorak = new VarplayerRequirement(VarPlayerID.ZAMOMAGE, 100, Operation.GREATER_EQUAL, "Unlocked Flames of Zamorak");
+		unlockedFlamesOfZamorak.setTooltip("Unlocked by casting the Flames of Zamorak 100 times within the mage arena");
 	}
 
 	@Override
@@ -237,7 +251,9 @@ public class TheMageArenaII extends BasicQuestHelper
 		ArrayList<Requirement> reqs = new ArrayList<>();
 		reqs.add(new SkillRequirement(Skill.MAGIC, 75));
 		reqs.add(new QuestRequirement(QuestHelperQuest.THE_MAGE_ARENA, QuestState.FINISHED));
-		reqs.add(new ItemRequirement("Unlocked all 3 god spells", -1, -1));
+		reqs.add(unlockedSaradominStrike);
+		reqs.add(unlockedClawsOfGuthix);
+		reqs.add(unlockedFlamesOfZamorak);
 		return reqs;
 	}
 
@@ -252,7 +268,7 @@ public class TheMageArenaII extends BasicQuestHelper
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
 		allSteps.add(new PanelDetails("Upgrading the God Cape", Arrays.asList(enterCavern,
-			talkToKolodion, locateAndKillMinions), knife, saradominStaff, guthixStaff, zamorakStaff, runesForCasts));
+			talkToKolodion, locateAndKillMinions), knife, saradominStaff, guthixStaff, zamorakStaff, unlockedSaradominStrike, unlockedClawsOfGuthix, unlockedFlamesOfZamorak, runesForCasts));
 		return allSteps;
 	}
 }

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
@@ -58,7 +58,10 @@ public class TheMageArenaII extends BasicQuestHelper
 	ItemRequirement zamorakStaff, guthixStaff, saradominStaff, runesForCasts, magicCombatGear, knife, brews, restores
 		, food, recoils, enchantedSymbol, justicarsHand, demonsHeart, entRoots, godCape;
 
-	Requirement inCavern, givenHand, givenHeart, givenRoots;
+	Requirement inCavern;
+	VarbitRequirement givenHand;
+	VarbitRequirement givenHeart;
+	VarbitRequirement givenRoots;
 
 	VarplayerRequirement unlockedSaradominStrike;
 	VarplayerRequirement unlockedClawsOfGuthix;
@@ -175,14 +178,15 @@ public class TheMageArenaII extends BasicQuestHelper
 
 		locateFollowerSara = new MageArenaBossStep(this, saradominStaff, "Saradomin", "If he fires a blue wave at " +
 			"you, move off your tile to avoid it. If you don't, he will pull you into melee distance.",
-			enchantedSymbol, food);
+			givenHand, givenRoots, givenHeart, enchantedSymbol, food);
 		locateFollowerSara.addDialogStep("Saradomin");
 		locateFollowerGuthix = new MageArenaBossStep(this, guthixStaff, "Guthix", "If he spawns green orbs, destroy " +
-			"them to stop them healing him.",	enchantedSymbol, food);
+			"them to stop them healing him.",
+			givenHand, givenRoots, givenHeart, enchantedSymbol, food);
 		locateFollowerGuthix.addDialogStep("Guthix");
 		locateFollowerZammy = new MageArenaBossStep(this, zamorakStaff, "Zamorak", "If he fires an energy ball at " +
 			"you, move away away from the boss to reduce the damage you take.",
-			enchantedSymbol, food);
+			givenHand, givenRoots, givenHeart, enchantedSymbol, food);
 		locateFollowerZammy.addDialogStep("Zamorak");
 
 		enterCavernWithHand = new ObjectStep(this, ObjectID.MAGEARENA_LEVER_TO_CELLAR, new WorldPoint(3090, 3956, 0), "Return with" +

--- a/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
+++ b/src/main/java/com/questhelper/helpers/miniquests/themagearenaii/TheMageArenaII.java
@@ -272,7 +272,7 @@ public class TheMageArenaII extends BasicQuestHelper
 	{
 		List<PanelDetails> allSteps = new ArrayList<>();
 		allSteps.add(new PanelDetails("Upgrading the God Cape", Arrays.asList(enterCavern,
-			talkToKolodion, locateAndKillMinions), knife, saradominStaff, guthixStaff, zamorakStaff, unlockedSaradominStrike, unlockedClawsOfGuthix, unlockedFlamesOfZamorak, runesForCasts));
+			talkToKolodion, locateAndKillMinions, useGodCapeOnKolidion), knife, saradominStaff, guthixStaff, zamorakStaff, unlockedSaradominStrike, unlockedClawsOfGuthix, unlockedFlamesOfZamorak, runesForCasts));
 		return allSteps;
 	}
 }


### PR DESCRIPTION
suggest wilderness swords for knife requirement

track user's spell unlocking with varbits

fix MA2 locating: When the player has finished one boss during MA2, that option entirely disappears meaning we can't do static index checking.

add finishing step to sidebar
