### PR TITLE
fix: widget text requirement expand macro

### DIFF
--- a/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
+++ b/src/main/java/com/questhelper/playerquests/bikeshedder/BikeShedder.java
@@ -82,6 +82,7 @@ public class BikeShedder extends BasicQuestHelper
 	private DetailedQuestStep conditionalRequirementLookAtCoins;
 	private ItemRequirement conditionalRequirementGoldBar;
 	private WidgetTextRequirement lookAtCooksAssistantRequirement;
+	private WidgetTextRequirement lookAtCooksAssistantTextFinishedRequirement;
 	private DetailedQuestStep lookAtCooksAssistant;
 	private WidgetTextRequirement lookAtCooksAssistantTextRequirement;
 	private ZoneRequirement byStaircaseInSunrisePalace;
@@ -251,7 +252,9 @@ public class BikeShedder extends BasicQuestHelper
 		lookAtCooksAssistantRequirement.setDisplayText("Cook's Assistant quest journal open");
 		lookAtCooksAssistantTextRequirement = new WidgetTextRequirement(InterfaceID.Questjournal.TEXTLAYER, true, "he now lets me use his high quality range");
 		lookAtCooksAssistantTextRequirement.setDisplayText("Cook's Assistant quest journal open & received reward (checking text)");
-		lookAtCooksAssistant = new DetailedQuestStep(this, "Open the Cook's Assistant quest journal. You must have started the quest for this test to work.", lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement);
+		lookAtCooksAssistantTextFinishedRequirement = new WidgetTextRequirement(InterfaceID.Questjournal.TEXTLAYER, true, "<str>As a reward he now lets me use his high quality range");
+		lookAtCooksAssistantTextFinishedRequirement.setDisplayText("Cook's Assistant quest journal open & received reward (checking text & tag)");
+		lookAtCooksAssistant = new DetailedQuestStep(this, "Open the Cook's Assistant quest journal. You must have started the quest for this test to work.", lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement, lookAtCooksAssistantTextFinishedRequirement);
 
 		var upstairsInSunrisePalace = new Zone(new WorldPoint(1684, 3162, 1), new WorldPoint(1691, 3168, 1));
 		byStaircaseInSunrisePalace = new ZoneRequirement(upstairsInSunrisePalace);
@@ -358,7 +361,7 @@ public class BikeShedder extends BasicQuestHelper
 		panels.add(new PanelDetails("Use coins on mysterious bush", List.of(useCoinOnBush, useManyCoinsOnBush), List.of(oneCoin, manyCoins)));
 		panels.add(new PanelDetails("Conditional requirement", List.of(conditionalRequirementLookAtCoins), List.of(conditionalRequirementCoins, conditionalRequirementGoldBar)));
 		panels.add(new PanelDetails("Item step", List.of(getCoins), List.of(anyCoins)));
-		panels.add(new PanelDetails("Quest state", List.of(lookAtCooksAssistant), List.of(lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement)));
+		panels.add(new PanelDetails("Quest state", List.of(lookAtCooksAssistant), List.of(lookAtCooksAssistantRequirement, lookAtCooksAssistantTextRequirement, lookAtCooksAssistantTextFinishedRequirement)));
 		panels.add(new PanelDetails("Ensure staircase upstairs in Sunrise Palace is highlighted", List.of(goDownstairsInSunrisePalace), List.of()));
 		panels.add(new PanelDetails("Sailing", List.of(talkToNpcOnBoat, talkToKlarenceFromShip, useSalvagingHook, useObjectOffBoat), List.of()));
 		panels.add(new PanelDetails("Key ring", List.of(keyringStep), List.of(dustyKeyItem, dustyKeyKeyRing)));

--- a/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
@@ -156,17 +156,24 @@ public class WidgetTextRequirement extends SimpleRequirement
 			}
 			if (widget != null)
 			{
+				if (widget.isHidden())
+				{
+					return false;
+				}
+
+				var widgetText = client.macroExpand(widget.getText());
+
 				for (String textOption : text)
 				{
 					if (checkChildren)
 					{
-						if (getChildren(widget, textOption) && !widget.isHidden())
+						if (getChildren(client, widget, textOption))
 						{
 							return true;
 						}
 					}
 
-					if (widget.getText().contains(textOption) && !widget.isHidden())
+					if (widgetText.contains(textOption))
 					{
 						return true;
 					}
@@ -176,7 +183,7 @@ public class WidgetTextRequirement extends SimpleRequirement
 		return false;
 	}
 
-	private boolean getChildren(Widget parentWidget, String textOption)
+	private boolean getChildren(Client client, Widget parentWidget, String textOption)
 	{
 		Widget[] children = parentWidget.getStaticChildren();
 		if (children.length == 0)
@@ -202,14 +209,15 @@ public class WidgetTextRequirement extends SimpleRequirement
 			Widget currentWidget = parentWidget.getStaticChildren()[i];
 			if (currentWidget.getNestedChildren() != null)
 			{
-				if (currentWidget.getText().contains(textOption))
+				var widgetText = client.macroExpand(currentWidget.getText());
+				if (widgetText.contains(textOption))
 				{
 					return true;
 				}
 			}
 			else
 			{
-				if (getChildren(currentWidget, textOption))
+				if (getChildren(client, currentWidget, textOption))
 				{
 					return true;
 				}

--- a/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
+++ b/src/main/java/com/questhelper/requirements/widget/WidgetTextRequirement.java
@@ -218,11 +218,6 @@ public class WidgetTextRequirement extends SimpleRequirement
 		return false;
 	}
 
-	public void checkWidgetText(Client client)
-	{
-		hasPassed = hasPassed || checkWidget(client);
-	}
-
 	@Nonnull
 	@Override
 	public String getDisplayText()


### PR DESCRIPTION
This is a pre-emptive fix.
Currently, Jagex is not using macros in quest journal strings, but if they do, this will capture & expand them.
