### PR TITLE
feat: allow other plugins to start any helper via PluginMessage

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -53,7 +53,9 @@ import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.RuneLite;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.api.ChatMessageType;
 import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
@@ -611,9 +613,14 @@ public class QuestHelperPlugin extends Plugin
 	 * quests. Post a message with namespace "questhelper", name "start", and
 	 * a "quest" entry in the data map containing the helper's display name:
 	 * </p>
+	 * The data map must also carry a "source" entry with the requesting
+	 * plugin's display name; the start is announced in the player's chat so
+	 * it is always visible which plugin triggered it.
 	 * <pre>{@code
-	 * eventBus.post(new PluginMessage("questhelper", "start", Map.of("quest", "Dragon Slayer I")));
-	 * eventBus.post(new PluginMessage("questhelper", "start", Map.of("quest", "Ardougne Elite Diary")));
+	 * eventBus.post(new PluginMessage("questhelper", "start",
+	 * 	Map.of("quest", "Dragon Slayer I", "source", "My Plugin")));
+	 * eventBus.post(new PluginMessage("questhelper", "start",
+	 * 	Map.of("quest", "Ardougne Elite Diary", "source", "My Plugin")));
 	 * }</pre>
 	 *
 	 * @param event The plugin message posted by another plugin.
@@ -627,13 +634,21 @@ public class QuestHelperPlugin extends Plugin
 		}
 
 		Object quest = event.getData().get("quest");
-		if (!(quest instanceof String))
+		Object source = event.getData().get("source");
+		if (!(quest instanceof String) || !(source instanceof String))
 		{
-			log.debug("Ignoring quest helper start plugin message with invalid quest payload: {}", quest);
+			log.debug("Ignoring quest helper start plugin message with invalid quest or source payload: {} (source {})", quest, source);
 			return;
 		}
 
-		clientThread.invokeLater(() -> questMenuHandler.startUpQuest((String) quest));
+		clientThread.invokeLater(() ->
+		{
+			chatMessageManager.queue(QueuedMessage.builder()
+				.type(ChatMessageType.GAMEMESSAGE)
+				.runeLiteFormattedMessage("Quest Helper for " + quest + " started, requested by " + source + ".")
+				.build());
+			questMenuHandler.startUpQuest((String) quest);
+		});
 	}
 
 	public void displayPanel()

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -618,9 +618,13 @@ public class QuestHelperPlugin extends Plugin
 	 * it is always visible which plugin triggered it.
 	 * <pre>{@code
 	 * eventBus.post(new PluginMessage("questhelper", "start",
-	 * 	Map.of("quest", "Dragon Slayer I", "source", "My Plugin")));
+	 * 	Map.of("quest", "Dragon Slayer I", "source", "<My Plugin>")));
 	 * eventBus.post(new PluginMessage("questhelper", "start",
-	 * 	Map.of("quest", "Ardougne Elite Diary", "source", "My Plugin")));
+	 * 	Map.of("quest", "Ardougne Elite Diary", "source", "<My Plugin>")));
+	 * eventBus.post(new PluginMessage("questhelper", "start",
+	 * 	Map.of("quest", "Herb run", "source", "<My Plugin>")));
+	 * eventBus.post(new PluginMessage("questhelper", "start",
+	 * 	Map.of("quest", "Agility", "source", "<My Plugin>")));
 	 * }</pre>
 	 *
 	 * @param event The plugin message posted by another plugin.

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -59,6 +59,7 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ClientShutdown;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.PluginMessage;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SkillIconManager;
@@ -597,6 +598,42 @@ public class QuestHelperPlugin extends Plugin
 				questMenuHandler.startUpQuest(questName);
 			}
 		}
+	}
+
+	/**
+	 * Allows other plugins to start ANY helper via a {@link PluginMessage},
+	 * mirroring the plugin message convention Quest Helper already uses to
+	 * integrate with other plugins (e.g. Shortest Path).
+	 * <p>
+	 * The lookup goes through the same generic path as the sidebar and quest
+	 * list, so every registered helper type works: quests, miniquests,
+	 * achievement diaries, skill helpers, generic helpers, and player-made
+	 * quests. Post a message with namespace "questhelper", name "start", and
+	 * a "quest" entry in the data map containing the helper's display name:
+	 * </p>
+	 * <pre>{@code
+	 * eventBus.post(new PluginMessage("questhelper", "start", Map.of("quest", "Dragon Slayer I")));
+	 * eventBus.post(new PluginMessage("questhelper", "start", Map.of("quest", "Ardougne Elite Diary")));
+	 * }</pre>
+	 *
+	 * @param event The plugin message posted by another plugin.
+	 */
+	@Subscribe
+	public void onPluginMessage(PluginMessage event)
+	{
+		if (!"questhelper".equals(event.getNamespace()) || !"start".equals(event.getName()))
+		{
+			return;
+		}
+
+		Object quest = event.getData().get("quest");
+		if (!(quest instanceof String))
+		{
+			log.debug("Ignoring quest helper start plugin message with invalid quest payload: {}", quest);
+			return;
+		}
+
+		clientThread.invokeLater(() -> questMenuHandler.startUpQuest((String) quest));
 	}
 
 	public void displayPanel()


### PR DESCRIPTION
Quest Helper already participates in the RuneLite `PluginMessage` ecosystem *outbound* — it posts to `shortestpath` (DetailedQuestStep) and `notenoughrunes` (QuestRequirementsPanel) — but has no inbound receiver, so other plugins can't deep-link into it. This adds the other direction using the same convention:

| field | value |
|---|---|
| **namespace** | `questhelper` |
| **name** | `start` |
| **data** | `{ "quest": "<helper display name>", "source": "<requesting plugin display name>" }` — both required |

```java
eventBus.post(new PluginMessage("questhelper", "start",
    Map.of("quest", "Dragon Slayer I", "source", "<My Plugin>")));
eventBus.post(new PluginMessage("questhelper", "start",
    Map.of("quest", "Ardougne Elite Diary", "source", "<My Plugin>")));
eventBus.post(new PluginMessage("questhelper", "start",
    Map.of("quest", "Herb run", "source", "<My Plugin>")));      // generic helper
eventBus.post(new PluginMessage("questhelper", "start",
    Map.of("quest", "Agility", "source", "<My Plugin>")));       // skill helper
```

**The start is announced in the player's chat** — `Quest Helper for Dragon Slayer I started, requested by My Plugin.` — so it's always visible which plugin triggered it. Messages without a `source` are ignored.

**Works for every helper type**, not just quests: the handler delegates to the existing `QuestMenuHandler#startUpQuest(String)` — the same generic path the quest list and `onChatMessage` auto-start use — so quests, miniquests, **achievement diaries, skill helpers, generic helpers, and player-made quests** all resolve through `QuestHelperQuest.getByName`, and the Shield of Arrav / RFD special cases are inherited rather than duplicated. The call is wrapped in `clientThread.invokeLater` since `PluginMessage` arrives on the poster's thread and the Shield of Arrav branch reads the local player.

Malformed or foreign messages are ignored (namespace/name gate + payload type checks), so nothing changes for anyone who doesn't post the message.

Motivation: I maintain the Goal Planner hub plugin and want "resume in Quest Helper" on quest **and diary** goals — but this is deliberately generic so any plugin (or future Quest Helper features) can use it. Tested end-to-end: a dev client running both plugins, with Goal Planner posting the message and this handler starting quest and diary helpers.

`./gradlew build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

