### PR TITLE
fix: hide "entity" overlays if we're in a cutscene

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -50,6 +50,7 @@ import net.runelite.api.*;
 import net.runelite.api.events.*;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.RuneLite;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
@@ -179,6 +180,9 @@ public class QuestHelperPlugin extends Plugin
 
 	private final Collection<String> configEvents = Arrays.asList("orderListBy", "filterListBy", "questDifficulty", "showCompletedQuests");
 	private final Collection<String> configItemEvents = Arrays.asList("highlightNeededQuestItems", "highlightNeededMiniquestItems", "highlightNeededAchievementDiaryItems");
+
+	@Getter
+	private boolean inCutscene = false;
 
 	@Provides
 	QuestHelperConfig getConfig(ConfigManager configManager)
@@ -352,6 +356,11 @@ public class QuestHelperPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
+		if (event.getVarbitId() == VarbitID.CUTSCENE_STATUS)
+		{
+			this.inCutscene = event.getValue() == 1;
+		}
+
 		if (!(client.getGameState() == GameState.LOGGED_IN))
 		{
 			return;

--- a/src/main/java/com/questhelper/overlays/QuestHelperMinimapOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperMinimapOverlay.java
@@ -26,6 +26,11 @@ public class QuestHelperMinimapOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (plugin.isInCutscene())
+		{
+			return null;
+		}
+
 		QuestHelper quest = plugin.getSelectedQuest();
 
 		if (quest != null && quest.getCurrentStep() != null && quest.getCurrentStep().getActiveStep() != null)

--- a/src/main/java/com/questhelper/overlays/QuestHelperWorldArrowOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperWorldArrowOverlay.java
@@ -49,6 +49,11 @@ public class QuestHelperWorldArrowOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (plugin.isInCutscene())
+		{
+			return null;
+		}
+
 		QuestHelper quest = plugin.getSelectedQuest();
 
 		if (quest != null && quest.getCurrentStep() != null)

--- a/src/main/java/com/questhelper/overlays/QuestHelperWorldLineOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperWorldLineOverlay.java
@@ -54,6 +54,11 @@ public class QuestHelperWorldLineOverlay extends Overlay
 			return null;
 		}
 
+		if (plugin.isInCutscene())
+		{
+			return null;
+		}
+
 		QuestHelper quest = plugin.getSelectedQuest();
 
 		if (quest != null && quest.getCurrentStep() != null)

--- a/src/main/java/com/questhelper/overlays/QuestHelperWorldOverlay.java
+++ b/src/main/java/com/questhelper/overlays/QuestHelperWorldOverlay.java
@@ -63,15 +63,24 @@ public class QuestHelperWorldOverlay extends Overlay
 
 		QuestHelper quest = plugin.getSelectedQuest();
 
-		if (quest != null && quest.getCurrentStep() != null)
+		if (quest != null)
 		{
-			quest.makeWorldOverlayHint(graphics, plugin);
-			quest.getCurrentStep().makeWorldOverlayHint(graphics, plugin);
+			var currentStep = quest.getCurrentStep();
+			if (currentStep != null)
+			{
+				if (!plugin.isInCutscene() || currentStep.getActiveStep().isAllowInCutscene())
+				{
+					currentStep.makeWorldOverlayHint(graphics, plugin);
+				}
+			}
 		}
 
-		plugin.getBackgroundHelpers().forEach((name, questHelper) -> questHelper.getCurrentStep().makeWorldOverlayHint(graphics, plugin));
+		if (!plugin.isInCutscene())
+		{
+			plugin.getBackgroundHelpers().forEach((name, questHelper) -> questHelper.getCurrentStep().makeWorldOverlayHint(graphics, plugin));
 
-		plugin.getRuneliteObjectManager().makeWorldOverlayHint(graphics);
+			plugin.getRuneliteObjectManager().makeWorldOverlayHint(graphics);
+		}
 
 		return null;
 	}

--- a/src/main/java/com/questhelper/questhelpers/QuestHelper.java
+++ b/src/main/java/com/questhelper/questhelpers/QuestHelper.java
@@ -300,11 +300,6 @@ public abstract class QuestHelper implements Module, QuestDebugRenderer
 		return questStateEnteredFinished;
 	}
 
-	public void makeWorldOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
-	{
-
-	}
-
 	protected void setupZones()
 	{
 

--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -304,11 +304,6 @@ public class DetailedQuestStep extends QuestStep
 			return;
 		}
 
-		if (inCutscene)
-		{
-			return;
-		}
-
 		if (!markedTiles.isEmpty())
 		{
 			for (QuestTile location : markedTiles)
@@ -359,11 +354,6 @@ public class DetailedQuestStep extends QuestStep
 			return;
 		}
 
