### PR TITLE
feat: allow DT2 "ChestCodeStep" to have its name customized

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/ChestCodeStep.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/ChestCodeStep.java
@@ -48,9 +48,9 @@ public class ChestCodeStep extends QuestStep
 
 	private boolean SHOULD_PRESS_CONFIRM;
 
-	public ChestCodeStep(QuestHelper questHelper, String answer, int sizeOfLoop, int... targets)
+	public ChestCodeStep(QuestHelper questHelper, String objectName, String answer, int sizeOfLoop, int... targets)
 	{
-		super(questHelper, "Open the chest using the code " + answer + ".");
+		super(questHelper, "Open the " + objectName + " using the code " + answer + ".");
 		SIZE_OF_LOOP = sizeOfLoop;
 		NUMBER_OF_DIALS = targets.length;
 		buttonToPress = new int[NUMBER_OF_DIALS];

--- a/src/main/java/com/questhelper/helpers/quests/deserttreasureii/SucellusSteps.java
+++ b/src/main/java/com/questhelper/helpers/quests/deserttreasureii/SucellusSteps.java
@@ -435,7 +435,7 @@ public class SucellusSteps extends ConditionalStep
 			new WorldPoint(2975, 6360, 2),
 			new WorldPoint(2975, 6348, 2)
 		));
-		unlockChestStep = new PuzzleWrapperStep(getQuestHelper(), new ChestCodeStep(getQuestHelper(), "214013", 5, 2, 1, 4, 0, 1, 3),
+		unlockChestStep = new PuzzleWrapperStep(getQuestHelper(), new ChestCodeStep(getQuestHelper(), "chest", "214013", 5, 2, 1, 4, 0, 1, 3),
 			"Enter the correct code for the chest.");
 
 		unlockChest = new PuzzleWrapperStep(getQuestHelper(), unlockChestRealStep, unlockChestFakeStep).withNoHelpHiddenInSidebar(true);
@@ -501,7 +501,7 @@ public class SucellusSteps extends ConditionalStep
 			new WorldPoint(2912, 6395, 2)
 		));
 		goToAdminRoom = new PuzzleWrapperStep(getQuestHelper(), goToAdminRoomRealStep, goToAdminRoomHiddenStep);
-		unlockChest2 = new PuzzleWrapperStep(getQuestHelper(), new ChestCodeStep(getQuestHelper(), "LIES", 10, 0, 4, 1, 5),
+		unlockChest2 = new PuzzleWrapperStep(getQuestHelper(), new ChestCodeStep(getQuestHelper(), "chest", "LIES", 10, 0, 4, 1, 5),
 			"Enter the correct code for the chest.").withNoHelpHiddenInSidebar(true);
 		goToAdminRoom.addSubSteps(unlockChest2);
 
@@ -560,7 +560,7 @@ public class SucellusSteps extends ConditionalStep
 			new WorldPoint(2884, 6374, 2),
 			new WorldPoint(2889, 6375, 2)
 		));
-		openDiamondChestStep = new PuzzleWrapperStep(getQuestHelper(), new ChestCodeStep(getQuestHelper(), "WRATH", 10, 2, 3, 5, 9, 5),
+		openDiamondChestStep = new PuzzleWrapperStep(getQuestHelper(), new ChestCodeStep(getQuestHelper(), "chest", "WRATH", 10, 2, 3, 5, 9, 5),
 			"Enter the correct code for the chest.").withNoHelpHiddenInSidebar(true);
 
 		openDiamondChest = new PuzzleWrapperStep(getQuestHelper(), openDiamondChestRealStep, openDiamondChestFakeStep);

--- a/src/main/java/com/questhelper/helpers/quests/thefinaldawn/TheFinalDawn.java
+++ b/src/main/java/com/questhelper/helpers/quests/thefinaldawn/TheFinalDawn.java
@@ -852,7 +852,7 @@ public class TheFinalDawn extends BasicQuestHelper
 		giveBonesOrMeatToDog = giveBonesOrMeatToDogNoPuzzleWrap.puzzleWrapStep("Work out how to calm down the dog.");
 		enterDoorCode = new ObjectStep(this, ObjectID.VMQ4_JANUS_HOUSE_PUZZLE_DOOR, new WorldPoint(1649, 3093, 0), "Pet the dog to see the code for the door." +
 				" Open the door using the code 'GUS'.").puzzleWrapStep("Work out the door code.");
-		openDoorWithGusCode = new ChestCodeStep(this, "GUS", 10, 0, 4, 0).puzzleWrapStep(true);
+		openDoorWithGusCode = new ChestCodeStep(this, "door", "GUS", 10, 0, 4, 0).puzzleWrapStep(true);
 		enterDoorCode.addSubSteps(openDoorWithGusCode);
 		takePotato = new ItemStep(this, "Pick up the sack of potatoes (3).", potatoes).puzzleWrapStep("Work out how to make a way to trap Janus and how to " +
 				"knock him out.");

--- a/src/main/java/com/questhelper/helpers/quests/theribbitingtaleofalilypadlabourdispute/TheRibbitingTaleOfALilyPadLabourDispute.java
+++ b/src/main/java/com/questhelper/helpers/quests/theribbitingtaleofalilypadlabourdispute/TheRibbitingTaleOfALilyPadLabourDispute.java
@@ -143,7 +143,7 @@ public class TheRibbitingTaleOfALilyPadLabourDispute extends BasicQuestHelper
 			"Search the chest in the building next to Marcellus. The code is 'NALIA'.");
 		chestStep.addAlternateObjects(ObjectID.FROG_QUEST_CHEST_OPEN);
 		openChest = new PuzzleWrapperStep(this, chestStep, "Work out how to open the chest in Marcellus' house.");
-		enterCode = new PuzzleWrapperStep(this, new ChestCodeStep(this, "NALIA", 10,
+		enterCode = new PuzzleWrapperStep(this, new ChestCodeStep(this, "chest", "NALIA", 10,
 			3, 3, 4, 4, 9), "Work out how to open the chest in Marcellus' house.");
 		openChest.addSubSteps(enterCode);
 		plantPlushy = new ObjectStep(this, ObjectID.FROG_QUEST_POO, new WorldPoint(1694, 2976, 0),


### PR DESCRIPTION
The "ChestCodeStep" is already a perfect "Combination lock" solver, but its step name made it only super suitable for chests.

This change adds an object name param so it can be more nicely used for caskets/doors/sheds.
There's a world in where this step lives in the generic "steps" package instead of under DT2, but I didn't want to disrupt too many things at once.
