### PR TITLE
feat(api): expose public QuestHelperApi for inter-plugin integration

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -598,12 +598,6 @@ public class QuestHelperPlugin extends Plugin implements QuestHelperApi
 		});
 	}
 
-	// --- QuestHelperApi ------------------------------------------------------
-	//
-	// Stable surface for other RuneLite plugins. See com.questhelper.api for
-	// the contract. Keep signatures stable — they're called reflectively from
-	// plugin-hub plugins whose classloader does not share types with us.
-
 	@Override
 	public List<QuestSummary> getQuests()
 	{
@@ -651,8 +645,6 @@ public class QuestHelperPlugin extends Plugin implements QuestHelperApi
 	{
 		displayPanel();
 	}
-
-	// --- /QuestHelperApi -----------------------------------------------------
 
 	private void scanAndInstantiate()
 	{

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -29,6 +29,8 @@ import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.questhelper.api.QuestHelperApi;
+import com.questhelper.api.QuestSummary;
 import com.questhelper.bank.banktab.BankTabItems;
 import com.questhelper.bank.banktab.PotionStorage;
 import com.questhelper.bank.banktab.QuestBankTabInterface;
@@ -85,7 +87,7 @@ import java.util.stream.Collectors;
 	tags = { "quest", "helper", "overlay" }
 )
 @Slf4j
-public class QuestHelperPlugin extends Plugin
+public class QuestHelperPlugin extends Plugin implements QuestHelperApi
 {
 	@Getter
 	@Inject
@@ -595,6 +597,62 @@ public class QuestHelperPlugin extends Plugin
 			clientToolbar.openPanel(navButton);
 		});
 	}
