### PR TITLE
feat: update step world point based on varp

### DIFF
--- a/src/main/java/com/questhelper/steps/DetailedQuestStep.java
+++ b/src/main/java/com/questhelper/steps/DetailedQuestStep.java
@@ -52,6 +52,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.ItemSpawned;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.gameval.SpriteID;
 import net.runelite.client.eventbus.EventBus;
@@ -77,6 +78,10 @@ public class DetailedQuestStep extends QuestStep
 
 	@Inject
 	EventBus eventBus;
+
+	/// Use this to update the step's world point to the value from the given world point
+	@Setter
+	protected Integer worldPointVarp = null;
 
 	@Getter
 	protected DefinedPoint definedPoint;
@@ -176,6 +181,12 @@ public class DetailedQuestStep extends QuestStep
 	public void startUp()
 	{
 		super.startUp();
+
+		if (worldPointVarp != null)
+		{
+			updateWorldPointFromVarpValue(client.getVarpValue(worldPointVarp));
+		}
+
 		if (definedPoint != null)
 		{
 			if (questHelper.getConfig().showWorldMapPoint())
@@ -251,6 +262,15 @@ public class DetailedQuestStep extends QuestStep
 	public void addTeleport(Requirement newTeleport)
 	{
 		teleport.add(newTeleport);
+	}
+
+	@Subscribe
+	public void onVarbitChanged(final VarbitChanged event)
+	{
+		if (worldPointVarp != null && event.getVarpId() == worldPointVarp)
+		{
+			updateWorldPointFromVarpValue(event.getValue());
+		}
 	}
 
 	@Subscribe
@@ -926,5 +946,19 @@ public class DetailedQuestStep extends QuestStep
 	public void addHighlightZone(Zone zone)
 	{
 		highlightZones.add(zone);
+	}
+
+	/// Given a value produced by a VarPlayer, update the world point.
+	/// The value is either -1 to denote (no value), or a "Coord" that RuneLite can convert for us.
+	private void updateWorldPointFromVarpValue(int varpValue)
+	{
+		if (varpValue == -1)
+		{
+			setWorldPoint((DefinedPoint) null);
+		}
+		else
+		{
+			setWorldPoint(WorldPoint.fromCoord(varpValue));
+		}
 	}
 }


### PR DESCRIPTION
From the BMR helper

This is used during the Sangvestini puzzle segment where, if you die, there's a VarPlayer that updates with the locations of your death pile.
Example usage:

```java
pickupCrankWheelFromWhereYouDied.setWorldPointVarp(VarPlayerID.SANGVESTI_PLAYER_LAST_DEATH_POS);
```
