### PR TITLE
fix: replace cheerer animation ID with gameval equivalent

### DIFF
--- a/src/main/java/com/questhelper/runeliteobjects/Cheerer.java
+++ b/src/main/java/com/questhelper/runeliteobjects/Cheerer.java
@@ -30,6 +30,7 @@ import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectMan
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.NpcID;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 
@@ -54,7 +55,7 @@ public class Cheerer
 		// Spawn the initial NPC in lumbridge.
 		// When the NPC is activated from the player completing a quest, we will always update the position anyway.
 		var spawnPos = new WorldPoint(3223, 3218, 0);
-		FakeNpc wiseOldMan = runeliteObjectManager.createFakeNpc("global", wiseOldManOutfit(client), spawnPos, 862);
+		FakeNpc wiseOldMan = runeliteObjectManager.createFakeNpc("global", wiseOldManOutfit(client), spawnPos, AnimationID.EMOTE_CHEER);
 		wiseOldMan.setName("Wise Old Man");
 		wiseOldMan.setExamine("Loves questing.");
 		wiseOldMan.addExamineAction(runeliteObjectManager);
@@ -86,7 +87,7 @@ public class Cheerer
 		// Spawn the initial NPC in lumbridge.
 		// When the NPC is activated from the player completing a quest, we will always update the position anyway.
 		var spawnPos = new WorldPoint(3223, 3218, 0);
-		FakeNpc zoinkwiz = runeliteObjectManager.createFakeNpc("global", zoinkwizOutfit(client), spawnPos, 862);
+		FakeNpc zoinkwiz = runeliteObjectManager.createFakeNpc("global", zoinkwizOutfit(client), spawnPos, AnimationID.EMOTE_CHEER);
 		zoinkwiz.setName("Zoinkwiz");
 		zoinkwiz.setExamine("Loves questing.");
 		zoinkwiz.addExamineAction(runeliteObjectManager);


### PR DESCRIPTION
## Summary

Replaces the hardcoded cheerer animation ID with the equivalent gameval reference.

## Related issue

Fixes #2652

## Testing

- Ran `./gradlew compileJava compileTestJava`

- Ran `./gradlew classes`

- Ran `./gradlew assemble`