### PR TITLE
minimap: use new high precision camera yaw

### DIFF
--- a/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
+++ b/src/main/java/com/questhelper/steps/tools/QuestPerspective.java
@@ -272,10 +272,10 @@ public class QuestPerspective
 			return null;
 		}
 
-		final int angle = client.getCameraYawTarget() & 0x7FF;
+		final int angle = client.getCameraYawTarget() & 0x3FFF;
 
-		final int sin = Perspective.SINE[angle];
-		final int cos = Perspective.COSINE[angle];
+		final int sin = Perspective.SINE14[angle];
+		final int cos = Perspective.COSINE14[angle];
 
 		final int xx = y * sin + cos * x >> 16;
 		final int yy = sin * x - y * cos >> 16;


### PR DESCRIPTION
fixes #2746

broken by https://github.com/runelite/runelite/commit/ce5918d33a3cb5dd7f9261e1797f4a4334d23fff#diff-bd72e0749a6b55bec42902046c682dcb4390d2fd9918a038e74e2c1335338252

`getCameraYawTarget()` now uses 14-bit angles with new `SINE14` and `COSINE14` tables to match. this caused the `QuestPerspective` code to get an angle 8x higher than it was expecting.

fixed by using the new mask & tables as per upstream's [`localToMinimap` impl](https://github.com/runelite/runelite/blob/master/runelite-api/src/main/java/net/runelite/api/Perspective.java#L605-L608).

note: i can't build & test this at the moment, sorry about that. just hoping it points in the right direction.

cheers!