### PR TITLE
fix: talk to king roald step of darkness of hallowvale

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/darknessofhallowvale/DarknessOfHallowvale.java
+++ b/src/main/java/com/questhelper/helpers/quests/darknessofhallowvale/DarknessOfHallowvale.java
@@ -499,8 +499,8 @@ public class DarknessOfHallowvale extends BasicQuestHelper
 		searchBushes = new ObjectStep(this, ObjectID.MYQ_PT3_CUTSCENE_WEREWOLF_BUSH, new WorldPoint(3390, 3480, 0), "Search the bushes west of Paterdomus.");
 		searchBushes.addSubSteps(leaveDrezelToBushes);
 		returnFromBushesToDrezel = new ObjectStep(this, ObjectID.TRAPDOOR, new WorldPoint(3405, 3507, 0), "");
-		talkToRoald = new NpcStep(this, NpcID.KING_ROALD_CUTSCENE, new WorldPoint(3222, 3473, 0), "Talk to King Roald in Varrock Castle.");
-		talkToRoald.addDialogSteps("Talk to the king about Morytania.", "What should I do now?", "Yes thanks. I'll accept the free teleport.");
+		talkToRoald = new NpcStep(this, new int[] {NpcID.KING_ROALD, NpcID.KING_ROALD_CUTSCENE}, new WorldPoint(3222, 3473, 0), "Talk to King Roald in Varrock Castle.");
+		talkToRoald.addDialogSteps("I must speak with you on a matter of grave importance.","Talk to the king about Morytania.", "What should I do now?", "Yes thanks. I'll accept the free teleport.");
 
 		goToMines = new NpcStep(this, NpcID.SANG_MYQ3_FEMALE_WALK_VYREWATCH_1, new WorldPoint(3615, 3263, 0), "Talk to a Vyrewatch to be sent to the mines.", true);
 		goToMines.addDialogSteps("Send me to the mines.", "Send me to the mines! (Do a bit of menial work)");


### PR DESCRIPTION
Fixing the "Talk to King Roald in Varrock Castle" step of Darkness of Hallowvale.

The NPC ID and first dialogue option do not match so they were not highlighted correctly. I suspect that this mismatch may be caused by differing progress/completion of other quests that involve this NPC. Because of this, I added on the ID and dialogue option instead of replacing them.

Before:
<img width="1297" height="733" alt="before" src="https://github.com/user-attachments/assets/b7604c57-3182-41ce-8c38-86a8580d7fa2" />

After:
<img width="1593" height="856" alt="fix" src="https://github.com/user-attachments/assets/490e7640-9557-4ab3-bb3d-e34c5ef0ac88" />
