### PR TITLE
feat: add jeweller's chisel as a chisel alternative

### DIFF
--- a/src/main/java/com/questhelper/collections/ItemCollections.java
+++ b/src/main/java/com/questhelper/collections/ItemCollections.java
@@ -167,6 +167,11 @@ public enum ItemCollections
 		ItemID.IMCANDO_HAMMER_OFFHAND
 	)),
 
+	CHISEL("Chisel", ImmutableList.of(
+		ItemID.CHISEL,
+		ItemID.JEWELLERS_CHISEL
+	)),
+
 	SAW("Saw", ImmutableList.of(
 		ItemID.POH_SAW,
 		ItemID.WEARABLE_SAW,

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
@@ -153,7 +153,7 @@ public class KourendElite extends ComplexStateQuestHelper
 		// Items required
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES)
 			.showConditioned(new Conditions(LogicType.OR, notCraftBloodRune, notCreateTeleport)).isNotConsumed();
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL)
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL)
 			.showConditioned(new Conditions(LogicType.OR, notCraftBloodRune, notCreateTeleport)).isNotConsumed();
 		chisel.setTooltip("One can be found in the Arceuus essence mine.");
 		axe = new ItemRequirement("Any axe", ItemCollections.AXES).showConditioned(notChopRedwood).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaEasy.java
@@ -159,7 +159,7 @@ public class MorytaniaEasy extends ComplexStateQuestHelper
 		notKillWerewolf = new VarplayerRequirement(VarPlayerID.MORYTANIA_ACHIEVEMENT_DIARY, false, 10);
 		notRestorePrayer = new VarplayerRequirement(VarPlayerID.MORYTANIA_ACHIEVEMENT_DIARY, false, 11);
 
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).showConditioned(notCraftSnelm).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).showConditioned(notCraftSnelm).isNotConsumed();
 		snailShell = new ItemRequirement("Blamish snail shell", ItemCollections.SNAIL_SHELLS)
 			.showConditioned(notCraftSnelm);
 		thinSnail = new ItemRequirement("Thin snail", ItemID.SNAIL_CORPSE1).showConditioned(notCookSnail);

--- a/src/main/java/com/questhelper/helpers/quests/atasteofhope/ATasteOfHope.java
+++ b/src/main/java/com/questhelper/helpers/quests/atasteofhope/ATasteOfHope.java
@@ -238,7 +238,7 @@ public class ATasteOfHope extends BasicQuestHelper
 		emerald = new ItemRequirement("Emerald", ItemID.EMERALD);
 		emeraldHighlighted = new ItemRequirement("Emerald", ItemID.EMERALD);
 		emeraldHighlighted.setHighlightInInventory(true);
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		airRune3 = new ItemRequirement("Air rune", ItemCollections.AIR_RUNE, 3);
 		airStaff = new ItemRequirement("Air staff", ItemCollections.AIR_STAFF).isNotConsumed();
 		cosmicRune = new ItemRequirement("Cosmic rune", ItemID.COSMICRUNE);

--- a/src/main/java/com/questhelper/helpers/quests/bigchompybirdhunting/BigChompyBirdHunting.java
+++ b/src/main/java/com/questhelper/helpers/quests/bigchompybirdhunting/BigChompyBirdHunting.java
@@ -149,7 +149,7 @@ public class BigChompyBirdHunting extends BasicQuestHelper
 		feathers = new ItemRequirement("Feathers", ItemID.FEATHER, 100);
 		knife = new ItemRequirement("Knife", ItemID.KNIFE).isNotConsumed();
 		hammer = new ItemRequirement("Hammer", ItemCollections.HAMMER).isNotConsumed();
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		chisel.setHighlightInInventory(true);
 		wolfBones4 = new ItemRequirement("Wolf bones", ItemID.WOLF_BONES, 4);
 		wolfBones4.setTooltip("You can kill wolves (level 64) around Feldip for bones");

--- a/src/main/java/com/questhelper/helpers/quests/dragonslayerii/DragonSlayerII.java
+++ b/src/main/java/com/questhelper/helpers/quests/dragonslayerii/DragonSlayerII.java
@@ -426,7 +426,7 @@ public class DragonSlayerII extends BasicQuestHelper
 		dragonstone = new ItemRequirement("Dragonstone", ItemID.DRAGONSTONE);
 		moltenGlass2 = new ItemRequirement("Molten glass", ItemID.MOLTEN_GLASS, 2);
 		glassblowingPipe = new ItemRequirement("Glassblowing pipe", ItemID.GLASSBLOWINGPIPE).isNotConsumed();
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		spade = new ItemRequirement("Spade", ItemID.SPADE).isNotConsumed();
 		astralRune = new ItemRequirement("Astral rune", ItemID.ASTRALRUNE);
 		sealOfPassage = new ItemRequirement("Seal of passage", ItemID.LUNAR_SEAL_OF_PASSAGE);

