### PR TITLE
fix: remove color tags from achievement diary chat message requirements

### DIFF
--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneElite.java
@@ -182,45 +182,45 @@ public class ArdougneElite extends ComplexStateQuestHelper
 
 		madeString = new ChatMessageRequirement(
 			inWitchaven,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) madeString).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inWitchaven),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 
 		madeLimbs = new ChatMessageRequirement(
 			inYanille,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 2.</col>"
+			"Achievement Diary Stage Task - Current stage: 2."
 		);
 		((ChatMessageRequirement) madeLimbs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inYanille),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 2.</col>"
+				"Achievement Diary Stage Task - Current stage: 2."
 			)
 		);
 
 		madeStock = new ChatMessageRequirement(
 			inYanille,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 3.</col>"
+			"Achievement Diary Stage Task - Current stage: 3."
 		);
 		((ChatMessageRequirement) madeStock).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inYanille),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 3.</col>"
+				"Achievement Diary Stage Task - Current stage: 3."
 			)
 		);
 
 		madeCrossU = new ChatMessageRequirement(
 			inYanille,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 4.</col>"
+			"Achievement Diary Stage Task - Current stage: 4."
 		);
 		((ChatMessageRequirement) madeCrossU).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inYanille),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 4.</col>"
+				"Achievement Diary Stage Task - Current stage: 4."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/ardougne/ArdougneMedium.java
@@ -211,12 +211,12 @@ public class ArdougneMedium extends ComplexStateQuestHelper
 
 		grapUp = new ChatMessageRequirement(
 			inWall,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) grapUp).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inWall),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/falador/FaladorMedium.java
@@ -251,12 +251,12 @@ public class FaladorMedium extends ComplexStateQuestHelper
 
 		// varbit 15347 0 -> 1?
 		choppedLogs = new ChatMessageRequirement(
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) choppedLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inTav),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/fremennik/FremennikEasy.java
@@ -176,16 +176,16 @@ public class FremennikEasy extends ComplexStateQuestHelper
 		deathPlateau = new QuestRequirement(QuestHelperQuest.DEATH_PLATEAU, QuestState.FINISHED);
 
 		choppedLogs = new ChatMessageRequirement(
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 
 		minedSilver = new ChatMessageRequirement(
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) minedSilver).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inMine),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinElite.java
@@ -180,12 +180,12 @@ public class KandarinElite extends ComplexStateQuestHelper
 
 		fishedSharks = new ChatMessageRequirement(
 			inCatherby,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 5 caught, 0 cooked.</col>"
+			"Achievement Diary Stage Task - Current stage: 5 caught, 0 cooked."
 		);
 		((ChatMessageRequirement) fishedSharks).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inCatherby),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 5 caught, 0 cooked.</col>"
+				"Achievement Diary Stage Task - Current stage: 5 caught, 0 cooked."
 			)
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kandarin/KandarinHard.java
@@ -213,12 +213,12 @@ public class KandarinHard extends ComplexStateQuestHelper
 
 		choppedLogs = new ChatMessageRequirement(
 			inSeers,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) choppedLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inSeers),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/kourend/KourendElite.java
@@ -208,23 +208,23 @@ public class KourendElite extends ComplexStateQuestHelper
 
 		anglerCaught = new ChatMessageRequirement(
 			inFish,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) anglerCaught).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inFish),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 
 		barkHarvested = new ChatMessageRequirement(
 			inFarming,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 3.</col>"
+			"Achievement Diary Stage Task - Current stage: 3."
 		);
 		((ChatMessageRequirement) barkHarvested).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inFarming),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 3.</col>"
+				"Achievement Diary Stage Task - Current stage: 3."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeEasy.java
@@ -186,12 +186,12 @@ public class LumbridgeEasy extends ComplexStateQuestHelper
 		inLumby = new ZoneRequirement(lumby);
 
 		choppedLogs = new ChatMessageRequirement(
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) choppedLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inLumby),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/lumbridgeanddraynor/LumbridgeHard.java
@@ -216,12 +216,12 @@ public class LumbridgeHard extends ComplexStateQuestHelper
 
 		madeAmuletU = new ChatMessageRequirement(
 			inLumby,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) madeAmuletU).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inLumby),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/morytania/MorytaniaHard.java
