### PR TITLE
feat: custom icons for steps

### DIFF
--- a/src/main/java/com/questhelper/steps/NpcStep.java
+++ b/src/main/java/com/questhelper/steps/NpcStep.java
@@ -363,10 +363,22 @@ public class NpcStep extends DetailedQuestStep
 					? IMAGE_Z_OFFSET
 					: (npc.getLogicalHeight() / 2);
 
-				Point imageLocation = npc.getCanvasImageLocation(icon, zOffset);
+				var iconToUse = this.icon;
+
+				// Find best icon for this NPC
+				for (var customIcon : customIcons)
+				{
+					if (customIcon.getTargetId() == npc.getId())
+					{
+						iconToUse = customIcon.getIcon();
+						break;
+					}
+				}
+
+				Point imageLocation = npc.getCanvasImageLocation(iconToUse, zOffset);
 				if (imageLocation != null)
 				{
-					OverlayUtil.renderImageLocation(graphics, imageLocation, icon);
+					OverlayUtil.renderImageLocation(graphics, imageLocation, iconToUse);
 				}
 			}
 		}

--- a/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/src/main/java/com/questhelper/steps/QuestStep.java
@@ -41,6 +41,7 @@ import com.questhelper.steps.widget.Spell;
 import com.questhelper.steps.widget.SpellWidgetHighlight;
 import com.questhelper.steps.widget.WidgetHighlight;
 import com.questhelper.tools.VisibilityHelper;
+import com.questhelper.util.QuestStepIcon;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -134,6 +135,9 @@ public abstract class QuestStep implements Module
 
 	protected int iconItemID = -1;
 	protected BufferedImage icon;
+
+	/// List of custom icons that can be used instead of icon
+	@NonNull protected final List<QuestStepIcon> customIcons = new ArrayList<>();
 
 	@Getter
 	protected final QuestHelper questHelper;
@@ -507,6 +511,11 @@ public abstract class QuestStep implements Module
 			.build());
 	}
 
+	public void addCustomIcon(QuestStepIcon questStepIcon)
+	{
+		customIcons.add(questStepIcon);
+	}
+
 	public QuestStep addIcon(int iconItemID)
 	{
 		this.iconItemID = iconItemID;
@@ -578,6 +587,11 @@ public abstract class QuestStep implements Module
 		else if (icon == null)
 		{
 			icon = getQuestImage();
+		}
+
+		for (var customIcon : customIcons)
+		{
+			customIcon.setup(itemManager);
 		}
 	}
 

--- a/src/main/java/com/questhelper/util/QuestStepIcon.java
+++ b/src/main/java/com/questhelper/util/QuestStepIcon.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, pajlada <rasmus.karlsson@pajlada.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.questhelper.util;
+
+import com.questhelper.steps.overlay.IconOverlay;
+import lombok.Getter;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.ImageUtil;
+import javax.annotation.Nullable;
+import java.awt.image.BufferedImage;
+
+public class QuestStepIcon
+{
+	/// Item ID to use for the icon
+	private final int itemID;
+
+	@Getter
+	@Nullable private BufferedImage icon = null;
+
+	/// The specific NPC or Object ID that this icon is only rendered on
+	@Getter
+	private final int targetId;
+
+	@Getter
+	private final double scale;
+
+	public QuestStepIcon(int itemID, int targetId, double scale)
+	{
+		this.itemID = itemID;
+		this.targetId = targetId;
+		this.scale = scale;
+	}
+
+	public void setup(ItemManager itemManager)
+	{
+		if (itemID == -1) {
+			return;
+		}
+
+		icon = IconOverlay.createIconImage(itemManager.getImage(itemID));
+		var baseWidth = icon.getWidth();
+		var baseHeight = icon.getHeight();
+		icon = ImageUtil.resizeImage(icon, (int)(baseWidth * this.scale), (int)(baseHeight * this.scale), true);
+	}
+}


### PR DESCRIPTION
From BMR PR

Usage to show dragon scimitar on npc with id 16236, and the blood moon rises spine icon on npc with id 16237, both at 75% scale:

```java
killNylocas.addCustomIcon(new QuestStepIcon(ItemID.DRAGON_SCIMITAR, 16236, 0.75));
killNylocas.addCustomIcon(new QuestStepIcon(ItemID.SOTFA_FOREST_TALON, 16237, 0.75));
```