--- a/src/main/java/com/questhelper/helpers/quests/enakhraslament/EnakhrasLament.java
+++ b/src/main/java/com/questhelper/helpers/quests/enakhraslament/EnakhrasLament.java
@@ -218,7 +218,7 @@ public class EnakhrasLament extends BasicQuestHelper
 	protected void setupRequirements()
 	{
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES).isNotConsumed();
-		chiselHighlighted = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chiselHighlighted = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		chiselHighlighted.setHighlightInInventory(true);
 
 		sandstone52 = new ItemRequirement("52 kg of sandstone", -1, -1);

--- a/src/main/java/com/questhelper/helpers/quests/fallenfromgrace/FallenFromGrace.java
+++ b/src/main/java/com/questhelper/helpers/quests/fallenfromgrace/FallenFromGrace.java
@@ -153,7 +153,7 @@ public class FallenFromGrace extends BasicQuestHelper
 	{
 		raftOrSkiff = new ItemRequirement("A raft or a skiff", -1);
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES).isNotConsumed().canBeObtainedDuringQuest();
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed().canBeObtainedDuringQuest();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed().canBeObtainedDuringQuest();
 		hammer = new ItemRequirement("Hammer", ItemCollections.HAMMER).isNotConsumed().canBeObtainedDuringQuest();
 		combatGear = new ItemRequirement("Combat gear", -1, -1).isNotConsumed();
 

--- a/src/main/java/com/questhelper/helpers/quests/hauntedmine/HauntedMine.java
+++ b/src/main/java/com/questhelper/helpers/quests/hauntedmine/HauntedMine.java
@@ -166,7 +166,7 @@ public class HauntedMine extends BasicQuestHelper
 		zealotsKeyHighlighted = new ItemRequirement("Zealot's key", ItemID.HAUNTEDMINE_LIFT_KEY);
 		zealotsKeyHighlighted.setHighlightInInventory(true);
 
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		glowingFungus = new ItemRequirement("Glowing fungus", ItemID.GLOWING_FUNGUS);
 		glowingFungusHighlight = new ItemRequirement("Glowing fungus", ItemID.GLOWING_FUNGUS);
 		glowingFungusHighlight.setHighlightInInventory(true);

