### PR TITLE
tower-of-life: fix pipe puzzle stale widget references

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/toweroflife/PuzzleSolver.java
+++ b/src/main/java/com/questhelper/helpers/quests/toweroflife/PuzzleSolver.java
@@ -246,7 +246,6 @@ public class PuzzleSolver
 	{
 
 		private final WidgetDetails pieceInfo;
-		private final Widget piece;
 		private final int correctOrientation, selectedVBit, targetX, targetY;
 
 		public PipeSolverSolution(WidgetDetails piece, int targetX, int targetY, int correctOrientation, int selectedVBit)
@@ -257,13 +256,18 @@ public class PuzzleSolver
 		public PipeSolverSolution(WidgetDetails pieceDetails, int targetX, int targetY, int correctOrientation, int selectedVBit, Function<Widget, Integer> getPieceX, Function<Widget, Integer> getPieceY)
 		{
 			this.pieceInfo = pieceDetails;
-			this.piece = PuzzleSolver.this.getWidget(pieceInfo);
-			if (this.piece == null)
-				throw new WidgetNotFoundException();
 			this.targetX = targetX;
 			this.targetY = targetY;
 			this.correctOrientation = correctOrientation;
 			this.selectedVBit = selectedVBit;
+		}
+
+		private Widget getPiece()
+		{
+			Widget widget = PuzzleSolver.this.getWidget(pieceInfo);
+			if (widget == null)
+				throw new WidgetNotFoundException();
+			return widget;
 		}
 
 		public boolean isSolved()
@@ -278,27 +282,27 @@ public class PuzzleSolver
 
 		public boolean isLeft()
 		{
-			return piece.getOriginalX() < targetX - 4;
+			return getPiece().getOriginalX() < targetX - 4;
 		}
 
 		public boolean isRight()
 		{
-			return piece.getOriginalX() > targetX + 4;
+			return getPiece().getOriginalX() > targetX + 4;
 		}
 
 		public boolean isAbove()
 		{
-			return piece.getOriginalY() < targetY - 4;
+			return getPiece().getOriginalY() < targetY - 4;
 		}
 
 		public boolean isBelow()
 		{
-			return piece.getOriginalY() > targetY + 4;
+			return getPiece().getOriginalY() > targetY + 4;
 		}
 
 		public boolean isOriented()
 		{
-			return piece.getModelId() == correctOrientation;
+			return getPiece().getModelId() == correctOrientation;
 		}
 
 	}


### PR DESCRIPTION
Fixes #2283

PipeSolverSolution captured Widget objects at construction time. When the pipe puzzle UI was closed and reopened mid-puzzle, these references become stale.

Tested to work in leagues.