-		if (inCutscene)
-		{
-			return;
-		}
-
 		if (currentRender < (MAX_RENDER_SIZE / 2))
 		{
 			renderArrow(graphics);
@@ -374,11 +364,6 @@ public class DetailedQuestStep extends QuestStep
 	public void makeWorldLineOverlayHint(Graphics2D graphics, QuestHelperPlugin plugin)
 	{
 		if (client.getLocalPlayer() == null)
-		{
-			return;
-		}
-
-		if (inCutscene)
 		{
 			return;
 		}
@@ -501,11 +486,6 @@ public class DetailedQuestStep extends QuestStep
 				return;
 			}
 
-			if (inCutscene)
-			{
-				return;
-			}
-
 			WorldPoint point = mapPoint.getWorldPoint();
 
 			if (currentRender < MAX_RENDER_SIZE / 2 || !getQuestHelper().getConfig().haveMinimapArrowFlash())
@@ -566,7 +546,7 @@ public class DetailedQuestStep extends QuestStep
 	{
 		super.makeOverlayHint(panelComponent, plugin, additionalText, new ArrayList<>());
 
-		if (inCutscene || hideRequirements)
+		if (hideRequirements)
 		{
 			return;
 		}
@@ -695,10 +675,6 @@ public class DetailedQuestStep extends QuestStep
 
 	private void checkAllTilesForItemHighlighting(Tile tile, Collection<Integer> ids, Graphics2D graphics)
 	{
-		if (inCutscene)
-		{
-			return;
-		}
 		Player player = client.getLocalPlayer();
 
 		if (player == null)

--- a/src/main/java/com/questhelper/steps/DigStep.java
+++ b/src/main/java/com/questhelper/steps/DigStep.java
@@ -96,11 +96,6 @@ public class DigStep extends DetailedQuestStep
 	{
 		super.makeWorldOverlayHint(graphics, plugin);
 
-		if (inCutscene)
-		{
-			return;
-		}
-
 		LocalPoint localLocation = definedPoint.resolveLocalPoint(client);
 
 		if (localLocation == null)

--- a/src/main/java/com/questhelper/steps/ObjectStep.java
+++ b/src/main/java/com/questhelper/steps/ObjectStep.java
@@ -310,11 +310,6 @@ public class ObjectStep extends DetailedQuestStep
 			return;
 		}
 
-		if (inCutscene)
-		{
-			return;
-		}
-
 		Point mousePosition = client.getMouseCanvasPosition();
 
 		if (client.getLocalPlayer() == null)
@@ -392,7 +387,7 @@ public class ObjectStep extends DetailedQuestStep
 		if (iconItemID != -1 && closestObject != null && questHelper.getConfig().showSymbolOverlay())
 		{
 			Shape clickbox = closestObject.getClickbox();
-			if (clickbox != null && !inCutscene)
+			if (clickbox != null)
 			{
 				Rectangle2D boundingBox = clickbox.getBounds2D();
 				graphics.drawImage(icon, (int) boundingBox.getCenterX() - 15, (int) boundingBox.getCenterY() - 10,

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -128,9 +128,7 @@ public abstract class QuestStep implements Module
 	@Setter
 	private Requirement lockingCondition;
 
-	private int currentCutsceneStatus = 0;
-	protected boolean inCutscene;
-
+	@Getter
 	@Setter
 	protected boolean allowInCutscene = false;
 
@@ -267,19 +265,6 @@ public abstract class QuestStep implements Module
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		if (!allowInCutscene)
-		{
-			int newCutsceneStatus = client.getVarbitValue(VarbitID.CUTSCENE_STATUS);
-			if (currentCutsceneStatus == 0 && newCutsceneStatus == 1)
-			{
-				enteredCutscene();
-			}
-			else if (currentCutsceneStatus == 1 && newCutsceneStatus == 0)
-			{
-				leftCutscene();
-			}
-			currentCutsceneStatus = newCutsceneStatus;
-		}
 	}
 
 	@Subscribe
@@ -307,16 +292,6 @@ public abstract class QuestStep implements Module
 		}
 
 		text.add(newLine);
-	}
-
-	public void enteredCutscene()
-	{
-		inCutscene = true;
-	}
-
-	public void leftCutscene()
-	{
-		inCutscene = false;
 	}
 
 	public void highlightChoice()

--- a/src/main/java/com/questhelper/steps/WorldEntityStep.java
+++ b/src/main/java/com/questhelper/steps/WorldEntityStep.java
@@ -68,10 +68,6 @@ public class WorldEntityStep extends DetailedQuestStep
 		super.makeWorldOverlayHint(graphics, plugin);
 
 		lastFrameStructure = null;
-		if (inCutscene)
-		{
-			return;
-		}
 
 		WorldEntity worldEntity = findWorldEntity();
 		if (worldEntity == null) return;


### PR DESCRIPTION
This moves the logic to the Overlays themselves, rather than storing the cutscene state in each quest step, and forcing
each quest step's render functions to check that overlay status

this also semi-relatedly removes unused Quest-specific overlay rendering