@@ -205,12 +205,12 @@ public class MorytaniaHard extends ComplexStateQuestHelper
 		inHarmony = new ZoneRequirement(harmony);
 
 		choppedLogs = new ChatMessageRequirement(
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) choppedLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inIsland),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockEasy.java
@@ -181,12 +181,12 @@ public class VarrockEasy extends ComplexStateQuestHelper
 
 		madeBowl = new ChatMessageRequirement(
 			inPotteryRoom,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) madeBowl).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inPotteryRoom),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockElite.java
@@ -150,12 +150,12 @@ public class VarrockElite extends ComplexStateQuestHelper
 
 		madeTips = new ChatMessageRequirement(
 			inAnvil,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) madeTips).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inAnvil),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/varrock/VarrockHard.java
@@ -250,24 +250,24 @@ public class VarrockHard extends ComplexStateQuestHelper
 		);
 		boughtSpotterCape = new ChatMessageRequirement(
 			inAsyffShop,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) boughtSpotterCape).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inAsyffShop),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 
 		inYewZone = new ZoneRequirement(new Zone(new WorldPoint(3225, 3456, 0), new WorldPoint(3254, 3478, 0)));
 		cutYewTree = new ChatMessageRequirement(
 			inYewZone,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) cutYewTree).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inYewZone),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 	}

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternHard.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternHard.java
@@ -209,23 +209,23 @@ public class WesternHard extends ComplexStateQuestHelper
 
 		caughtMonkfish = new ChatMessageRequirement(
 			inPisc,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) caughtMonkfish).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inPisc),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 
 		choppedLogs = new ChatMessageRequirement(
 			inApeAtoll,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) choppedLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inApeAtoll),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternMedium.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/westernprovinces/WesternMedium.java
@@ -213,12 +213,12 @@ public class WesternMedium extends ComplexStateQuestHelper
 
 		choppedLogs = new ChatMessageRequirement(
 			inApeAtoll,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) choppedLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inApeAtoll),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 

--- a/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessElite.java
+++ b/src/main/java/com/questhelper/helpers/achievementdiaries/wilderness/WildernessElite.java
@@ -166,45 +166,45 @@ public class WildernessElite extends ComplexStateQuestHelper
 
 		gatheredLogs = new ChatMessageRequirement(
 			inResource,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) gatheredLogs).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inResource),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 
 		caughtCrab = new ChatMessageRequirement(
 			inResource,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+			"Achievement Diary Stage Task - Current stage: 1."
 		);
 		((ChatMessageRequirement) caughtCrab).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inResource),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 1.</col>"
+				"Achievement Diary Stage Task - Current stage: 1."
 			)
 		);
 
 		barsSmelted = new ChatMessageRequirement(
 			inResource,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 4.</col>"
+			"Achievement Diary Stage Task - Current stage: 4."
 		);
 		((ChatMessageRequirement) caughtCrab).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inResource),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 4.</col>"
+				"Achievement Diary Stage Task - Current stage: 4."
 			)
 		);
 
 		runiteFromGolems = new ChatMessageRequirement(
 			inResource,
-			"<col=0040ff>Achievement Diary Stage Task - Current stage: 2.</col>"
+			"Achievement Diary Stage Task - Current stage: 2."
 		);
 		((ChatMessageRequirement) caughtCrab).setInvalidateRequirement(
 			new ChatMessageRequirement(
 				new Conditions(LogicType.NOR, inResource),
-				"<col=0040ff>Achievement Diary Stage Task - Current stage: 2.</col>"
+				"Achievement Diary Stage Task - Current stage: 2."
 			)
 		);
 


### PR DESCRIPTION
Jagex has replaced some of these color tags with `@col_xd@` macros instead of the old `<color=0f0f0f0f0f0>` tag. We could use RuneLite's `client.macroExpand` function, but as @coopermor brought up `ChatMessageRequirement` already performs a contains, we could just as well not include the color tags.