--- a/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/MonkeyMadnessII.java
+++ b/src/main/java/com/questhelper/helpers/quests/monkeymadnessii/MonkeyMadnessII.java
@@ -258,8 +258,8 @@ public class MonkeyMadnessII extends BasicQuestHelper
 		lightSource = new ItemRequirement("A lightsource", ItemCollections.LIGHT_SOURCES).isNotConsumed();
 		hammerSidebar = new ItemRequirement("Hammer (obtainable in quest)", ItemCollections.HAMMER).isNotConsumed();
 		hammer = new ItemRequirement("Hammer", ItemCollections.HAMMER).isNotConsumed();
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
-		chiselSidebar = new ItemRequirement("Chisel (obtainable in quest)", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
+		chiselSidebar = new ItemRequirement("Chisel (obtainable in quest)", ItemCollections.CHISEL).isNotConsumed();
 		mspeakAmulet = new ItemRequirement("M'speak amulet", ItemID.MM_AMULET_OF_MONKEY_SPEAK).isNotConsumed();
 		mspeakAmuletEquipped = new ItemRequirement("M'speak amulet", ItemID.MM_AMULET_OF_MONKEY_SPEAK, 1, true).isNotConsumed();
 
@@ -319,7 +319,7 @@ public class MonkeyMadnessII extends BasicQuestHelper
 
 		coins20 = new ItemRequirement("Coins", ItemCollections.COINS, 20);
 
-		chiselHighlighted = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chiselHighlighted = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		chiselHighlighted.setHighlightInInventory(true);
 		deconstructedOnyx = new ItemRequirement("Deconstructed onyx", ItemID.MM2_DECONSTRUCTED_ONYX);
 		deconstructedOnyx.setHighlightInInventory(true);

--- a/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
+++ b/src/main/java/com/questhelper/helpers/quests/mourningsendpartii/MourningsEndPartII.java
@@ -419,7 +419,7 @@ public class MourningsEndPartII extends BasicQuestHelper
 		ropeHighlight = new ItemRequirement("Rope", ItemID.ROPE);
 		ropeHighlight.setHighlightInInventory(true);
 
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		staminaPotions = new ItemRequirement("Stamina potions", ItemCollections.STAMINA_POTIONS);
 		prayerPotions = new ItemRequirement("Prayer potions for Protect from Melee",
 			ItemCollections.PRAYER_POTIONS, -1);

--- a/src/main/java/com/questhelper/helpers/quests/onesmallfavour/OneSmallFavour.java
+++ b/src/main/java/com/questhelper/helpers/quests/onesmallfavour/OneSmallFavour.java
@@ -373,7 +373,7 @@ public class OneSmallFavour extends BasicQuestHelper
 		steelBar = new ItemRequirement("Steel bar", ItemID.STEEL_BAR);
 		softClay = new ItemRequirement("Soft clay", ItemID.SOFTCLAY);
 		softClay.setHighlightInInventory(true);
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		chisel.setHighlightInInventory(true);
 		bronzeBar = new ItemRequirement("Bronze bar", ItemID.BRONZE_BAR);
 		ironBar = new ItemRequirement("Iron bar", ItemID.IRON_BAR);

--- a/src/main/java/com/questhelper/helpers/quests/shilovillage/ShiloVillage.java
+++ b/src/main/java/com/questhelper/helpers/quests/shilovillage/ShiloVillage.java
@@ -176,7 +176,7 @@ public class ShiloVillage extends BasicQuestHelper
 		torchOrCandle.setTooltip("You will NOT get this item back");
 		rope = new ItemRequirement("Rope", ItemID.ROPE);
 		bronzeWire = new ItemRequirement("Bronze wire", ItemID.BRONZECRAFTWIRE);
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		bones3 = new ItemRequirement("Bones", ItemID.BONES, 3);
 
 		combatGear = new ItemRequirement("Combat gear", -1, -1).isNotConsumed();

--- a/src/main/java/com/questhelper/helpers/quests/sinsofthefather/SinsOfTheFather.java
+++ b/src/main/java/com/questhelper/helpers/quests/sinsofthefather/SinsOfTheFather.java
@@ -360,7 +360,7 @@ public class SinsOfTheFather extends BasicQuestHelper
 		haemBook = new ItemRequirement("Haemalchemy volume 2", ItemID.MYQ5_HAEMALCHEMY_VOL_2);
 		haemBook.setTooltip("If you lost the book, search the bookshelf in the room west of Safalaan to get it back");
 
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 
 		vyreTop = new ItemRequirement("Vyrewatch top", ItemID.VYRE_TORSO);
 		vyreTop.setTooltip("You can get this from Trader Sven in southern Meiyerditch near Old Man Ral's house for 650gp");

--- a/src/main/java/com/questhelper/helpers/quests/sleepinggiants/SleepingGiants.java
+++ b/src/main/java/com/questhelper/helpers/quests/sleepinggiants/SleepingGiants.java
@@ -185,7 +185,7 @@ public class SleepingGiants extends BasicQuestHelper
 		hammer.canBeObtainedDuringQuest();
 		hammer.setTooltip("Imcando hammer also works");
 
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL);
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL);
 
 		iceGloves = new ItemRequirement("Ice Gloves", ItemID.ICE_GLOVES);
 		iceGloves.setTooltip("Allows you to skip filling and using a bucket of water.");

