### PR TITLE
fix: The Red Reef Add keel recommendation

### DIFF
--- a/src/main/java/com/questhelper/helpers/quests/theredreef/TheRedReef.java
+++ b/src/main/java/com/questhelper/helpers/quests/theredreef/TheRedReef.java
@@ -188,7 +188,7 @@ public class TheRedReef extends BasicQuestHelper
 	@Override
 	protected void setupRequirements()
 	{
-		rangedCombatGearOrShipWithCannons = new ItemRequirement("Ranged/Mage combat gear to skip boat combat, or a boat with cannons to deal with pirates", -1, -1).isNotConsumed();
+		rangedCombatGearOrShipWithCannons = new ItemRequirement("Ranged/Mage combat gear to skip boat combat, or a boat with cannons to deal with pirates. An upgraded keel helps with survival. (Mithril is more than enough)", -1, -1).isNotConsumed();
 		rangedCombatGearOrShipWithCannons.setDisplayItemId(BankSlotIcons.getRangedCombatGear());
 		combatGear = new ItemRequirement("Combat gear", -1, -1).isNotConsumed();
 		combatGear.setDisplayItemId(BankSlotIcons.getRangedCombatGear());


### PR DESCRIPTION
Starting the ship combat with a low level keel, Bronze/Iron, makes this combat more difficult. Increasing armor and HP by upgrading the keel makes this easier.

Updated the description of the item requirement for ship combat combat to include information about using an upgraded keel.