+
+	// --- QuestHelperApi ------------------------------------------------------
+	//
+	// Stable surface for other RuneLite plugins. See com.questhelper.api for
+	// the contract. Keep signatures stable — they're called reflectively from
+	// plugin-hub plugins whose classloader does not share types with us.
+
+	@Override
+	public List<QuestSummary> getQuests()
+	{
+		List<QuestSummary> out = new ArrayList<>(QuestHelperQuest.values().length);
+		for (QuestHelperQuest qhq : QuestHelperQuest.values())
+		{
+			out.add(new QuestSummary(
+				qhq.name(),
+				qhq.getName(),
+				qhq.getQuestType() != null ? qhq.getQuestType().name() : null,
+				qhq.getDifficulty() != null ? qhq.getDifficulty().name() : null,
+				qhq.isDeveloperQuest()
+			));
+		}
+		out.sort(Comparator.comparing(QuestSummary::getDisplayName, String.CASE_INSENSITIVE_ORDER));
+		return Collections.unmodifiableList(out);
+	}
+
+	@Override
+	public boolean openQuest(String questName)
+	{
+		if (questName == null) return false;
+		QuestHelperQuest match = null;
+		for (QuestHelperQuest qhq : QuestHelperQuest.values())
+		{
+			if (qhq.name().equals(questName))
+			{
+				match = qhq;
+				break;
+			}
+		}
+		if (match == null) return false;
+		QuestHelper helper = match.getQuestHelper();
+		if (helper == null) return false;
+
+		// Always show the panel — bypass the autoOpenSidebar config since the
+		// caller is explicitly requesting a quest to be opened.
+		displayPanel();
+		questManager.startUpQuest(helper, false);
+		return true;
+	}
+
+	@Override
+	public void openPanel()
+	{
+		displayPanel();
+	}
+
+	// --- /QuestHelperApi -----------------------------------------------------
 
 	private void scanAndInstantiate()
 	{

--- a/src/main/java/com/questhelper/api/QuestHelperApi.java
+++ b/src/main/java/com/questhelper/api/QuestHelperApi.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.api;
+
+import java.util.List;
+
+/**
+ * Stable, public surface that other RuneLite plugins can use to integrate with
+ * Quest Helper.
+ * <p>
+ * The Quest Helper plugin class itself implements this interface, so external
+ * callers can either:
+ * <ul>
+ *   <li>Cast directly to {@code QuestHelperApi} if they share a classloader
+ *       (e.g. RuneLite core plugins), or</li>
+ *   <li>Invoke the methods reflectively after locating the plugin via
+ *       {@code PluginManager#getPlugins()} — the method signatures are
+ *       intentionally restricted to JDK and {@link QuestSummary} types so
+ *       this works across plugin-hub classloader boundaries.</li>
+ * </ul>
+ *
+ * <h2>Compatibility</h2>
+ * Method signatures on this interface and {@link QuestSummary} are treated as
+ * a public contract — they will not be renamed or have parameters changed
+ * without a deprecation cycle.
+ */
+public interface QuestHelperApi
+{
+	/**
+	 * Returns the full list of quest helpers known to the plugin, sorted by
+	 * display name. Includes developer-only entries (see
+	 * {@link QuestSummary#isDeveloperOnly()}) so callers can filter as they
+	 * wish.
+	 *
+	 * @return an unmodifiable list of {@link QuestSummary}, never null.
+	 */
+	List<QuestSummary> getQuests();
+
+	/**
+	 * Opens the Quest Helper side panel and selects the quest with the given
+	 * name. The name must match {@link QuestSummary#getName()} (i.e. the
+	 * underlying {@code QuestHelperQuest} enum constant name).
+	 * <p>
+	 * Safe to call from any thread; the actual quest start-up is scheduled on
+	 * the client thread and panel opening on the Swing EDT.
+	 *
+	 * @param questName the stable quest name from {@link QuestSummary#getName()}.
+	 * @return {@code true} if a matching quest was found and start-up was
+	 *         scheduled, {@code false} if the name was unknown.
+	 */
+	boolean openQuest(String questName);
+
+	/**
+	 * Opens the Quest Helper side panel without changing the selected quest.
+	 * Safe to call from any thread.
+	 */
+	void openPanel();
+}

--- a/src/main/java/com/questhelper/api/QuestSummary.java
+++ b/src/main/java/com/questhelper/api/QuestSummary.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, Zoinkwiz <https://github.com/Zoinkwiz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.questhelper.api;
+
+import java.util.Objects;
+
+/**
+ * Immutable description of a quest exposed via {@link QuestHelperApi#getQuests()}.
+ * <p>
+ * Only primitive / JDK types are used so the DTO survives travelling across the
+ * RuneLite plugin classloader boundary (e.g. when another plugin obtains the
+ * Quest Helper plugin through {@code PluginManager#getPlugins()} and invokes
+ * the API reflectively).
+ */
+public final class QuestSummary
+{
+	private final String name;
+	private final String displayName;
+	private final String questType;
+	private final String difficulty;
+	private final boolean developerOnly;
+
+	public QuestSummary(String name, String displayName, String questType, String difficulty, boolean developerOnly)
+	{
+		this.name = Objects.requireNonNull(name, "name");
+		this.displayName = Objects.requireNonNull(displayName, "displayName");
+		this.questType = questType;
+		this.difficulty = difficulty;
+		this.developerOnly = developerOnly;
+	}
+
+	/**
+	 * Stable identifier for the quest — matches {@code QuestHelperQuest.name()}
+	 * and is the value accepted by {@link QuestHelperApi#openQuest(String)}.
+	 */
+	public String getName()
+	{
+		return name;
+	}
+
+	/** Human-readable quest title (e.g. "Cook's Assistant"). */
+	public String getDisplayName()
+	{
+		return displayName;
+	}
+
+	/** Quest type bucket (e.g. "F2P", "P2P", "MINIQUEST", "SKILL_F2P"). May be null. */
+	public String getQuestType()
+	{
+		return questType;
+	}
+
+	/** Difficulty bucket (e.g. "NOVICE", "INTERMEDIATE", "EXPERIENCED", "MASTER"). May be null. */
+	public String getDifficulty()
+	{
+		return difficulty;
+	}
+
+	/** True if the quest is only visible when RuneLite is launched in developer mode. */
+	public boolean isDeveloperOnly()
+	{
+		return developerOnly;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (!(o instanceof QuestSummary)) return false;
+		QuestSummary that = (QuestSummary) o;
+		return name.equals(that.name);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return name.hashCode();
+	}
+
+	@Override
+	public String toString()
+	{
+		return "QuestSummary{" + name + " -> " + displayName + "}";
+	}
+}


### PR DESCRIPTION
Adds a stable surface that other RuneLite plugins can use to:
- list the quests known to Quest Helper (QuestHelperApi#getQuests)
- open the side panel and select a specific quest (openQuest)
- open the side panel without changing selection (openPanel)

The QuestHelperPlugin class now implements QuestHelperApi, and the
interface + QuestSummary DTO only reference JDK types so the API
remains callable reflectively from plugin-hub plugins that do not
share a classloader.

I plan to use this in https://github.com/Bobakanoosh/runelite-bruhsailor