### PR TITLE
fix(kandarin easy): better false comparison

### DIFF
--- a/src/main/java/com/questhelper/statemanagement/AchievementDiaryStepManager.java
+++ b/src/main/java/com/questhelper/statemanagement/AchievementDiaryStepManager.java
@@ -69,7 +69,7 @@ public class AchievementDiaryStepManager
 
 	public static void check(Client client)
 	{
-		if (inWorkshop.getMatchedZoneLastCheck() != false && !inWorkshop.check(client))
+		if (!Boolean.FALSE.equals(inWorkshop.getMatchedZoneLastCheck()) && !inWorkshop.check(client))
 		{
 			killedFire.setConfigValue("false");
 			killedEarth.setConfigValue("false");


### PR DESCRIPTION
can't compare null with false apparently

introduced in #2711 