--- a/src/main/java/com/questhelper/helpers/quests/tearsofguthix/TearsOfGuthix.java
+++ b/src/main/java/com/questhelper/helpers/quests/tearsofguthix/TearsOfGuthix.java
@@ -101,7 +101,7 @@ public class TearsOfGuthix extends BasicQuestHelper
 	{
 		litSapphireLantern = new ItemRequirement("Sapphire lantern", ItemID.TOG_SAPPHIRE_LANTERN_LIT).isNotConsumed();
 		litSapphireLantern.setTooltip("You can make this by using a cut sapphire on a bullseye lantern");
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 		tinderbox = new ItemRequirement("Tinderbox", ItemID.TINDERBOX).isNotConsumed();
 		pickaxe = new ItemRequirement("Any pickaxe", ItemCollections.PICKAXES).isNotConsumed();
 		rope = new ItemRequirement("Rope", ItemID.ROPE);
@@ -110,7 +110,7 @@ public class TearsOfGuthix extends BasicQuestHelper
 		litSapphireLanternHighlighted = new ItemRequirement("Sapphire lantern", ItemID.TOG_SAPPHIRE_LANTERN_LIT);
 		litSapphireLanternHighlighted.setTooltip("You can make this by using a cut sapphire on a bullseye lantern");
 		litSapphireLanternHighlighted.setHighlightInInventory(true);
-		chiselHighlighted = new ItemRequirement("Chisel", ItemID.CHISEL);
+		chiselHighlighted = new ItemRequirement("Chisel", ItemCollections.CHISEL);
 		chiselHighlighted.setHighlightInInventory(true);
 		tinderboxHighlighted = new ItemRequirement("Tinderbox", ItemID.TINDERBOX);
 		tinderboxHighlighted.setHighlightInInventory(true);

--- a/src/main/java/com/questhelper/helpers/quests/templeoftheeye/TempleOfTheEye.java
+++ b/src/main/java/com/questhelper/helpers/quests/templeoftheeye/TempleOfTheEye.java
@@ -211,7 +211,7 @@ public class TempleOfTheEye extends BasicQuestHelper
 	protected void setupRequirements()
 	{
 		bucketOfWater = new ItemRequirement("Bucket of water", ItemID.BUCKET_WATER);
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL);
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL);
 		chisel.canBeObtainedDuringQuest();
 		pickaxe = new ItemRequirement("Pickaxe", ItemCollections.PICKAXES);
 		pickaxe.canBeObtainedDuringQuest();

--- a/src/main/java/com/questhelper/helpers/quests/thebloodmoonrises/TheBloodMoonRises.java
+++ b/src/main/java/com/questhelper/helpers/quests/thebloodmoonrises/TheBloodMoonRises.java
@@ -824,7 +824,7 @@ public class TheBloodMoonRises extends BasicQuestHelper
 
 		hallowedMarks = new ItemRequirement("Hallowed marks", ItemID.MYQ6_HALLOWED_MARKS);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER);
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL);
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL);
 		knife = new ItemRequirement("Knife", ItemID.KNIFE);
 		blisterwoodLogs = new ItemRequirement("Blisterwood logs", ItemID.BLISTERWOOD_LOGS);
 		blessedSilverSickle = new ItemRequirement("Silver sickle (b)", ItemID.SILVER_SICKLE_BLESSED);

--- a/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
+++ b/src/main/java/com/questhelper/helpers/quests/theslugmenace/TheSlugMenace.java
@@ -178,7 +178,7 @@ public class TheSlugMenace extends BasicQuestHelper
 		blankFire = new ItemRequirement("Blank fire rune", ItemID.SLUG2_RUNE_FIRE_BLANK);
 		blankMind = new ItemRequirement("Blank mind rune", ItemID.SLUG2_RUNE_MIND_BLANK);
 
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL).isNotConsumed();
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL).isNotConsumed();
 
 		usedAirRune = new VarbitRequirement(VarbitID.SLUG2_USED_AIR_RUNE, 1);
 		usedEarthRune = new VarbitRequirement(VarbitID.SLUG2_USED_EARTH_RUNE, 1);

--- a/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WhileGuthixSleeps.java
+++ b/src/main/java/com/questhelper/helpers/quests/whileguthixsleeps/WhileGuthixSleeps.java
@@ -703,7 +703,7 @@ public class WhileGuthixSleeps extends BasicQuestHelper
 
 		spade = new ItemRequirement("Spade", ItemID.SPADE);
 		hammer = new ItemRequirement("Hammer", ItemID.HAMMER);
-		chisel = new ItemRequirement("Chisel", ItemID.CHISEL);
+		chisel = new ItemRequirement("Chisel", ItemCollections.CHISEL);
 
 		emptyDruidPouch = new ItemRequirement("Druid pouch", ItemID.DRUID_POUCH_EMPTY);
 		fullDruidPouch = new ItemRequirement("Druid pouch", ItemID.DRUID_POUCH);


### PR DESCRIPTION
Adds a CHISEL ItemCollections entry (chisel + jeweller's chisel) and switches all quest and diary chisel ItemRequirements to use it, so the jeweller's chisel satisfies chisel item requirements.