### PR TITLE
fix: auto start quest

### DIFF
--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -78,6 +78,7 @@ import javax.swing.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @PluginDescriptor(
@@ -88,6 +89,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public class QuestHelperPlugin extends Plugin
 {
+	private static final Pattern NEW_QUEST_REGEX = Pattern.compile("You've started a new quest(?: speedrun)?: (?<questName>.*)");
+
 	@Getter
 	@Inject
 	@Named("developerMode")
@@ -588,12 +591,12 @@ public class QuestHelperPlugin extends Plugin
 				addCheerer();
 			}
 		}
-		if (config.autoStartQuests() && chatMessage.getType() == ChatMessageType.GAMEMESSAGE)
+		if (config.autoStartQuests() && chatMessage.getType() == ChatMessageType.GAMEMESSAGE && questManager.getSelectedQuest() == null)
 		{
-			if (questManager.getSelectedQuest() == null && chatMessage.getMessage().contains("You've started a new quest"))
-			{
-				String questName = chatMessage.getMessage().substring(chatMessage.getMessage().indexOf(">") + 1);
-				questName = questName.substring(0, questName.indexOf("<"));
+			var cleanedMessage = Text.removeTags(client.macroExpand(chatMessage.getMessage()));
+			var matcher = NEW_QUEST_REGEX.matcher(cleanedMessage);
+			if (matcher.matches()) {
+				var questName = matcher.group("questName");
 				questMenuHandler.startUpQuest(questName);
 			}
 		}

--- a/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -39,7 +39,6 @@ import com.questhelper.questinfo.QuestHelperQuest;
 import com.questhelper.requirements.item.ItemRequirement;
 import com.questhelper.runeliteobjects.Cheerer;
 import com.questhelper.runeliteobjects.GlobalFakeObjects;
-import com.questhelper.runeliteobjects.RuneliteConfigSetter;
 import com.questhelper.runeliteobjects.extendedruneliteobjects.RuneliteObjectManager;
 import com.questhelper.statemanagement.PlayerStateManager;
 import com.questhelper.tools.Icon;


### PR DESCRIPTION
Some formatting changed related to macros that caused the original syntax to fail.

Rather than attempting to reason with the stringmatching, I'm using RuneLite's expandMacro & removeTags functions to
clean the string up to be "clean text" as the user sees it, then matching the quest name with a regex instead.

I have tested that this works with Prince Ali Rescue in a main world and with Cooks Assistant in a speedrun world.
