### PR TITLE
fix: adding default values for tree run configs

### DIFF
--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/FarmingUtils.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/FarmingUtils.java
@@ -374,17 +374,41 @@ public class FarmingUtils
 		FARMING();
 	}
 
-	public enum PayOrCut
+	public enum PayOrCut implements ConfigEnum
 	{
 		PAY(),
 		DIG();
+
+		@Override
+		public String getConfigKey()
+		{
+			return "payOrCutTree";
+		}
+
+		@Override
+		public PayOrCut getDefault()
+		{
+			return PayOrCut.PAY;
+		}
 	}
 
-	public enum PayOrCompost
+	public enum PayOrCompost implements ConfigEnum
 	{
 		PAY(),
 		COMPOST(),
 		NEITHER();
+
+		@Override
+		public String getConfigKey()
+		{
+			return "payOrCompostTree";
+		}
+
+		@Override
+		public PayOrCompost getDefault()
+		{
+			return PayOrCompost.PAY;
+		}
 	}
 }
 

--- a/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
+++ b/src/main/java/com/questhelper/helpers/mischelpers/farmruns/TreeRun.java
@@ -494,8 +494,7 @@ public class TreeRun extends ComplexStateQuestHelper
 
 		payingForRemoval = new RuneliteRequirement(configManager, PAY_OR_CUT, PayOrCut.PAY.name());
 		payingForProtection = new RuneliteRequirement(configManager, PAY_OR_COMPOST, PayOrCompost.PAY.name());
-		usingCompostorNothing = or(new RuneliteRequirement(configManager, PAY_OR_COMPOST, PayOrCompost.COMPOST.name()),
-			new RuneliteRequirement(configManager, PAY_OR_COMPOST, PayOrCompost.NEITHER.name()));
+		usingCompostorNothing = new RuneliteRequirement(configManager, PAY_OR_COMPOST, PayOrCompost.COMPOST.name());
 	}
 
 	@Override


### PR DESCRIPTION
### Description of Changes

This is my first time making changes to this repo so please let me know if I am completely off the mark or if there is a more elegant way to fix this.

- Adding default values for the PayOrCut and PayOrCompost tree run configurations.

- Updating Neither selection for PayOrCompost to hide compost from the required items.

fixes #2795 

### Result Images

Pay / Pay Default

<img width="291" height="619" alt="image" src="https://github.com/user-attachments/assets/e8f4f21e-1e76-47df-9915-7c6a0d4372a3" />

<br/><br/>Dig

<img width="286" height="598" alt="image" src="https://github.com/user-attachments/assets/00f327cd-34e8-4a49-aa3b-b0607d09c1e7" />

<br/><br/>Compost

<img width="287" height="537" alt="image" src="https://github.com/user-attachments/assets/64c5fd81-9dde-4ced-92cd-97f568afe899" />

<br/><br/>Neither

<img width="286" height="509" alt="image" src="https://github.com/user-attachments/assets/bf708631-8c35-4124-993b-21e32f346ae0" />

